### PR TITLE
Parsing of inserts moved away from the ClickhouseIndexingSubscriber

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,17 +20,13 @@ lazy val root = Project("clickhouse-scala-client", file("."))
       "UTF-8"
     ),
     libraryDependencies ++= Seq(
-      "com.typesafe.akka"              %% "akka-http"            % AkkaHttpVersion,
-      "com.typesafe.scala-logging"     %% "scala-logging"        % "3.7.2",
-      "com.google.guava"               % "guava"                 % "19.0",
-      "com.fasterxml.jackson.core"     % "jackson-core"          % JacksonVersion,
-      "com.fasterxml.jackson.core"     % "jackson-databind"      % JacksonVersion,
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % JacksonVersion,
-      "com.fasterxml.jackson.core"     % "jackson-annotations"   % JacksonVersion,
-      "com.fasterxml.jackson.module"   %% "jackson-module-scala" % JacksonScalaVersion,
-      "org.scalatest"                  %% "scalatest"            % "3.0.0" % Test,
-      "com.typesafe.akka"              %% "akka-testkit"         % AkkaVersion % Test,
-      "ch.qos.logback"                 % "logback-classic"       % "1.2.3" % Test
+      "com.typesafe.akka"          %% "akka-http"      % AkkaHttpVersion,
+      "com.typesafe.scala-logging" %% "scala-logging"  % "3.7.2",
+      "com.google.guava"           % "guava"           % "19.0",
+      "joda-time"                  % "joda-time"       % "2.9.9",
+      "org.scalatest"              %% "scalatest"      % "3.0.0" % Test,
+      "com.typesafe.akka"          %% "akka-testkit"   % AkkaVersion % Test,
+      "ch.qos.logback"             % "logback-classic" % "1.2.3" % Test
     ),
     sbtrelease.ReleasePlugin.autoImport.releasePublishArtifactsAction := PgpKeys.publishSigned.value,
     publishTo := {

--- a/src/main/scala/com/crobox/clickhouse/stream/ClickhouseIndexingSubscriber.scala
+++ b/src/main/scala/com/crobox/clickhouse/stream/ClickhouseIndexingSubscriber.scala
@@ -3,6 +3,7 @@ package com.crobox.clickhouse.stream
 import akka.Done
 import akka.actor.{Actor, ActorRef, ActorRefFactory, Cancellable, PoisonPill, Props, Terminated}
 import com.crobox.clickhouse.ClickhouseClient
+import com.crobox.clickhouse.stream.ClickhouseBulkActor.{InsertParsed, InsertRaw}
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.joda.JodaModule
@@ -12,7 +13,7 @@ import org.reactivestreams.{Subscriber, Subscription}
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
 
 object ClickhouseIndexingSubscriber extends LazyLogging {
@@ -58,9 +59,9 @@ object ClickhouseIndexingSubscriber extends LazyLogging {
  * @author Sjoerd Mulder
  * @since 16-9-16
  */
-class ClickhouseIndexingSubscriber(client: ClickhouseClient,
-                                   config: SubscriberConfig)(implicit actorRefFactory: ActorRefFactory)
-    extends Subscriber[ClickhouseBulkActor.Insert] {
+class ClickhouseIndexingSubscriber(client: ClickhouseClient, config: SubscriberConfig)(
+    implicit actorRefFactory: ActorRefFactory
+) extends Subscriber[ClickhouseBulkActor.Insert] {
 
   private var actor: ActorRef = _
 
@@ -159,7 +160,21 @@ object ClickhouseBulkActor {
 
   case class Request(size: Int)
 
-  case class Insert(table: String, data: Map[String, Any])
+  abstract class Insert(val table: String, val data: Map[String, Any])
+
+  case class InsertParsed(
+      override val table: String,
+      override val data: Map[String, String]
+  ) extends Insert(table, data)
+
+  @deprecated(
+    "Use InsertParsed instead. " +
+      "The concern of parsing is not part of the clickhouse client, and will be removed in the future."
+  )
+  case class InsertRaw(
+      override val table: String,
+      override val data: Map[String, Any]
+  ) extends Insert(table, data)
 
   case class Send(req: String, attempts: Int)
 
@@ -178,7 +193,9 @@ class ClickhouseBulkActor(targetTable: String,
 
   logger.info(s"Starting ClickhouseBulkActor for $targetTable")
 
-  import context.{dispatcher, system}
+  import context.system
+
+  implicit val ec: ExecutionContext = context.dispatcher
 
   private val buffer = new ArrayBuffer[ClickhouseBulkActor.Insert]()
   buffer.sizeHint(config.batchSize)
@@ -223,7 +240,6 @@ class ClickhouseBulkActor(targetTable: String,
         index()
       completed = true
       shutdownIfAllConfirmed()
-
     case m: ClickhouseBulkActor.Insert =>
       if (m.table != targetTable) {
         logger.warn(s"Received insert for ${m.table} but this indexer writes to $targetTable")
@@ -279,21 +295,41 @@ class ClickhouseBulkActor(targetTable: String,
     buffer.clear()
     context.stop(self)
   }
-
-  val insertQuery = s"INSERT INTO $targetTable FORMAT JSONEachRow"
-
   private val objectMapper = new ObjectMapper()
     .registerModule(new JodaModule)
     .registerModule(new DefaultScalaModule)
     .setSerializationInclusion(JsonInclude.Include.NON_DEFAULT)
 
   private def index(): Unit = {
-    val payload = buffer.map(i => objectMapper.writeValueAsString(i.data)).mkString("\n") + "\n"
-    val count   = buffer.size
+    val colList = buffer
+      .map(_.data)
+      .reduce(
+        (e1, e2) => if (e1.size > e2.size) e1 else e2
+      )
+      .keys
+      .toSeq
+
+    val regularPayload = buffer
+      .collect {
+        case InsertParsed(table, data) => {
+          "(" + data.values.mkString(", ") + ")"
+        }
+      }
+      .mkString(",\n") + "\n"
+
+    val jsonPayload = buffer
+      .collect {
+        case InsertRaw(table, data) => objectMapper.writeValueAsString(data)
+      }
+      .mkString("\n") + "\n"
+
+    val count = buffer.size
     logger.debug(s"Inserting $count")
+
     sent = sent + count
     logger.debug(s"Clickhouse $targetTable sent: $sent (confirmed: $confirmed, failed: $failed)")
-    send(payload, count)
+    send(targetTable, jsonPayload, count)
+    send(targetTable, regularPayload, count, rawColList = colList)
     buffer.clear()
 
     // buffer is now empty so no point keeping a scheduled flush after operation
@@ -301,13 +337,28 @@ class ClickhouseBulkActor(targetTable: String,
     flushAfterScheduler = None
   }
 
-  private def send(payload: String, count: Int, retries: Int = 3): Unit =
-    client.execute(insertQuery, payload) onComplete {
-      case Failure(_) if retries > 0 => send(payload, count, retries - 1)
-      case Failure(e)                => self ! ClickhouseBulkActor.FlushFailure(e, count)
-      case Success(resp: String)     => self ! ClickhouseBulkActor.FlushSuccess(resp, count)
+  private def send(table: String,
+                   payload: String,
+                   count: Int,
+                   retries: Int = 3,
+                   rawColList: Seq[String] = Seq.empty): Unit = {
+    val insertQuery = {
+      if (rawColList.isEmpty) {
+        s"INSERT INTO $table FORMAT JSONEachRow"
+      } else {
+        val colList = rawColList.mkString(", ")
+        s"INSERT INTO $table ($colList) VALUES"
+      }
     }
-
+    client.execute(insertQuery, payload) onComplete {
+      case Failure(_) if retries > 0 =>
+        send(table, payload, count, retries - 1, rawColList)
+      case Failure(e) =>
+        self ! ClickhouseBulkActor.FlushFailure(e, count)
+      case Success(resp: String) =>
+        self ! ClickhouseBulkActor.FlushSuccess(resp, count)
+    }
+  }
 }
 
 case class SubscriberConfig(batchSize: Int = 10000,

--- a/src/test/scala/com/crobox/clickhouse/balancing/ConnectionManagerActorTest.scala
+++ b/src/test/scala/com/crobox/clickhouse/balancing/ConnectionManagerActorTest.scala
@@ -77,7 +77,7 @@ class ConnectionManagerActorTest extends ClickhouseClientAsyncSpec {
   }
 
   it should "stash messages when no connections were received yet" in {
-    val client = TestProbe()
+    val client      = TestProbe()
     val managerName = UUID.randomUUID().toString
     val manager =
       system.actorOf(ConnectionManagerActor.props(uri => uris(uri)(uri), config), managerName)

--- a/src/test/scala/com/crobox/clickhouse/stream/ClickhouseIndexingSubscriberTest.scala
+++ b/src/test/scala/com/crobox/clickhouse/stream/ClickhouseIndexingSubscriberTest.scala
@@ -1,0 +1,119 @@
+package com.crobox.clickhouse.stream
+
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl._
+import com.crobox.clickhouse.ClickhouseClient
+import com.crobox.clickhouse.stream.ClickhouseBulkActor.{InsertParsed, InsertRaw}
+import com.crobox.clickhouse.test.ClickhouseClientSpec
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+
+import scala.collection.mutable
+import scala.concurrent.{Await, Future, Promise}
+import scala.concurrent.duration._
+import scala.util.{Random, Try}
+
+class ClickhouseIndexingSubscriberTest
+    extends ClickhouseClientSpec
+    with BeforeAndAfterEach
+    with ScalaFutures
+    with Eventually {
+
+  val timeout = 10.seconds
+
+  implicit val materializer = ActorMaterializer()
+
+  import system.dispatcher
+
+  val client: ClickhouseClient = new ClickhouseClient(config)
+
+  var subscriberCompletes: Promise[Unit] = Promise[Unit]
+
+  val createDb    = "CREATE DATABASE IF NOT EXISTS test"
+  val dropDb   = "DROP DATABASE IF EXISTS test"
+  val createTable = """CREATE TABLE test.insert
+                      |(
+                      |    i UInt64,
+                      |    s String,
+                      |    a Array(UInt32)
+                      |) ENGINE = Memory""".stripMargin
+
+  override protected def beforeEach(): Unit = {
+    super.beforeAll()
+
+    Await.ready(for {
+      db     <- client.execute(createDb)
+      create <- client.execute(createTable)
+    } yield create, timeout)
+
+    subscriberCompletes = Promise[Unit]
+  }
+
+  override protected def afterEach(): Unit = {
+    super.afterEach()
+
+    Await.ready(client.execute(dropDb), timeout)
+  }
+
+  implicit val patience = PatienceConfig(10.seconds, 1000.millis)
+
+  val unparsedInserts: Seq[Map[String, Any]] = (1 to 10).map(
+    _ =>
+      Map(
+        "i" -> Random.nextInt(100),
+        "s" -> "two",
+        "a" -> (1 to Random.nextInt(20)).map(_ => Random.nextInt(200))
+    )
+  )
+
+  val parsedInserts: Seq[Map[String, String]] = unparsedInserts.map(_.mapValues({
+    case value: Int             => value.toString
+    case value: String          => "'" + value + "'"
+    case value: IndexedSeq[Int] => "[" + value.mkString(", ") + "]"
+  }))
+
+  def testSubscriber = new ClickhouseIndexingSubscriber(client,
+    SubscriberConfig(
+      batchSize = 10,
+      flushInterval = Some(10.millis),
+      flushAfter = Some(10.millis),
+      successCallback = (a,b) => {
+        if (!subscriberCompletes.isCompleted) subscriberCompletes.complete(Try{}); Unit
+      }))
+
+  it should "inject sql parsed rows" in {
+    val sink = Sink.fromSubscriber(testSubscriber)
+
+    Source
+      .fromIterator(() => parsedInserts.toIterator)
+      .map(data => InsertParsed("test.insert", data))
+      .toMat(sink)(Keep.left)
+      .run()
+
+    Await.ready(subscriberCompletes.future, 5.seconds)
+
+    eventually {
+      checkRowCount().futureValue shouldBe parsedInserts.size
+    }
+  }
+
+  it should "inject unparsed rows" in {
+    val sink = Sink.fromSubscriber(testSubscriber)
+
+    Source
+      .fromIterator(() => unparsedInserts.toIterator)
+      .map(data => InsertRaw("test.insert", data))
+      .toMat(sink)(Keep.left)
+      .run()
+
+    Await.ready(subscriberCompletes.future, 5.seconds)
+
+    eventually {
+      checkRowCount().futureValue shouldBe unparsedInserts.size
+    }
+  }
+
+  private def checkRowCount(): Future[Int] = client.query("SELECT count(*) FROM test.insert").map(res =>
+    Try(res.stripLineEnd.toInt).getOrElse(0)
+  )
+}


### PR DESCRIPTION
ClickhouseIndexingSubscriber parsed and unparsed inserts now both possible

This is a temporary migration path solution, until all parsing is done outside of this library.