### PR TITLE
Enhance aggregated functions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,8 @@ lazy val root = (project in file("."))
     inThisBuild(
       List(
         organization := "com.crobox.clickhouse",
-        scalaVersion := "2.12.4",
-        crossScalaVersions := List("2.11.12", "2.12.4"),
+        scalaVersion := "2.12.5",
+        crossScalaVersions := List("2.11.12", "2.12.5"),
         scalacOptions ++= List(
           "-unchecked",
           "-deprecation",

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/AggregationFunctions.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/AggregationFunctions.scala
@@ -38,11 +38,11 @@ object AggregateFunction {
      * Having a column with type array, it aggregates all the results for that column by running the provided aggregation functions for each vertical slice of the array elements.
      * Therefore, for the query result:
      * \array_col|
-     * |[x1, y1, z1]
+     * |[x1, y1, z1, u1]
      * |[x2, y2, z2]
      * |[x3, y3, z3]
      *
-     * if you run sumForEach(array_col) you will get an array result with the following entries: [sum(x1,x3,x3), sum(y1,y2,y3), sum(z1, z2, z3)]
+     * if you run sumForEach(array_col) you will get an array result with the following entries: [sum(x1,x3,x3), sum(y1,y2,y3), sum(z1, z2, z3), sum(u1)]
      *
      * */
     def forEach[V, T <: TableColumn[Seq[V]], Res](

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/AggregationFunctions.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/AggregationFunctions.scala
@@ -1,0 +1,180 @@
+package com.crobox.clickhouse.dsl
+
+import com.crobox.clickhouse.dsl.AggregateFunction.Combinator
+import com.crobox.clickhouse.dsl.AnyResult.{AnyModifier, AnyResultDsl}
+import com.crobox.clickhouse.dsl.Leveled.LevelModifier
+import com.crobox.clickhouse.dsl.Sum.{SumDsl, SumModifier}
+import com.crobox.clickhouse.dsl.TableColumn.AnyTableColumn
+import com.crobox.clickhouse.dsl.Uniq.{UniqDsl, UniqModifier}
+import com.crobox.clickhouse.time.MultiInterval
+import org.joda.time.DateTime
+
+//https://clickhouse.yandex/docs/en/agg_functions/reference
+abstract class AggregateFunction[V](targetColumn: AnyTableColumn) extends ExpressionColumn[V](targetColumn)
+
+case class CombinedAggregatedFunction[T <: TableColumn[_], Res](combinator: Combinator[T, Res],
+                                                                target: AggregateFunction[_])
+    extends AggregateFunction[Res](EmptyColumn())
+
+object AggregateFunction {
+  type StateResult = String
+  sealed trait Combinator[T <: Column, Result]
+
+  case class If[T <: Column, Res](condition: Comparison)      extends Combinator[T, Res]
+  case class CombinatorArray[T <: TableColumn[Seq[V]], V]()   extends Combinator[T, V]
+  case class ArrayForEach[T <: TableColumn[Seq[Seq[V]]], V]() extends Combinator[T, Seq[V]]
+  case class State[T <: Column]()                             extends Combinator[T, StateResult]
+  case class Merge[T <: TableColumn[StateResult], Res]()      extends Combinator[T, Res]
+
+  trait AggregationFunctionsCombinersDsl {
+
+    def aggIf[T <: TableColumn[Res], Res](condition: Comparison)(aggregated: AggregateFunction[Res]) =
+      CombinedAggregatedFunction(If(condition), aggregated)
+
+    def array[T <: TableColumn[Seq[Res]], Res](aggregated: AggregateFunction[Res]) =
+      CombinedAggregatedFunction(CombinatorArray[T, Res](), aggregated)
+
+    def forEach[T <: TableColumn[Seq[Seq[V]]], V](aggregated: AggregateFunction[V]) =
+      CombinedAggregatedFunction(ArrayForEach[T, V](), aggregated)
+
+    def state[T <: TableColumn[_]](aggregated: AggregateFunction[_]) =
+      CombinedAggregatedFunction(State[T](), aggregated)
+
+    def merge[T <: TableColumn[StateResult], Res](aggregated: AggregateFunction[Res]) =
+      CombinedAggregatedFunction(Merge[T, Res](), aggregated)
+  }
+
+  trait AggregationFunctionsDsl extends AggregationFunctionsCombinersDsl with UniqDsl with AnyResultDsl with SumDsl {
+
+    def count() =
+      Count()
+
+    def count(column: TableColumn[_]) =
+      Count(Option(column))
+
+    def uniq(tableColumn: AnyTableColumn) =
+      Uniq(tableColumn)
+
+    def sum[T: Numeric](tableColumn: TableColumn[T]) =
+      Sum(tableColumn)
+
+    def min[V](tableColumn: TableColumn[V]) =
+      Min(tableColumn)
+
+    def max[V](tableColumn: TableColumn[V]) =
+      Max(tableColumn)
+
+    def timeSeries(tableColumn: TableColumn[Long],
+                   interval: MultiInterval,
+                   dateColumn: Option[TableColumn[DateTime]] = None) =
+      TimeSeries(tableColumn, interval, dateColumn)
+
+    def groupUniqArray[V](tableColumn: TableColumn[V]) =
+      GroupUniqArray(tableColumn)
+
+  }
+}
+
+case class Count(column: Option[AnyTableColumn] = None) extends AggregateFunction[Long](column.getOrElse(EmptyColumn()))
+
+case class Uniq(tableColumn: AnyTableColumn, modifier: UniqModifier = Uniq.Normal)
+    extends AggregateFunction[Long](tableColumn)
+
+object Uniq {
+  sealed trait UniqModifier
+  case object Normal   extends UniqModifier
+  case object Combined extends UniqModifier
+  case object HLL12    extends UniqModifier
+  case object Exact    extends UniqModifier
+
+  trait UniqDsl {
+    def combined(uniq: Uniq) = uniq.copy(modifier = Combined)
+    def exact(uniq: Uniq)    = uniq.copy(modifier = Exact)
+    def hll12(uniq: Uniq)    = uniq.copy(modifier = HLL12)
+    def simple(uniq: Uniq)   = uniq.copy(modifier = Normal)
+  }
+}
+
+case class AnyResult[T](tableColumn: TableColumn[T], modifier: AnyModifier = AnyResult.Normal)
+    extends AggregateFunction[Long](tableColumn)
+
+object AnyResult {
+  sealed trait AnyModifier
+  case object Normal extends AnyModifier
+  case object Heavy  extends AnyModifier
+  case object Last   extends AnyModifier
+
+  trait AnyResultDsl {
+    def heavy[T](any: AnyResult[T])  = any.copy(modifier = Heavy)
+    def last[T](any: AnyResult[T])   = any.copy(modifier = Last)
+    def simple[T](any: AnyResult[T]) = any.copy(modifier = Normal)
+  }
+}
+
+case class Sum[T: Numeric](tableColumn: TableColumn[T], modifier: SumModifier = Sum.Normal)
+    extends AggregateFunction[Long](tableColumn)
+
+object Sum {
+  sealed trait SumModifier
+  case object Normal       extends SumModifier
+  case object WithOverflow extends SumModifier
+  case object Map          extends SumModifier
+
+  trait SumDsl {
+    def overflown[T: Numeric](sum: Sum[T]) = sum.copy(modifier = WithOverflow)
+    def mapped[T: Numeric](sum: Sum[T])    = sum.copy(modifier = Map)
+    def simple[T: Numeric](sum: Sum[T])    = sum.copy(modifier = Normal)
+  }
+
+}
+
+case class Avg[T: Numeric](tableColumn: AnyTableColumn) extends AggregateFunction[Long](tableColumn)
+
+case class ArrayJoin[V](tableColumn: TableColumn[Seq[V]]) extends ExpressionColumn[V](tableColumn)
+
+case class GroupUniqArray[V](tableColumn: TableColumn[V]) extends AggregateFunction[Seq[V]](tableColumn)
+
+case class GroupArray[V](tableColumn: TableColumn[V], maxValues: Option[Long])
+    extends AggregateFunction[Seq[V]](tableColumn)
+
+/*Works for numbers, dates, and dates with times. Returns: for numbers – Float64; for dates – a date; for dates with times – a date with time.Works for numbers, dates, and dates with times. Returns: for numbers – Float64; for dates – a date; for dates with times – a date with time.*/
+case class Quantile[T](tableColumn: TableColumn[T],
+                       modifier: LevelModifier,
+                       level: Either[Float, Seq[Float]] = Left(0.5F))
+    extends AggregateFunction[Long](tableColumn) {
+  level match {
+    case Left(quantileLevel) => require(quantileLevel >= 0 && quantileLevel <= 1)
+    case Right(levels)       => levels.foreach(level => require(level >= 0 && level <= 1))
+  }
+}
+
+case class Median[T](tableColumn: TableColumn[T], modifier: LevelModifier, level: Float = 0.5F)
+    extends AggregateFunction[Long](tableColumn) {
+  require(level > 0 && level < 1)
+}
+
+object Leveled {
+  sealed trait LevelModifier
+  case object Normal                                                 extends LevelModifier
+  case object Exact                                                  extends LevelModifier
+  case object TDigest                                                extends LevelModifier
+  case class Deterministic[T: Numeric](determinator: TableColumn[T]) extends LevelModifier
+  /*Works for numbers. Intended for calculating quantiles of page loading time in milliseconds.*/
+  case object Timing extends LevelModifier
+  /*The result is calculated as if the x value were passed weight number of times to the quantileTiming function.*/
+  case class Weighted(weight: Int) extends LevelModifier {
+    require(weight >= 0)
+  }
+  case class ExactWeighted(weight: Int) extends LevelModifier {
+    require(weight >= 0)
+  }
+}
+
+case class Min[V](tableColumn: TableColumn[V]) extends AggregateFunction[V](tableColumn)
+
+case class Max[V](tableColumn: TableColumn[V]) extends AggregateFunction[V](tableColumn)
+
+case class TimeSeries(tableColumn: TableColumn[Long],
+                      interval: MultiInterval,
+                      dateColumn: Option[TableColumn[DateTime]])
+    extends AggregateFunction[Long](tableColumn)

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/AggregationFunctions.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/AggregationFunctions.scala
@@ -20,11 +20,11 @@ object AggregateFunction {
   type StateResult = String
   sealed trait Combinator[T <: Column, Result]
 
-  case class If[T <: Column, Res](condition: Comparison)      extends Combinator[T, Res]
-  case class CombinatorArray[T <: TableColumn[Seq[V]], V]()   extends Combinator[T, V]
-  case class ArrayForEach[T <: TableColumn[Seq[Seq[V]]], V]() extends Combinator[T, Seq[V]]
-  case class State[T <: Column]()                             extends Combinator[T, StateResult]
-  case class Merge[T <: TableColumn[StateResult], Res]()      extends Combinator[T, Res]
+  case class If[T <: Column, Res](condition: Comparison)    extends Combinator[T, Res]
+  case class CombinatorArray[T <: TableColumn[Seq[V]], V]() extends Combinator[T, V]
+  case class ArrayForEach[T <: TableColumn[Seq[_]], Res]()  extends Combinator[T, Seq[Res]]
+  case class State[T <: Column]()                           extends Combinator[T, StateResult]
+  case class Merge[T <: TableColumn[StateResult], Res]()    extends Combinator[T, Res]
 
   trait AggregationFunctionsCombinersDsl {
 
@@ -34,8 +34,21 @@ object AggregateFunction {
     def array[T <: TableColumn[Seq[Res]], Res](aggregated: AggregateFunction[Res]) =
       CombinedAggregatedFunction(CombinatorArray[T, Res](), aggregated)
 
-    def forEach[T <: TableColumn[Seq[Seq[V]]], V](aggregated: AggregateFunction[V]) =
-      CombinedAggregatedFunction(ArrayForEach[T, V](), aggregated)
+    /**
+     * Having a column with type array, it aggregates all the results for that column by running the provided aggregation functions for each vertical slice of the array elements.
+     * Therefore, for the query result:
+     * \array_col|
+     * |[x1, y1, z1]
+     * |[x2, y2, z2]
+     * |[x3, y3, z3]
+     *
+     * if you run sumForEach(array_col) you will get an array result with the following entries: [sum(x1,x3,x3), sum(y1,y2,y3), sum(z1, z2, z3)]
+     *
+     * */
+    def forEach[V, T <: TableColumn[Seq[V]], Res](
+        column: T
+    )(forEachFunc: TableColumn[V] => AggregateFunction[Res]): AggregateFunction[Seq[Res]] =
+      CombinedAggregatedFunction(ArrayForEach(), forEachFunc(ref[V](column.name)))
 
     def state[T <: TableColumn[_]](aggregated: AggregateFunction[_]) =
       CombinedAggregatedFunction(State[T](), aggregated)
@@ -57,17 +70,8 @@ object AggregateFunction {
     def count(column: TableColumn[_]) =
       Count(Option(column))
 
-    def uniq(tableColumn: AnyTableColumn) =
-      Uniq(tableColumn)
-
     def average[T: Numeric](tableColumn: TableColumn[T]) =
       Avg(tableColumn)
-
-    def any[T](tableColumn: TableColumn[T]) =
-      AnyResult(tableColumn)
-
-    def sum[T: Numeric](tableColumn: TableColumn[T]) =
-      Sum(tableColumn)
 
     def min[V](tableColumn: TableColumn[V]) =
       Min(tableColumn)
@@ -82,65 +86,76 @@ object AggregateFunction {
 
     def groupUniqArray[V](tableColumn: TableColumn[V]) =
       GroupUniqArray(tableColumn)
-
-    def median[V](target: TableColumn[V], level: Float = 0.5F) = Median(target, level = level)
-
-    def quantile[V](target: TableColumn[V], level: Float = 0.5F) = Quantile(target, level = level)
-
-    def quantiles[V](target: TableColumn[V], levels: Float*) = Quantiles(target, levels)
-
   }
 }
 
 case class Count(column: Option[AnyTableColumn] = None) extends AggregateFunction[Long](column.getOrElse(EmptyColumn()))
 
-case class Uniq(tableColumn: AnyTableColumn, modifier: UniqModifier = Uniq.Normal)
+case class Uniq(tableColumn: AnyTableColumn, modifier: UniqModifier = Uniq.Simple)
     extends AggregateFunction[Long](tableColumn)
 
 object Uniq {
   sealed trait UniqModifier
-  case object Normal   extends UniqModifier
+  case object Simple   extends UniqModifier
   case object Combined extends UniqModifier
   case object HLL12    extends UniqModifier
   case object Exact    extends UniqModifier
 
   trait UniqDsl {
-    def combined(uniq: Uniq) = uniq.copy(modifier = Combined)
-    def exact(uniq: Uniq)    = uniq.copy(modifier = Exact)
-    def hll12(uniq: Uniq)    = uniq.copy(modifier = HLL12)
-    def simple(uniq: Uniq)   = uniq.copy(modifier = Normal)
+
+    def uniq(tableColumn: AnyTableColumn) =
+      Uniq(tableColumn)
+    def uniqCombined(tableColumn: AnyTableColumn): Uniq = Uniq(tableColumn, Combined)
+    def uniqExact(tableColumn: AnyTableColumn): Uniq    = Uniq(tableColumn, Exact)
+    def uniqHLL12(tableColumn: AnyTableColumn): Uniq    = Uniq(tableColumn, HLL12)
   }
 }
 
-case class AnyResult[T](tableColumn: TableColumn[T], modifier: AnyModifier = AnyResult.Normal)
+case class AnyResult[T](tableColumn: TableColumn[T], modifier: AnyModifier = AnyResult.Simple)
     extends AggregateFunction[T](tableColumn)
 
 object AnyResult {
   sealed trait AnyModifier
-  case object Normal extends AnyModifier
+  case object Simple extends AnyModifier
   case object Heavy  extends AnyModifier
   case object Last   extends AnyModifier
 
   trait AnyResultDsl {
-    def heavy[T](any: AnyResult[T])  = any.copy(modifier = Heavy)
-    def last[T](any: AnyResult[T])   = any.copy(modifier = Last)
-    def simple[T](any: AnyResult[T]) = any.copy(modifier = Normal)
+
+    def any[T](tableColumn: TableColumn[T]): AnyResult[T] =
+      AnyResult(tableColumn)
+
+    def anyHeavy[T](tableColumn: TableColumn[T]): AnyResult[T] =
+      AnyResult(tableColumn, Heavy)
+
+    def anyLast[T](tableColumn: TableColumn[T]): AnyResult[T] =
+      AnyResult(tableColumn, Last)
   }
 }
 
-case class Sum[T: Numeric](tableColumn: TableColumn[T], modifier: SumModifier = Sum.Normal)
+case class Sum[T: Numeric](tableColumn: TableColumn[T], modifier: SumModifier = Sum.Simple)
     extends AggregateFunction[Double](tableColumn)
+
+case class SumMap[T: Numeric, V: Numeric](key: TableColumn[Seq[T]], value: TableColumn[Seq[V]])
+    extends AggregateFunction[(Seq[T], Seq[V])](key)
 
 object Sum {
   sealed trait SumModifier
-  case object Normal       extends SumModifier
+  case object Simple       extends SumModifier
   case object WithOverflow extends SumModifier
   case object Map          extends SumModifier
 
   trait SumDsl {
-    def overflown[T: Numeric](sum: Sum[T]) = sum.copy(modifier = WithOverflow)
-    def mapped[T: Numeric](sum: Sum[T])    = sum.copy(modifier = Map)
-    def simple[T: Numeric](sum: Sum[T])    = sum.copy(modifier = Normal)
+
+    def sum[T: Numeric](tableColumn: TableColumn[T]) =
+      Sum(tableColumn)
+
+    def sumOverflown[T: Numeric](tableColumn: TableColumn[T]) =
+      Sum(tableColumn, WithOverflow)
+
+    def sumMap[T: Numeric, V: Numeric](key: TableColumn[Seq[T]], value: TableColumn[Seq[V]]) =
+      SumMap(key, value)
+
   }
 
 }
@@ -155,15 +170,15 @@ case class GroupArray[V](tableColumn: TableColumn[V], maxValues: Option[Long])
     extends AggregateFunction[Seq[V]](tableColumn)
 
 /*Works for numbers, dates, and dates with times. Returns: for numbers – Float64; for dates – a date; for dates with times – a date with time.Works for numbers, dates, and dates with times. Returns: for numbers – Float64; for dates – a date; for dates with times – a date with time.*/
-case class Quantile[T](tableColumn: TableColumn[T], level: Float = 0.5F, modifier: LevelModifier = Leveled.Normal)
+case class Quantile[T](tableColumn: TableColumn[T], level: Float = 0.5F, modifier: LevelModifier = Leveled.Simple)
     extends LeveledAggregatedFunction[T](tableColumn) {
   require(level >= 0 && level <= 1)
 }
-case class Quantiles[T](tableColumn: TableColumn[T], levels: Seq[Float], modifier: LevelModifier = Leveled.Normal)
+case class Quantiles[T](tableColumn: TableColumn[T], levels: Seq[Float], modifier: LevelModifier = Leveled.Simple)
     extends LeveledAggregatedFunction[Seq[T]](tableColumn) {
   levels.foreach(level => require(level >= 0 && level <= 1))
 }
-case class Median[T](tableColumn: TableColumn[T], level: Float, modifier: LevelModifier = Leveled.Normal)
+case class Median[T](tableColumn: TableColumn[T], level: Float, modifier: LevelModifier = Leveled.Simple)
     extends LeveledAggregatedFunction[T](tableColumn) {
   require(level > 0 && level < 1)
 }
@@ -171,7 +186,7 @@ case class Median[T](tableColumn: TableColumn[T], level: Float, modifier: LevelM
 object Leveled {
   sealed trait LevelModifier
   sealed abstract class LeveledAggregatedFunction[T](target: AnyTableColumn) extends AggregateFunction[T](target)
-  case object Normal                                                         extends LevelModifier
+  case object Simple                                                         extends LevelModifier
   case object Exact                                                          extends LevelModifier
   case object TDigest                                                        extends LevelModifier
   case class Deterministic[T: Numeric](determinator: TableColumn[T])         extends LevelModifier
@@ -183,67 +198,58 @@ object Leveled {
 
   trait LevelModifierDsl {
 
-    def simple[T](aggregation: LeveledAggregatedFunction[T]): LeveledAggregatedFunction[T] =
-      aggregation match {
-        case median: Median[_]       => median.copy(modifier = Normal).asInstanceOf[LeveledAggregatedFunction[T]]
-        case quantile: Quantile[_]   => quantile.copy(modifier = Normal).asInstanceOf[LeveledAggregatedFunction[T]]
-        case quantiles: Quantiles[_] => quantiles.copy(modifier = Normal).asInstanceOf[LeveledAggregatedFunction[T]]
-      }
+    def median[V](target: TableColumn[V], level: Float = 0.5F) = Median(target, level = level)
 
-    def exact[T](aggregation: LeveledAggregatedFunction[T]): LeveledAggregatedFunction[T] =
-      aggregation match {
-        case median: Median[_]       => median.copy(modifier = Exact).asInstanceOf[LeveledAggregatedFunction[T]]
-        case quantile: Quantile[_]   => quantile.copy(modifier = Exact).asInstanceOf[LeveledAggregatedFunction[T]]
-        case quantiles: Quantiles[_] => quantiles.copy(modifier = Exact).asInstanceOf[LeveledAggregatedFunction[T]]
-      }
+    def quantile[V](target: TableColumn[V], level: Float = 0.5F) = Quantile(target, level = level)
 
-    def tDigest[T](aggregation: LeveledAggregatedFunction[T]): LeveledAggregatedFunction[T] =
-      aggregation match {
-        case median: Median[_]       => median.copy(modifier = TDigest).asInstanceOf[LeveledAggregatedFunction[T]]
-        case quantile: Quantile[_]   => quantile.copy(modifier = TDigest).asInstanceOf[LeveledAggregatedFunction[T]]
-        case quantiles: Quantiles[_] => quantiles.copy(modifier = TDigest).asInstanceOf[LeveledAggregatedFunction[T]]
-      }
+    def quantiles[V](target: TableColumn[V], levels: Float*) = Quantiles(target, levels)
 
-    def timing[T](aggregation: LeveledAggregatedFunction[T]) =
-      aggregation match {
-        case median: Median[_]       => median.copy(modifier = Timing).asInstanceOf[LeveledAggregatedFunction[T]]
-        case quantile: Quantile[_]   => quantile.copy(modifier = Timing).asInstanceOf[LeveledAggregatedFunction[T]]
-        case quantiles: Quantiles[_] => quantiles.copy(modifier = Timing).asInstanceOf[LeveledAggregatedFunction[T]]
-      }
+    def medianExact[V](target: TableColumn[V], level: Float = 0.5F) = Median(target, level, Exact)
 
-    def deterministic[T: Numeric](determinator: TableColumn[T])(aggregation: LeveledAggregatedFunction[T]) =
-      aggregation match {
-        case median: Median[_] =>
-          median.copy(modifier = Deterministic(determinator)).asInstanceOf[LeveledAggregatedFunction[T]]
-        case quantile: Quantile[_] =>
-          quantile.copy(modifier = Deterministic(determinator)).asInstanceOf[LeveledAggregatedFunction[T]]
-        case quantiles: Quantiles[_] =>
-          quantiles.copy(modifier = Deterministic(determinator)).asInstanceOf[LeveledAggregatedFunction[T]]
-      }
+    def quantileExact[V](target: TableColumn[V], level: Float = 0.5F) = Quantile(target, level, Exact)
 
-    def weighted[T](weight: TableColumn[Int])(aggregation: LeveledAggregatedFunction[T]) =
-      aggregation match {
-        case median: Median[_] =>
-          median.copy(modifier = extractWeighted(median.modifier, weight)).asInstanceOf[LeveledAggregatedFunction[T]]
-        case quantile: Quantile[_] =>
-          quantile
-            .copy(modifier = extractWeighted(quantile.modifier, weight))
-            .asInstanceOf[LeveledAggregatedFunction[T]]
-        case quantiles: Quantiles[_] =>
-          quantiles
-            .copy(modifier = extractWeighted(quantiles.modifier, weight))
-            .asInstanceOf[LeveledAggregatedFunction[T]]
-      }
+    def quantilesExact[V](target: TableColumn[V], levels: Float*) = Quantiles(target, levels, Exact)
 
-    private def extractWeighted(modifier: LevelModifier, weight: TableColumn[Int]) =
-      modifier match {
-        case Timing => TimingWeighted(weight)
-        case Exact  => ExactWeighted(weight)
-        case other =>
-          throw new IllegalArgumentException(
-            s"Cannot use modifier $other for weighted leveled (median, quantile, quantiles)"
-          )
-      }
+    def medianExactWeighted[V](target: TableColumn[V], weight: TableColumn[Int], level: Float = 0.5F) =
+      Median(target, level, ExactWeighted(weight))
+
+    def quantileExactWeighted[V](target: TableColumn[V], weight: TableColumn[Int], level: Float = 0.5F) =
+      Quantile(target, level, ExactWeighted(weight))
+
+    def quantilesExactWeighted[V](target: TableColumn[V], weight: TableColumn[Int], levels: Float*) =
+      Quantiles(target, levels, ExactWeighted(weight))
+
+    def medianTDigest[V](target: TableColumn[V], level: Float = 0.5F) = Median(target, level, TDigest)
+
+    def quantileTDigest[V](target: TableColumn[V], level: Float = 0.5F) = Quantile(target, level, TDigest)
+
+    def quantilesTDigest[V](target: TableColumn[V], levels: Float*) = Quantiles(target, levels, TDigest)
+
+    def medianTiming[V](target: TableColumn[V], level: Float = 0.5F) = Median(target, level, Timing)
+
+    def quantileTiming[V](target: TableColumn[V], level: Float = 0.5F) = Quantile(target, level, Timing)
+
+    def quantilesTiming[V](target: TableColumn[V], levels: Float*) = Quantiles(target, levels, Timing)
+
+    def medianTimingWeighted[V](target: TableColumn[V], weight: TableColumn[Int], level: Float = 0.5F) =
+      Median(target, level, TimingWeighted(weight))
+
+    def quantileTimingWeighted[V](target: TableColumn[V], weight: TableColumn[Int], level: Float = 0.5F) =
+      Quantile(target, level, TimingWeighted(weight))
+
+    def quantilesTimingWeighted[V](target: TableColumn[V], weight: TableColumn[Int], levels: Float*) =
+      Quantiles(target, levels, TimingWeighted(weight))
+
+    def medianDeterministic[V, T: Numeric](target: TableColumn[V], determinator: TableColumn[T], level: Float = 0.5F) =
+      Median(target, level, Deterministic(determinator))
+
+    def quantileDeterministic[V, T: Numeric](target: TableColumn[V],
+                                             determinator: TableColumn[T],
+                                             level: Float = 0.5F) =
+      Quantile(target, level, Deterministic(determinator))
+
+    def quantilesDeterministic[V, T: Numeric](target: TableColumn[V], determinator: TableColumn[T], levels: Float*) =
+      Quantiles(target, levels, Deterministic(determinator))
 
   }
 

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/TableColumn.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/TableColumn.scala
@@ -4,9 +4,7 @@ import com.crobox.clickhouse.dsl.AggregateFunction.AggregationFunctionsDsl
 import com.crobox.clickhouse.dsl.TableColumn.AnyTableColumn
 import com.crobox.clickhouse.dsl.marshalling.QueryValue
 import com.crobox.clickhouse.dsl.schemabuilder.{ColumnType, DefaultValue}
-import com.crobox.clickhouse.time.MultiInterval
 import com.dongxiguo.fastring.Fastring.Implicits._
-import org.joda.time.DateTime
 
 sealed case class EmptyColumn() extends TableColumn("")
 

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/TableColumn.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/TableColumn.scala
@@ -1,13 +1,12 @@
 package com.crobox.clickhouse.dsl
 
-import com.dongxiguo.fastring.Fastring.Implicits._
-import com.crobox.clickhouse.dsl.TableColumn.{AnyTableColumn, ECondition}
+import com.crobox.clickhouse.dsl.AggregateFunction.AggregationFunctionsDsl
+import com.crobox.clickhouse.dsl.TableColumn.AnyTableColumn
 import com.crobox.clickhouse.dsl.marshalling.QueryValue
 import com.crobox.clickhouse.dsl.schemabuilder.{ColumnType, DefaultValue}
 import com.crobox.clickhouse.time.MultiInterval
+import com.dongxiguo.fastring.Fastring.Implicits._
 import org.joda.time.DateTime
-
-import scala.annotation.implicitNotFound
 
 sealed case class EmptyColumn() extends TableColumn("")
 
@@ -16,6 +15,7 @@ trait Column {
 }
 
 class TableColumn[V](val name: String) extends Column {
+
   def as(alias: String): AliasedColumn[V] =
     AliasedColumn(this, alias)
 
@@ -34,9 +34,8 @@ case class NativeColumn[V](override val name: String,
 
 object TableColumn {
   type AnyTableColumn = Column
+  val emptyColumn = EmptyColumn()
 
-  @implicitNotFound("Condition can only be provided as a ExpressionColumn[_] or Comparison")
-  type ECondition[E] = Union[E, Comparison with ExpressionColumn[_]]
 }
 
 case class RefColumn[V](ref: String) extends TableColumn[V](ref)
@@ -47,49 +46,11 @@ case class TupleColumn[V](elements: AnyTableColumn*) extends TableColumn[V]("")
 
 abstract class ExpressionColumn[V](targetColumn: AnyTableColumn) extends TableColumn[V](targetColumn.name)
 
-case class Count(column: Option[TableColumn[_]] = None) extends ExpressionColumn[Long](EmptyColumn())
-
-case class CountIf[C : ECondition](condition: C) extends ExpressionColumn[Long](EmptyColumn())
-
-case class UniqIf[C : ECondition](tableColumn: AnyTableColumn, condition: C)
-  extends ExpressionColumn[Long](tableColumn)
-
-case class SumIf[C : ECondition](tableColumn: AnyTableColumn, condition: C)
-  extends ExpressionColumn[Long](tableColumn)
-
-case class ArrayJoin[V](tableColumn: TableColumn[Seq[V]]) extends ExpressionColumn[V](tableColumn)
-
-case class GroupUniqArray[V](tableColumn: TableColumn[V]) extends ExpressionColumn[Seq[V]](tableColumn)
-
 case class UInt64(tableColumn: AnyTableColumn) extends ExpressionColumn[Long](tableColumn)
-
-case class Uniq(tableColumn: AnyTableColumn) extends ExpressionColumn[Long](tableColumn)
-
-case class UniqState(tableColumn: AnyTableColumn) extends ExpressionColumn[String](tableColumn)
-
-case class UniqMerge(tableColumn: AnyTableColumn) extends ExpressionColumn[Long](tableColumn)
-
-case class Sum(tableColumn: AnyTableColumn) extends ExpressionColumn[Long](tableColumn)
-
-case class Min[V](tableColumn: TableColumn[V]) extends ExpressionColumn[V](tableColumn)
-
-case class Max[V](tableColumn: TableColumn[V]) extends ExpressionColumn[V](tableColumn)
-
-case class Empty(tableColumn: AnyTableColumn) extends ExpressionColumn[Boolean](tableColumn)
-
-case class NotEmpty(tableColumn: AnyTableColumn) extends ExpressionColumn[Boolean](tableColumn)
 
 case class LowerCaseColumn(tableColumn: AnyTableColumn) extends ExpressionColumn[String](tableColumn)
 
-case class TimeSeries(tableColumn: TableColumn[Long],
-                      interval: MultiInterval,
-                      dateColumn: Option[TableColumn[DateTime]])
-    extends ExpressionColumn[Long](tableColumn)
-
 case class All() extends ExpressionColumn[Long](EmptyColumn())
-
-@deprecated("Use a comparison for this instead", "v0.4.0")
-case class BooleanInt(tableColumn: AnyTableColumn, expected: Int) extends ExpressionColumn[Int](tableColumn)
 
 case class Case[V](column: TableColumn[V], condition: Comparison)
 
@@ -98,7 +59,7 @@ case class Conditional[V](cases: Seq[Case[V]], default: AnyTableColumn) extends 
 /**
  * Used when referencing to a column in an expression
  */
-case class RawColumn(tableColumn: AnyTableColumn) extends ExpressionColumn[Boolean](tableColumn)
+case class RawColumn(tableColumn: AnyTableColumn)   extends ExpressionColumn[Boolean](tableColumn)
 
 /**
  * Parse the supplied value as a constant value column in the query
@@ -107,103 +68,60 @@ case class Const[V: QueryValue](const: V) extends ExpressionColumn[V](EmptyColum
   val parsed = implicitly[QueryValue[V]].apply(const)
 }
 
-trait ColumnOperations {
+trait ColumnOperations extends AggregationFunctionsDsl {
+  implicit val booleanNumeric: Numeric[Boolean] = new Numeric[Boolean] {
+    override def plus(x: Boolean, y: Boolean) = x || y
 
-  def conditional(column: AnyTableColumn, condition: Boolean): AnyTableColumn =
+    override def minus(x: Boolean, y: Boolean) = x ^ y
+
+    override def times(x: Boolean, y: Boolean) = x && y
+
+    override def negate(x: Boolean) = !x
+
+    override def fromInt(x: Int) = if (x <= 0) false else true
+
+    override def toInt(x: Boolean) = if (x) 1 else 0
+
+    override def toLong(x: Boolean) = if (x) 1 else 0
+
+    override def toFloat(x: Boolean) = if (x) 1 else 0
+
+    override def toDouble(x: Boolean) = if (x) 1 else 0
+
+    override def compare(x: Boolean, y: Boolean) = ???
+  }
+
+  def conditional(column: AnyTableColumn, condition: Boolean) =
     if (condition) column else EmptyColumn()
 
-  def ref[V](refName: String): TableColumn[V] =
+  def ref[V](refName: String) =
     new RefColumn[V](refName)
 
-  def const[V: QueryValue](const: V): Const[V] =
+  def const[V: QueryValue](const: V) =
     Const(const)
 
-  def toUInt64(tableColumn: TableColumn[Long]): UInt64 =
+  def toUInt64(tableColumn: TableColumn[Long]) =
     UInt64(tableColumn)
 
-  def count(): TableColumn[Long] =
-    Count()
-
-  def count(column: TableColumn[_]): TableColumn[Long] =
-    Count(Option(column))
-
-  def countIf[T](condition: Comparison): TableColumn[Long] =
-    CountIf(condition)
-
-  def countIf(expressionColumn: ExpressionColumn[_]): TableColumn[Long] =
-    CountIf[ExpressionColumn[_]](expressionColumn)
-
-  def uniqIf(tableColumn: AnyTableColumn, condition: ExpressionColumn[_]): TableColumn[Long] =
-    UniqIf[ExpressionColumn[_]](tableColumn, condition)
-
-  def uniqIf(tableColumn: AnyTableColumn, condition: Comparison): TableColumn[Long] =
-    UniqIf(tableColumn, condition)
-
-  def sumIf(tableColumn: AnyTableColumn, condition: ExpressionColumn[_]): TableColumn[Long] =
-    SumIf[ExpressionColumn[_]](tableColumn, condition)
-
-  def sumIf(tableColumn: AnyTableColumn, condition: Comparison): TableColumn[Long] =
-    SumIf(tableColumn, condition)
-
-  def notEmpty(tableColumn: AnyTableColumn): ExpressionColumn[Boolean] =
-    NotEmpty(tableColumn)
-
-  def empty(tableColumn: AnyTableColumn): ExpressionColumn[Boolean] =
-    Empty(tableColumn)
-
-  def is(tableColumn: AnyTableColumn): ExpressionColumn[Int] =
-    BooleanInt(tableColumn, 1)
-
-  def not(tableColumn: AnyTableColumn): ExpressionColumn[Int] =
-    BooleanInt(tableColumn, 0)
-
-  def rawColumn(tableColumn: AnyTableColumn): ExpressionColumn[Boolean] =
+  def rawColumn(tableColumn: AnyTableColumn) =
     RawColumn(tableColumn)
 
-  def uniq(tableColumn: AnyTableColumn): ExpressionColumn[Long] =
-    Uniq(tableColumn)
-
-  def uniqState(tableColumn: AnyTableColumn): ExpressionColumn[String] =
-    UniqState(tableColumn)
-
-  def uniqMerge(tableColumn: AnyTableColumn): ExpressionColumn[Long] =
-    UniqMerge(tableColumn)
-
-  def sum(tableColumn: AnyTableColumn): ExpressionColumn[Long] =
-    Sum(tableColumn)
-
-  def min[V](tableColumn: TableColumn[V]): ExpressionColumn[V] =
-    Min(tableColumn)
-
-  def max[V](tableColumn: TableColumn[V]): ExpressionColumn[V] =
-    Max(tableColumn)
-
-  def all(): All =
+  def all() =
     All()
 
-  def switch[V](defaultValue: TableColumn[V], cases: Case[V]*): TableColumn[V] =
+  def switch[V](defaultValue: TableColumn[V], cases: Case[V]*) =
     Conditional(cases, defaultValue)
 
-  def columnCase[V](condition: Comparison, value: TableColumn[V]): Case[V] = Case[V](value, condition)
+  def columnCase[V](condition: Comparison, value: TableColumn[V]) = Case[V](value, condition)
 
-  /*
-   * @dateColumn Optional column
-   * */
-  def timeSeries(tableColumn: TableColumn[Long],
-                 interval: MultiInterval,
-                 dateColumn: Option[TableColumn[DateTime]] = None): ExpressionColumn[Long] =
-    TimeSeries(tableColumn, interval, dateColumn)
 
-  def arrayJoin[V](tableColumn: TableColumn[Seq[V]]): ExpressionColumn[V] =
+  def arrayJoin[V](tableColumn: TableColumn[Seq[V]]) =
     ArrayJoin(tableColumn)
 
-  def groupUniqArray[V](tableColumn: TableColumn[V]): ExpressionColumn[Seq[V]] =
-    GroupUniqArray(tableColumn)
-
-  def tuple[T1, T2](firstColumn: TableColumn[T1], secondColumn: TableColumn[T2]): TupleColumn[(T1, T2)] =
+  def tuple[T1, T2](firstColumn: TableColumn[T1], secondColumn: TableColumn[T2]) =
     TupleColumn[(T1, T2)](firstColumn, secondColumn)
 
-  def lowercase(tableColumn: TableColumn[String]): ExpressionColumn[String] =
+  def lowercase(tableColumn: TableColumn[String]) =
     LowerCaseColumn(tableColumn)
 
 }

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/TableColumn.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/TableColumn.scala
@@ -17,8 +17,7 @@ class TableColumn[V](val name: String) extends Column {
   def as(alias: String): AliasedColumn[V] =
     AliasedColumn(this, alias)
 
-  def as(alias: TableColumn[V]): AliasedColumn[V] =
-    AliasedColumn(this, alias.name)
+  def as[C <: TableColumn[V]](alias: C): AliasedColumn[V] = AliasedColumn(this, alias.name)
 }
 
 case class NativeColumn[V](override val name: String,
@@ -57,7 +56,7 @@ case class Conditional[V](cases: Seq[Case[V]], default: AnyTableColumn) extends 
 /**
  * Used when referencing to a column in an expression
  */
-case class RawColumn(tableColumn: AnyTableColumn)   extends ExpressionColumn[Boolean](tableColumn)
+case class RawColumn(tableColumn: AnyTableColumn) extends ExpressionColumn[Boolean](tableColumn)
 
 /**
  * Parse the supplied value as a constant value column in the query
@@ -111,7 +110,6 @@ trait ColumnOperations extends AggregationFunctionsDsl {
     Conditional(cases, defaultValue)
 
   def columnCase[V](condition: Comparison, value: TableColumn[V]) = Case[V](value, condition)
-
 
   def arrayJoin[V](tableColumn: TableColumn[Seq[V]]) =
     ArrayJoin(tableColumn)

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -139,6 +139,7 @@ trait ClickhouseTokenizerModule extends TokenizerModule {
          fast"${levels.mkString(",")})(${tokenizeColumn(column)}${modifierValue.map("," + _).getOrElse("")}")
       case Uniq(column, modifier)      => (s"uniq${tokenizeUniqModifier(modifier)}", tokenizeColumn(column))
       case Sum(column, modifier)       => (s"sum${tokenizeSumModifier(modifier)}", tokenizeColumn(column))
+      case SumMap(key, value)          => (s"sumMap", tokenizeColumns(Seq(key, value)))
       case AnyResult(column, modifier) => (s"any${tokenizeAnyModifier(modifier)}", tokenizeColumn(column))
       case Min(tableColumn)            => ("min", tokenizeColumn(tableColumn))
       case Max(tableColumn)            => ("max", tokenizeColumn(tableColumn))
@@ -151,7 +152,7 @@ trait ClickhouseTokenizerModule extends TokenizerModule {
 
   def tokenizeLevelModifier(level: LevelModifier): (String, Option[String]) =
     level match {
-      case Leveled.Normal                      => ("", None)
+      case Leveled.Simple                      => ("", None)
       case Leveled.Deterministic(determinator) => ("Deterministic", Some(tokenizeColumn(determinator)))
       case Leveled.Timing                      => ("Timing", None)
       case Leveled.TimingWeighted(weight)      => ("TimingWeighted", Some(tokenizeColumn(weight)))
@@ -162,7 +163,7 @@ trait ClickhouseTokenizerModule extends TokenizerModule {
 
   def tokenizeUniqModifier(modifier: UniqModifier): String =
     modifier match {
-      case Uniq.Normal   => ""
+      case Uniq.Simple   => ""
       case Uniq.Combined => "Combined"
       case Uniq.Exact    => "Exact"
       case Uniq.HLL12    => "HLL12"
@@ -171,14 +172,14 @@ trait ClickhouseTokenizerModule extends TokenizerModule {
 
   def tokenizeSumModifier(modifier: SumModifier): String =
     modifier match {
-      case Sum.Normal       => ""
+      case Sum.Simple       => ""
       case Sum.WithOverflow => "WithOverflow"
       case Sum.Map          => "Map"
     }
 
   def tokenizeAnyModifier(modifier: AnyModifier): String =
     modifier match {
-      case AnyResult.Normal => ""
+      case AnyResult.Simple => ""
       case AnyResult.Heavy  => "Heavy"
       case AnyResult.Last   => "Last"
     }

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -154,9 +154,9 @@ trait ClickhouseTokenizerModule extends TokenizerModule {
       case Leveled.Normal                      => ("", None)
       case Leveled.Deterministic(determinator) => ("Deterministic", Some(tokenizeColumn(determinator)))
       case Leveled.Timing                      => ("Timing", None)
-      case Leveled.Weighted(weight)            => ("TimingWeighted", Some(weight.toString))
+      case Leveled.TimingWeighted(weight)      => ("TimingWeighted", Some(tokenizeColumn(weight)))
       case Leveled.Exact                       => ("Exact", None)
-      case Leveled.ExactWeighted(weight)       => ("ExactWeighted", Some(weight.toString))
+      case Leveled.ExactWeighted(weight)       => ("ExactWeighted", Some(tokenizeColumn(weight)))
       case Leveled.TDigest                     => ("TDigest", None)
     }
 

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -1,16 +1,24 @@
 package com.crobox.clickhouse.dsl.language
 
 import com.crobox.clickhouse.dsl
+import com.crobox.clickhouse.dsl.AggregateFunction._
+import com.crobox.clickhouse.dsl.AnyResult.AnyModifier
 import com.crobox.clickhouse.dsl.JoinQuery._
+import com.crobox.clickhouse.dsl.Leveled.LevelModifier
+import com.crobox.clickhouse.dsl.Sum.SumModifier
 import com.crobox.clickhouse.dsl.TableColumn.AnyTableColumn
+import com.crobox.clickhouse.dsl.Uniq.UniqModifier
 import com.crobox.clickhouse.dsl._
 import com.crobox.clickhouse.dsl.language.TokenizerModule.Database
 import com.crobox.clickhouse.time.TimeUnit.{Quarter, Total, Year}
 import com.crobox.clickhouse.time.{MultiDuration, SimpleDuration, TimeUnit}
 import com.dongxiguo.fastring.Fastring.Implicits._
+import com.google.common.base.Strings
 import com.typesafe.scalalogging.Logger
-import org.joda.time.DateTimeZone
+import org.joda.time.{DateTime, DateTimeZone}
 import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
 
 trait ClickhouseTokenizerModule extends TokenizerModule {
   private lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
@@ -55,7 +63,7 @@ trait ClickhouseTokenizerModule extends TokenizerModule {
         fast"$database.${table.name}"
       case Some(TableFromQuery(table: Table, Some(altDb))) =>
         fast"$altDb.${table.name}"
-      case _ => ""
+      case _                                               => ""
     }
   }
 
@@ -64,61 +72,144 @@ trait ClickhouseTokenizerModule extends TokenizerModule {
   protected def tokenizeColumn(column: AnyTableColumn): String = {
     require(column != null)
     column match {
-      case AliasedColumn(original, alias) => fast"${tokenizeColumn(original)} AS $alias"
-      case tuple: TupleColumn[_]          => fast"(${tuple.elements.map(tokenizeColumn).mkString(",")})"
-      case Count(countColumn)             => fast"count(${countColumn.map(tokenizeColumn).getOrElse("")})"
-      case c: Const[_]                    => c.parsed
-      case CountIf(expressionColumn: ExpressionColumn[_]) =>
-        fast"countIf(${tokenizeColumn(expressionColumn)})"
-      case CountIf(comparison: Comparison) =>
-        fast"countIf(${tokenizeCondition(comparison)})"
-      case ArrayJoin(tableColumn)         => fast"arrayJoin(${tokenizeColumn(tableColumn)})"
-      case GroupUniqArray(tableColumn)    => fast"groupUniqArray(${tokenizeColumn(tableColumn)})"
-      case All()                          => "*"
-      case UniqIf(tableColumn, expressionColumn: ExpressionColumn[_]) =>
-        fast"uniqIf(${tokenizeColumn(tableColumn)}, ${tokenizeColumn(expressionColumn)})"
-      case UniqIf(tableColumn, expressionColumn: Comparison) =>
-        fast"uniqIf(${tokenizeColumn(tableColumn)}, ${tokenizeCondition(expressionColumn)})"
-      case SumIf(tableColumn, expressionColumn: ExpressionColumn[_]) =>
-        fast"sumIf(${tokenizeColumn(tableColumn)}, ${tokenizeColumn(expressionColumn)})"
-      case SumIf(tableColumn, expressionColumn: Comparison) =>
-        fast"sumIf(${tokenizeColumn(tableColumn)}, ${tokenizeCondition(expressionColumn)})"
-      case BooleanInt(tableColumn, value) => fast"${tokenizeColumn(tableColumn)} = $value"
-      case Empty(tableColumn)             => fast"empty(${tokenizeColumn(tableColumn)})"
-      case NotEmpty(tableColumn)          => fast"notEmpty(${tokenizeColumn(tableColumn)})"
-      case UInt64(tableColumn)            => fast"toUInt64(${tokenizeColumn(tableColumn)})"
-      case Uniq(tableColumn)              => fast"uniq(${tokenizeColumn(tableColumn)})"
-      case UniqState(tableColumn)         => fast"uniqState(${tokenizeColumn(tableColumn)})"
-      case UniqMerge(tableColumn)         => fast"uniqMerge(${tokenizeColumn(tableColumn)})"
-      case Sum(tableColumn)               => fast"sum(${tokenizeColumn(tableColumn)})"
-      case Min(tableColumn)               => fast"min(${tokenizeColumn(tableColumn)})"
-      case Max(tableColumn)               => fast"max(${tokenizeColumn(tableColumn)})"
-      case LowerCaseColumn(tableColumn)   => fast"lowerUTF8(${tokenizeColumn(tableColumn)})"
-      case timeSeries: TimeSeries         => tokenizeTimeSeries(timeSeries)
-      case Conditional(cases, default) =>
-        fast"CASE ${cases
-          .map(ccase => fast"WHEN ${tokenizeCondition(ccase.condition)} THEN ${tokenizeColumn(ccase.column)}")
-          .mkString(" ")} ELSE ${tokenizeColumn(default)} END"
+      case AliasedColumn(original, alias) =>
+        val originalColumnToken = tokenizeColumn(original)
+        if (Strings.isNullOrEmpty(originalColumnToken)) alias else fast"$originalColumnToken AS $alias"
+      case tuple: TupleColumn[_]         => fast"(${tuple.elements.map(tokenizeColumn).mkString(",")})"
+      case col: ExpressionColumn[_]      => tokenizeExpressionColumn(col)
       case regularColumn: AnyTableColumn => regularColumn.name
     }
   }
 
-  private def tokenizeTimeSeries(timeSeries: TimeSeries): String = {
-    val column = tokenizeColumn(timeSeries.tableColumn)
-    val zone   = timeSeries.interval.getStart.getZone
-    tokenizeDuration(timeSeries, column, zone)
+  private def tokenizeExpressionColumn(col: ExpressionColumn[_]): String =
+    col match {
+      case agg: AggregateFunction[_]    => tokenizeAggregateFunction(agg)
+      case ArrayJoin(tableColumn)       => fast"arrayJoin(${tokenizeColumn(tableColumn)})"
+      case All()                        => "*"
+      case UInt64(tableColumn)          => fast"toUInt64(${tokenizeColumn(tableColumn)})"
+      case LowerCaseColumn(tableColumn) => fast"lowerUTF8(${tokenizeColumn(tableColumn)})"
+      case Conditional(cases, default) =>
+        fast"CASE ${cases
+          .map(ccase => fast"WHEN ${tokenizeCondition(ccase.condition)} THEN ${tokenizeColumn(ccase.column)}")
+          .mkString(" ")} ELSE ${tokenizeColumn(default)} END"
+      case c: Const[_] => c.parsed
+    }
+
+  private def tokenizeAggregateFunction(agg: AggregateFunction[_]): String =
+    agg match {
+      case nested: CombinedAggregatedFunction[_, _] =>
+        val tokenizedCombinators = collectCombinators(nested).map(tokenizeCombinator)
+        val combinators          = tokenizedCombinators.map(_._1).mkString("")
+        val combinatorsValues    = tokenizedCombinators.flatMap(_._2).mkString(",")
+        val (function, values)   = tokenizeInnerAggregatedFunction(extractTarget(nested))
+        val separator            = if (Strings.isNullOrEmpty(values) || Strings.isNullOrEmpty(combinatorsValues)) "" else ","
+        fast"$function$combinators($values$separator$combinatorsValues)"
+      case timeSeries: TimeSeries => tokenizeTimeSeries(timeSeries)
+      case aggregated: AggregateFunction[_] =>
+        val (function, values) = tokenizeInnerAggregatedFunction(aggregated)
+        fast"$function($values)"
+    }
+
+  def collectCombinators(function: AggregateFunction[_]): Seq[Combinator[_, _]] =
+    function match {
+      case CombinedAggregatedFunction(combinator, aggregated) => collectCombinators(aggregated) :+ combinator
+      case _                                                  => Seq()
+    }
+
+  def extractTarget(function: AggregateFunction[_]): AggregateFunction[_] =
+    function match {
+      case CombinedAggregatedFunction(_, aggregated) => extractTarget(aggregated)
+      case value                                     => value
+    }
+
+  private def tokenizeInnerAggregatedFunction(agg: AggregateFunction[_]): (String, String) =
+    agg match {
+      case Avg(column)   => ("avg", tokenizeColumn(column))
+      case Count(column) => ("count", tokenizeColumn(column.getOrElse(EmptyColumn())))
+      case Median(column, modifier, level) =>
+        val (modifierName, modifierValue) = tokenizeLevelModifier(modifier)
+        (fast"median$modifierName", fast"$level)(${tokenizeColumn(column)}${modifierValue.map("," + _).getOrElse("")}")
+      case Quantile(column, modifier, Left(level)) =>
+        val (modifierName, modifierValue) = tokenizeLevelModifier(modifier)
+        (fast"quantile$modifierName",
+         fast"$level)(${tokenizeColumn(column)}${modifierValue.map("," + _).getOrElse("")})")
+      case Quantile(column, modifier, Right(levels)) =>
+        val (modifierName, modifierValue) = tokenizeLevelModifier(modifier)
+        (fast"quantiles$modifierName",
+         fast"${levels.mkString(",")})(${tokenizeColumn(column)}${modifierValue.map("," + _).getOrElse("")}")
+      case Uniq(column, modifier)      => (s"uniq${tokenizeUniqModifier(modifier)}", tokenizeColumn(column))
+      case Sum(column, modifier)       => (s"sum${tokenizeSumModifier(modifier)}", tokenizeColumn(column))
+      case AnyResult(column, modifier) => (s"any${tokenizeAnyModifier(modifier)}", tokenizeColumn(column))
+      case Min(tableColumn)            => ("min", tokenizeColumn(tableColumn))
+      case Max(tableColumn)            => ("max", tokenizeColumn(tableColumn))
+      case GroupUniqArray(tableColumn) => ("groupUniqArray", tokenizeColumn(tableColumn))
+      case GroupArray(tableColumn, maxValues) =>
+        ("groupArray", fast"${maxValues.map(_.toString + ")(").getOrElse("")}${tokenizeColumn(tableColumn)}")
+      case f: AggregateFunction[_] =>
+        throw new IllegalArgumentException(s"Cannot use $f aggregated function with combinator")
+    }
+
+  def tokenizeLevelModifier(level: LevelModifier): (String, Option[String]) =
+    level match {
+      case Leveled.Normal                      => ("", None)
+      case Leveled.Deterministic(determinator) => ("Deterministic", Some(tokenizeColumn(determinator)))
+      case Leveled.Timing                      => ("Timing", None)
+      case Leveled.Weighted(weight)            => ("TimingWeighted", Some(weight.toString))
+      case Leveled.Exact                       => ("Exact", None)
+      case Leveled.ExactWeighted(weight)       => ("ExactWeighted", Some(weight.toString))
+      case Leveled.TDigest                     => ("TDigest", None)
+    }
+
+  def tokenizeUniqModifier(modifier: UniqModifier): String =
+    modifier match {
+      case Uniq.Normal   => ""
+      case Uniq.Combined => "Combined"
+      case Uniq.Exact    => "Exact"
+      case Uniq.HLL12    => "HLL12"
+
+    }
+
+  def tokenizeSumModifier(modifier: SumModifier): String =
+    modifier match {
+      case Sum.Normal       => ""
+      case Sum.WithOverflow => "WithOverflow"
+      case Sum.Map          => "Map"
+    }
+
+  def tokenizeAnyModifier(modifier: AnyModifier): String =
+    modifier match {
+      case AnyResult.Normal => ""
+      case AnyResult.Heavy  => "Heavy"
+      case AnyResult.Last   => "Last"
+    }
+
+  private def tokenizeCombinator(combinator: AggregateFunction.Combinator[_, _]): (String, Option[String]) =
+    combinator match {
+      case If(condition)     => ("If", Some(tokenizeCondition(condition)))
+      case CombinatorArray() => ("Array", None)
+      case ArrayForEach()    => ("ForEach", None)
+      case State()           => ("State", None)
+      case Merge()           => ("Merge", None)
+    }
+
+  private[language] def tokenizeTimeSeries(timeSeries: TimeSeries): String = {
+    val column   = tokenizeColumn(timeSeries.tableColumn)
+    tokenizeDuration(timeSeries, column)
   }
 
-  private def tokenizeDuration(timeSeries: TimeSeries, column: String, dateZone: DateTimeZone) = {
+
+  private def tokenizeDuration(timeSeries: TimeSeries, column: String) = {
     val interval = timeSeries.interval
-    val zoneId   = dateZone.getID
     interval.duration match {
       case MultiDuration(value, TimeUnit.Month) =>
-        fast"concat(toString(intDiv(toRelativeMonthNum(toDateTime($column / 1000),'$zoneId'), $value) * $value),'_$zoneId')"
+        val dateZone = determineZoneId(interval.rawStart)
+        fast"concat(toString(intDiv(toRelativeMonthNum(toDateTime($column / 1000),'$dateZone'), $value) * $value),'_$dateZone')"
       case MultiDuration(_, Quarter) =>
-        fast"concat(toString(toStartOfQuarter(toDateTime($column / 1000),'$zoneId')),'_$zoneId')"
+        val dateZone = determineZoneId(interval.rawStart)
+        fast"concat(toString(toStartOfQuarter(toDateTime($column / 1000),'$dateZone')),'_$dateZone')"
       case MultiDuration(_, Year) =>
-        fast"concat(toString(toStartOfYear(toDateTime($column / 1000),'$zoneId')),'_$zoneId')"
+        val dateZone = determineZoneId(interval.rawStart)
+        fast"concat(toString(toStartOfYear(toDateTime($column / 1000),'$dateZone')),'_$dateZone')"
       case SimpleDuration(Total) => fast"${interval.getStartMillis}"
       //        handles seconds/minutes/hours/days/weeks
       case multiDuration: MultiDuration =>
@@ -129,6 +220,20 @@ trait ClickhouseTokenizerModule extends TokenizerModule {
     }
   }
 
+  //TODO this is a fallback to find a similar timezone when the provided interval does not have a set timezone id. We should be able to disable this from the config and fail fast if we cannot determine the timezone for timeseries (probably default to failing)
+  private def determineZoneId(start: DateTime) = {
+    val provider = DateTimeZone.getProvider
+    val zones = provider.getAvailableIDs.asScala.map(provider.getZone)
+    val zone = start.getZone
+    val targetZone = zones
+      .find(_.getID == zone.getID)
+      .orElse(
+        zones.find(targetZone => targetZone.getOffset(start.getMillis) == start.getZone.getOffset(start.getMillis))
+      )
+      .getOrElse(throw new IllegalArgumentException(s"Could not determine the zone from source $zone"))
+      .getID
+    targetZone
+  }
   //  Table joins are tokenized as select * because of https://github.com/yandex/ClickHouse/issues/635
   private def tokenizeJoin(option: Option[JoinQuery])(implicit database: Database): String =
     option match {

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/package.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/package.scala
@@ -1,17 +1,33 @@
 package com.crobox.clickhouse
 
+import com.crobox.clickhouse.dsl.AggregateFunction.AggregationFunctionsCombinersDsl
+import com.crobox.clickhouse.dsl.AnyResult.AnyResultDsl
+import com.crobox.clickhouse.dsl.Leveled.LevelModifierDsl
+import com.crobox.clickhouse.dsl.{ColumnOperations, QueryFactory}
+import com.crobox.clickhouse.dsl.Sum.SumDsl
 import com.crobox.clickhouse.dsl.TableColumn.AnyTableColumn
+import com.crobox.clickhouse.dsl.Uniq.UniqDsl
 import com.crobox.clickhouse.dsl.execution.{ClickhouseQueryExecutor, QueryResult}
 import com.crobox.clickhouse.dsl.marshalling.{QueryValue, QueryValueFormats}
 import com.dongxiguo.fastring.Fastring.Implicits._
 import spray.json.{JsonReader, JsonWriter}
 
-import scala.annotation.implicitNotFound
 import scala.collection.immutable.Iterable
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-package object dsl extends ColumnOperations with QueryFactory with QueryValueFormats {
+trait DslLanguage
+    extends ColumnOperations
+    with AggregationFunctionsCombinersDsl
+    with UniqDsl
+    with AnyResultDsl
+    with SumDsl
+    with LevelModifierDsl
+    with QueryFactory
+    with QueryValueFormats
+object DslLanguage extends DslLanguage
+
+package object dsl extends DslLanguage {
 
   //Naive union type context bound
   trait Contra[-A]

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/package.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/package.scala
@@ -15,7 +15,7 @@ package object dsl extends ColumnOperations with QueryFactory with QueryValueFor
 
   //Naive union type context bound
   trait Contra[-A]
-  type Union[A,B] = Contra[A] <:< Contra[B]
+  type Union[A, B] = Contra[A] <:< Contra[B]
 
   implicit def fstr2str(fstr: Fastring): String = fstr.toString
 
@@ -36,25 +36,25 @@ package object dsl extends ColumnOperations with QueryFactory with QueryValueFor
   }
 
   /**
-    * Exposes the OperationalQuery.+ operator on Try[OperationalQuery]
-    */
+   * Exposes the OperationalQuery.+ operator on Try[OperationalQuery]
+   */
   implicit class OperationalQueryTryLifter(base: Try[OperationalQuery]) {
+
     def +(other: OperationalQuery): Try[OperationalQuery] =
       for {
-        b <- base
+        b  <- base
         bo <- b + other
       } yield OperationalQuery(bo.internalQuery)
 
     def +(other: Try[OperationalQuery]): Try[OperationalQuery] =
       for {
-        b <- base
-        o <- other
+        b  <- base
+        o  <- other
         bo <- b + o
       } yield OperationalQuery(bo.internalQuery)
   }
 
   implicit class StringColumnWithCondition(column: TableColumn[String]) {
-
 
     //TODO switch the starts/ends/contains for iterables to use a one if for lists
     def startsWith(others: Iterable[String])(implicit ev: QueryValue[String],
@@ -115,7 +115,6 @@ package object dsl extends ColumnOperations with QueryFactory with QueryValueFor
   }
 
   implicit class ColumnsWithCondition[V](column: TableColumn[V]) {
-
 
     def <(other: TableColumn[V]): Comparison =
       ColRefColumnComparison[V](column, "<", other)
@@ -268,22 +267,22 @@ package object dsl extends ColumnOperations with QueryFactory with QueryValueFor
   implicit def toComparison(comparisons: Seq[Comparison]): Comparison =
     comparisons.reduceOption(_ and _)
 
-  trait Comparison
+  abstract class Comparison extends TableColumn[Boolean]("")
 
   case class ChainableColumnCondition(left: Comparison, operator: String, right: Comparison) extends Comparison
 
-  abstract class AbstractColumnComparison[V, W](left: TableColumn[V], operator: String) extends Comparison {
+  abstract class ColumnComparison[V, W](left: TableColumn[V], operator: String) extends Comparison {
     val right: W
   }
 
   case class ValueColumnComparison[V, W](left: TableColumn[V], operator: String, override val right: W)(
       implicit ev: QueryValue[W]
-  ) extends AbstractColumnComparison[V, W](left: TableColumn[V], operator: String) {
+  ) extends ColumnComparison[V, W](left: TableColumn[V], operator: String) {
     val queryValueEvidence: QueryValue[W] = ev
   }
 
   case class ColRefColumnComparison[V](left: TableColumn[V], operator: String, override val right: TableColumn[V])
-      extends AbstractColumnComparison[V, TableColumn[V]](left: TableColumn[V], operator: String)
+      extends ColumnComparison[V, TableColumn[V]](left: TableColumn[V], operator: String)
 
   case class FunctionColumnComparison[V](functionName: String, column: TableColumn[V]) extends Comparison
 

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/schemabuilder/Column.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/schemabuilder/Column.scala
@@ -72,7 +72,7 @@ object ColumnType {
   }
 
 //  TODO modifi this to accept and expression column
-  case class AggregateFunction(function: String, columnType: ColumnType)
+  case class AggregateFunctionColumn(function: String, columnType: ColumnType)
       extends SimpleColumnType(s"AggregateFunction($function, ${columnType.toString})")
 
 }

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/AggregationFunctionsIT.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/AggregationFunctionsIT.scala
@@ -2,26 +2,53 @@ package com.crobox.clickhouse.dsl
 
 import java.util.UUID
 
-import com.crobox.clickhouse.TestSchemaClickhouseQuerySpec
+import com.crobox.clickhouse.{DslLanguage, TestSchemaClickhouseQuerySpec}
 import com.crobox.clickhouse.testkit.ClickhouseClientSpec
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 import spray.json.DefaultJsonProtocol._
 import spray.json.RootJsonFormat
 
-class AggregationFunctionsIT extends ClickhouseClientSpec with TestSchemaClickhouseQuerySpec with ScalaFutures {
+class AggregationFunctionsIT
+    extends ClickhouseClientSpec
+    with TestSchemaClickhouseQuerySpec
+    with ScalaFutures
+    with DslLanguage {
+
   private val entries                          = 200145
   override val table1Entries: Seq[Table1Entry] = Seq.fill(entries)(Table1Entry(UUID.randomUUID()))
+  override val table2Entries: Seq[Table2Entry] =
+    Seq.fill(entries)(Table2Entry(UUID.randomUUID(), randomString, randomInt, randomString, None))
   import scala.concurrent.ExecutionContext.Implicits.global
-  case class Result(columnResult: Int)
-  implicit val resultFormat: RootJsonFormat[Result] = jsonFormat[Int, Result](Result.apply, "result")
   implicit override val patienceConfig =
     PatienceConfig(timeout = scaled(Span(10, Seconds)), interval = scaled(Span(20, Millis)))
 
   "Combinators" should "apply for aggregations" in {
-    chExecuter
+    case class Result(columnResult: String) {
+      def result = columnResult.toInt
+    }
+    implicit val resultFormat: RootJsonFormat[Result] = jsonFormat[String, Result](Result.apply, "result")
+
+    val resultSimple = chExecuter
+      .execute[Result](select(simple { uniq(shieldId) } as "result") from OneTestTable)
+      .futureValue
+    val resultExact = chExecuter
       .execute[Result](select(exact { uniq(shieldId) } as "result") from OneTestTable)
-      .map(_.rows.head.columnResult shouldBe entries)
+      .futureValue
+    resultSimple.rows.head.result shouldBe (entries +- entries / 100)
+    resultSimple.rows.head.result should not be (entries)
+    resultExact.rows.head.result shouldBe entries
+  }
+
+  it should "run quantiles" in {
+    case class Result(result: Seq[Int])
+    implicit val resultFormat: RootJsonFormat[Result] = jsonFormat[Seq[Int], Result](Result.apply, "result")
+    val result = chExecuter
+      .execute[Result](
+        select(simple { quantiles(col2, 0.1F, 0.2F, 0.3F, 0.4F, 0.5F, 0.99F) } as "result") from TwoTestTable
+      )
+      .futureValue
+    result.rows.head.result should have length 6
   }
 
 }

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/AggregationFunctionsIT.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/AggregationFunctionsIT.scala
@@ -15,8 +15,9 @@ class AggregationFunctionsIT
     with ScalaFutures
     with DslLanguage {
 
-  private val entries                          = 200145
-  override val table1Entries: Seq[Table1Entry] = Seq.fill(entries)(Table1Entry(UUID.randomUUID()))
+  private val entries = 200145
+  override val table1Entries: Seq[Table1Entry] =
+    Seq.fill(entries)(Table1Entry(UUID.randomUUID(), numbers = Seq(1, 2, 3)))
   override val table2Entries: Seq[Table2Entry] =
     Seq.fill(entries)(Table2Entry(UUID.randomUUID(), randomString, randomInt, randomString, None))
   import scala.concurrent.ExecutionContext.Implicits.global
@@ -30,13 +31,13 @@ class AggregationFunctionsIT
     implicit val resultFormat: RootJsonFormat[Result] = jsonFormat[String, Result](Result.apply, "result")
 
     val resultSimple = chExecuter
-      .execute[Result](select(simple { uniq(shieldId) } as "result") from OneTestTable)
+      .execute[Result](select(uniq(shieldId) as "result") from OneTestTable)
       .futureValue
     val resultExact = chExecuter
-      .execute[Result](select(exact { uniq(shieldId) } as "result") from OneTestTable)
+      .execute[Result](select(uniqExact(shieldId) as "result") from OneTestTable)
       .futureValue
     resultSimple.rows.head.result shouldBe (entries +- entries / 100)
-    resultSimple.rows.head.result should not be (entries)
+    resultSimple.rows.head.result should not be entries
     resultExact.rows.head.result shouldBe entries
   }
 
@@ -45,10 +46,25 @@ class AggregationFunctionsIT
     implicit val resultFormat: RootJsonFormat[Result] = jsonFormat[Seq[Int], Result](Result.apply, "result")
     val result = chExecuter
       .execute[Result](
-        select(simple { quantiles(col2, 0.1F, 0.2F, 0.3F, 0.4F, 0.5F, 0.99F) } as "result") from TwoTestTable
+        select(quantiles(col2, 0.1F, 0.2F, 0.3F, 0.4F, 0.5F, 0.99F) as ref[Seq[Int]]("result")) from TwoTestTable
       )
       .futureValue
     result.rows.head.result should have length 6
+  }
+
+  it should "run for each" in {
+    case class Result(result: Seq[String])
+    implicit val resultFormat: RootJsonFormat[Result] = jsonFormat[Seq[String], Result](Result.apply, "result")
+    val result = chExecuter
+      .execute[Result](
+        select(forEach[Int, TableColumn[Seq[Int]], Double](numbers) { column =>
+          sum(column)
+        } as "result") from OneTestTable
+      )
+      .futureValue
+    val queryResult = result.rows.head.result.map(_.toInt)
+    queryResult should have length 3
+    queryResult should contain theSameElementsAs Seq(entries, entries * 2, entries * 3)
   }
 
 }

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/AggregationFunctionsIT.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/AggregationFunctionsIT.scala
@@ -1,0 +1,27 @@
+package com.crobox.clickhouse.dsl
+
+import java.util.UUID
+
+import com.crobox.clickhouse.TestSchemaClickhouseQuerySpec
+import com.crobox.clickhouse.testkit.ClickhouseClientSpec
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Seconds, Span}
+import spray.json.DefaultJsonProtocol._
+import spray.json.RootJsonFormat
+
+class AggregationFunctionsIT extends ClickhouseClientSpec with TestSchemaClickhouseQuerySpec with ScalaFutures {
+  private val entries                          = 200145
+  override val table1Entries: Seq[Table1Entry] = Seq.fill(entries)(Table1Entry(UUID.randomUUID()))
+  import scala.concurrent.ExecutionContext.Implicits.global
+  case class Result(columnResult: Int)
+  implicit val resultFormat: RootJsonFormat[Result] = jsonFormat[Int, Result](Result.apply, "result")
+  implicit override val patienceConfig =
+    PatienceConfig(timeout = scaled(Span(10, Seconds)), interval = scaled(Span(20, Millis)))
+
+  "Combinators" should "apply for aggregations" in {
+    chExecuter
+      .execute[Result](select(exact { uniq(shieldId) } as "result") from OneTestTable)
+      .map(_.rows.head.columnResult shouldBe entries)
+  }
+
+}

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/QueryMergeTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/QueryMergeTest.scala
@@ -6,7 +6,6 @@ import com.crobox.clickhouse.dsl
 import com.crobox.clickhouse.dsl.language.ClickhouseTokenizerModule
 import com.crobox.clickhouse.dsl.parallel._
 import com.crobox.clickhouse.testkit.ClickhouseClientSpec
-import org.scalactic.{AbstractStringUniformity, Uniformity}
 
 class QueryMergeTest extends ClickhouseClientSpec with TestSchema {
   val clickhouseTokenizer = new ClickhouseTokenizerModule {}
@@ -17,7 +16,7 @@ class QueryMergeTest extends ClickhouseClientSpec with TestSchema {
     val right: OperationalQuery = select(dsl.all()) from OneTestTable where shieldId.isEq(expectedUUID)
     val query                   = right merge left on timestampColumn
     clickhouseTokenizer.toSql(query.internalQuery).replaceAll("[\\s\\n]","") should be(
-      s"""SELECT shield_id, * FROM (
+      s"""SELECT shield_id,numbers, * FROM (
          |  SELECT item_id, ts FROM $tokenizerDatabase.twoTestTable WHERE column_3 = 'wompalama' GROUP BY ts ORDER BY ts ASC
          |) ALL LEFT JOIN (
          |  SELECT * FROM $tokenizerDatabase.captainAmerica WHERE shield_id = '$expectedUUID' GROUP BY ts ORDER BY ts ASC

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/QueryTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/QueryTest.scala
@@ -65,7 +65,7 @@ class QueryTest extends ClickhouseClientSpec with TestSchema {
     val query2 = select(itemId) from OneTestTable where col2 >= 2
     val composed = query + query2
     composed should matchPattern {
-      case t: Failure[IllegalArgumentException] =>
+      case Failure(_:IllegalArgumentException) =>
     }
   }
 

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/TestSchema.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/TestSchema.scala
@@ -30,7 +30,7 @@ trait TestSchema {
 
   case object OneTestTable extends Table {
     override val name: String                   = "captainAmerica"
-    override val columns: List[NativeColumn[_]] = List(shieldId, timestampColumn)
+    override val columns: List[NativeColumn[_]] = List(shieldId, timestampColumn, numbers)
   }
 
   case object TwoTestTable extends Table {
@@ -45,6 +45,7 @@ trait TestSchema {
 
   val shieldId        = NativeColumn[UUID]("shield_id")
   val itemId          = NativeColumn[UUID]("item_id")
+  val numbers         = NativeColumn[Seq[Int]]("numbers", ColumnType.Array(ColumnType.UInt32))
   val col1            = NativeColumn[String]("column_1")
   val col2            = NativeColumn[Int]("column_2", ColumnType.UInt32)
   val col3            = NativeColumn[String]("column_3")
@@ -53,7 +54,7 @@ trait TestSchema {
   val col6            = NativeColumn[String]("column_6")
   val timestampColumn = NativeColumn[Long]("ts", ColumnType.UInt64)
 
-  case class Table1Entry(shieldId: UUID, date: DateTime = DateTime.now())
+  case class Table1Entry(shieldId: UUID, date: DateTime = DateTime.now(), numbers: Seq[Int] = Seq())
 
   object Table1Entry {
 
@@ -62,10 +63,11 @@ trait TestSchema {
       override def write(obj: Table1Entry): JsValue =
         JsObject(
           "shield_id" -> JsString(obj.shieldId.toString),
-          "ts"        -> JsNumber(obj.date.getMillis)
+          "ts"        -> JsNumber(obj.date.getMillis),
+          "numbers"   -> JsArray(obj.numbers.map(JsNumber(_)).toVector)
         )
     }
-    val reader: RootJsonFormat[Table1Entry] = jsonFormat(Table1Entry.apply, "shield_id", "ts")
+    val reader: RootJsonFormat[Table1Entry] = jsonFormat(Table1Entry.apply, "shield_id", "ts", "numbers")
     implicit val format                     = jsonFormat(reader, Format)
   }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,8 +1,8 @@
 import sbt._
 object Build {
 
-  val AkkaVersion     = "2.5.9"
-  val AkkaHttpVersion = "10.0.11"
+  val AkkaVersion     = "2.5.11"
+  val AkkaHttpVersion = "10.1.1"
   val JacksonVersion  = "2.7.9"
 
   val testDependencies = Seq("org.scalatest" %% "scalatest" % "3.0.0",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.1.4


### PR DESCRIPTION
- Fixed bug when using timeseries for month/year/quarter, which were dependent on the timezone id and that was not available. For this we are falling back to finding a timezone id with the same offset. There will be differences between the timezone, but if you provide it with an id then that will be used.

- Added all combinators for aggregated functions and cleaned part of dsl
