### PR TITLE
Backward compatibile syntax for Engine DSL

### DIFF
--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/schemabuilder/CreateTableTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/schemabuilder/CreateTableTest.scala
@@ -134,6 +134,39 @@ class CreateTableTest extends FlatSpecLike with Matchers {
                        |SETTINGS index_granularity=8192""".stripMargin)
   }
 
+  it should "support the old create statement syntax with month partition" in {
+    val date        = NativeColumn[LocalDate]("date", ColumnType.Date)
+    val clientId    = NativeColumn("client_id", ColumnType.FixedString(16))
+    val hitId       = NativeColumn("hit_id", ColumnType.FixedString(16))
+    val testColumn  = NativeColumn("test_column", ColumnType.String)
+    val testColumn2 = NativeColumn("test_column2", ColumnType.Int8, Default("2"))
+    val result = CreateTable(
+      TestTable(
+        "merge_tree_table",
+        Seq(
+          date,
+          clientId,
+          hitId,
+          testColumn,
+          testColumn2
+        )
+      ),
+      Engine.MergeTree(date, Seq(date, clientId, hitId), Some("int64Hash(client_id)"))
+    ).toString
+
+    result should be("""CREATE TABLE default.merge_tree_table (
+                       |  date Date,
+                       |  client_id FixedString(16),
+                       |  hit_id FixedString(16),
+                       |  test_column String,
+                       |  test_column2 Int8 DEFAULT 2
+                       |) ENGINE = MergeTree
+                       |PARTITION BY (toYYYYMM(date))
+                       |ORDER BY (date, client_id, hit_id, int64Hash(client_id))
+                       |SAMPLE BY int64Hash(client_id)
+                       |SETTINGS index_granularity=8192""".stripMargin)
+  }
+
   lazy val replacingMergeTree = {
     val date        = NativeColumn[LocalDate]("date", ColumnType.Date)
     val clientId    = NativeColumn("client_id", ColumnType.FixedString(16))


### PR DESCRIPTION
Backward compatible DSL syntax for MergeTree engines, supporting the old
partitioning from clickhouse (using the month partition from a date column).