### PR TITLE
Propagate QueryValue evidence for NOT IN operator

### DIFF
--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/package.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/package.scala
@@ -222,8 +222,9 @@ package object dsl extends DslLanguage {
     override def isIn(other: Iterable[V])(implicit ev: QueryValue[V],
                                           validator: ComparisonValidator[Iterable[_ >: V]]): Comparison =
       super.isIn(other) match {
-        case comparison: ValueColumnComparison[_, V] => comparison.copy(operator = "NOT IN")
-        case other: Comparison                       => other
+        case comparison: ValueColumnComparison[_, V] =>
+          comparison.copy(operator = "NOT IN")(comparison.queryValueEvidence)
+        case other: Comparison => other
       }
   }
 

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/QueryTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/QueryTest.scala
@@ -35,6 +35,14 @@ class QueryTest extends ClickhouseClientSpec with TestSchema {
     )
   }
 
+  it should "propagate the evidence when negating isIn()" in {
+    val ids = Seq.fill(3)(UUID.randomUUID())
+    val query = select(shieldId) from OneTestTable where shieldId.not().isIn(ids.toSet)
+    clickhouseTokenizer.toSql(query.internalQuery) should be(
+      s"SELECT shield_id FROM default.captainAmerica WHERE shield_id NOT IN (${ids.map(s => s"'$s'").mkString(",")}) FORMAT JSON"
+    )
+  }
+
   it should "escape from evil" in {
     val query = select(shieldId) from OneTestTable where col3.isEq("use ' evil")
     clickhouseTokenizer.toSql(query.internalQuery) should be(


### PR DESCRIPTION
When negating the `isIn()` operator, the resolved query value evidence
from `isIn()` should be propagated explicitly to the copied comparison.