### PR TITLE
Custom partition MergeTree & Distributed DDL

### DIFF
--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/schemabuilder/CreateDatabase.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/schemabuilder/CreateDatabase.scala
@@ -6,14 +6,14 @@ import com.crobox.clickhouse.dsl.ClickhouseStatement
  * @author Sjoerd Mulder
  * @since 2-1-17
  */
-case class CreateDatabase(dbName: String, ifNotExists: Boolean = false) extends ClickhouseSchemaStatement {
+case class CreateDatabase(dbName: String, ifNotExists: Boolean = false, clusterName : Option[String] = None) extends ClickhouseSchemaStatement with DistributedDdlSupport {
 
   require(ClickhouseStatement.isValidIdentifier(dbName), s"Invalid database name identifier")
-
+  requireValidCluster("Cannot create a database with an invalid cluster name")
   /**
    * Returns the query string for this statement.
    *
    * @return String containing the Clickhouse dialect SQL statement
    */
-  override def query: String = s"CREATE DATABASE${printIfNotExists(ifNotExists)} $dbName"
+  override def query: String = s"CREATE DATABASE${printIfNotExists(ifNotExists)} $dbName${printOnCluster()}"
 }

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/schemabuilder/CreateTable.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/schemabuilder/CreateTable.scala
@@ -10,17 +10,13 @@ case class CreateTable(table: Table,
                        engine: Engine,
                        ifNotExists: Boolean = false,
                        databaseName: String = ClickhouseStatement.DefaultDatabase,
-                       onCluster: Option[String] = None)
-    extends ClickhouseSchemaStatement {
+                       clusterName : Option[String] = None)
+    extends ClickhouseSchemaStatement with DistributedDdlSupport {
 
   require(ClickhouseStatement.isValidIdentifier(table.name), "Cannot create a table with invalid identifier")
   require(ClickhouseStatement.isValidIdentifier(databaseName), "Cannot create a table with invalid database identifier")
-  onCluster.foreach(cluster =>
-      require(ClickhouseStatement.isValidIdentifier(cluster), "Cannot create a table with invalid cluster identifier")
-  )
+  requireValidCluster("Cannot create a table with invalid cluster identifier")
   require(table.columns.nonEmpty, "Cannot create a table without any columns")
-
-  private val onClusterString = onCluster.map(cluster => s" ON CLUSTER $cluster").getOrElse("")
 
   /**
    * Returns the query string for this statement.
@@ -29,7 +25,7 @@ case class CreateTable(table: Table,
    */
 //  TODO migrate this to the tokenizer as well
   override def query: String =
-    s"""CREATE TABLE${printIfNotExists(ifNotExists)} $databaseName.${table.name}$onClusterString (
+    s"""CREATE TABLE${printIfNotExists(ifNotExists)} $databaseName.${table.name}${printOnCluster()} (
        |  ${table.columns.map(_.query()).mkString(",\n  ")}
        |) ENGINE = $engine""".stripMargin
 }

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/schemabuilder/DistributedDdlSupport.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/schemabuilder/DistributedDdlSupport.scala
@@ -1,0 +1,17 @@
+package com.crobox.clickhouse.dsl.schemabuilder
+
+import com.crobox.clickhouse.dsl.ClickhouseStatement
+
+trait DistributedDdlSupport {
+
+  val clusterName : Option[String]
+
+  def requireValidCluster(errorMsg : String): Unit = {
+    require(clusterName.forall(ClickhouseStatement.isValidIdentifier), errorMsg)
+  }
+
+  protected[schemabuilder] def printOnCluster() : String = {
+    clusterName.map(cluster => s" ON CLUSTER $cluster").getOrElse("")
+  }
+
+}

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/schemabuilder/CreateDatabaseTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/schemabuilder/CreateDatabaseTest.scala
@@ -18,4 +18,14 @@ class CreateDatabaseTest extends FlatSpecLike with Matchers {
 
   }
 
+  it should "create a database with ON CLUSTER clause" in {
+    CreateDatabase("db", clusterName = Option("test_cluster")).toString should be ("CREATE DATABASE db ON CLUSTER test_cluster")
+  }
+
+  it should "reject database creation with an invalid cluster name" in {
+    an[IllegalArgumentException] should be thrownBy {
+      CreateDatabase("db", clusterName = Option(".Invalid"))
+    }
+  }
+
 }

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/schemabuilder/DistributedDdlSupportTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/schemabuilder/DistributedDdlSupportTest.scala
@@ -1,0 +1,40 @@
+package com.crobox.clickhouse.dsl.schemabuilder
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class DistributedDdlSupportTest extends FlatSpec with Matchers {
+
+  class Dummy(val clusterName: Option[String]) extends DistributedDdlSupport
+
+  it should "consider None as a valid cluster and NOT print ON CLUSTER statement" in {
+    val underTest = new Dummy(None)
+
+    underTest.requireValidCluster("")
+    underTest.printOnCluster() should be ("")
+  }
+
+  it should "consider Some(\"valid_cluster\") as a valid cluster and print ON CLUSTER statement" in {
+    val underTest = new Dummy(Some("valid_cluster"))
+
+    underTest.requireValidCluster("")
+    underTest.printOnCluster() should be (" ON CLUSTER valid_cluster")
+  }
+
+  it should "reject an invalid cluster name" in {
+    an[IllegalArgumentException] should be thrownBy {
+      new Dummy(Some("")).requireValidCluster("")
+    }
+
+    an[IllegalArgumentException] should be thrownBy {
+      new Dummy(Some(null)).requireValidCluster("")
+    }
+
+    an[IllegalArgumentException] should be thrownBy {
+      new Dummy(Some("9aze")).requireValidCluster("")
+    }
+
+    an[IllegalArgumentException] should be thrownBy {
+      new Dummy(Some("aze@")).requireValidCluster("")
+    }
+  }
+}


### PR DESCRIPTION
- Support custom partition key for MergeTree. (since clickhouse 1.1.54310)
- Use new syntax for MergeTree engine arguments
(PARTITION BY, ORDER BY, SAMPLE BY, SETTINGS)
- Partial support for Distributed DDL (create database / table)