### PR TITLE
Introduces CTable...

### DIFF
--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/Query.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/Query.scala
@@ -10,6 +10,19 @@ trait Table {
   val columns: List[NativeColumn[_]]
 }
 
+/**
+ * An extension on Table for case classes, 
+ * that provides an implementation of the column list for its own properties.
+ */
+trait CTable extends Table { self: Product =>
+   override val columns: List[NativeColumn[_]] = this
+     .productIterator
+     .collect {
+       case c : NativeColumn[_] => c
+     }
+     .toList
+ }
+
 trait Query {
   val internalQuery: InternalQuery
 }


### PR DESCRIPTION
... an extension on the Table trait for case classes and case objects, 
automatically defining the column list for its own properties.

This could be the default implementation of table, would it not be so that the Product has a limit of 22 values.
When Scala 2.13 is mainstream, we can introduce the HList version as being the default.