### PR TITLE
Send back exception when no connection is available

### DIFF
--- a/src/main/scala/com/crobox/clickhouse/balancing/iterator/CircularIteratorSet.scala
+++ b/src/main/scala/com/crobox/clickhouse/balancing/iterator/CircularIteratorSet.scala
@@ -17,7 +17,7 @@ class CircularIteratorSet[T](seed: Seq[T] = Seq.empty) extends AbstractIterator[
     internalIterator = Iterator.continually(elements).flatten
   }
 
-  override def hasNext = internalIterator.hasNext
+  override def hasNext = elements.nonEmpty
 
   override def next() = internalIterator.next()
 }


### PR DESCRIPTION
The connection manager was being restarted due to errors in trying to access an iterator which had no elements in it if all the hosts were marked as dead, which was causing problems after the connections came back to life. 
Right now the change would case the calls to fail fast when no connection is available, but in the future we might want to retry a few times before failing.