### PR TITLE
Support multiple types in AggregateFunction column

### DIFF
--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/schemabuilder/Column.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/schemabuilder/Column.scala
@@ -72,8 +72,8 @@ object ColumnType {
   }
 
 //  TODO modifi this to accept and expression column
-  case class AggregateFunctionColumn(function: String, columnType: ColumnType)
-      extends SimpleColumnType(s"AggregateFunction($function, ${columnType.toString})")
+  case class AggregateFunctionColumn(function: String, columnType: ColumnType, nextTypes: ColumnType*)
+      extends SimpleColumnType(s"AggregateFunction($function, ${(columnType +: nextTypes).map(_.toString).mkString(", ")})")
 
 }
 

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/schemabuilder/ColumnTypeTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/schemabuilder/ColumnTypeTest.scala
@@ -21,4 +21,14 @@ class ColumnTypeTest extends FlatSpecLike with Matchers {
     }
   }
 
+  it should "support multiple arguments for AggregateFunction column" in {
+    ColumnType.AggregateFunctionColumn("uniq", ColumnType.String).toString should be(
+      "AggregateFunction(uniq, String)"
+    )
+
+    ColumnType.AggregateFunctionColumn("uniqIf", ColumnType.String, ColumnType.UInt8).toString should be(
+      "AggregateFunction(uniqIf, String, UInt8)"
+    )
+  }
+
 }


### PR DESCRIPTION
When declaring a column with the AggregateFunction type, some aggregate
functions requires multiple arguments (i.e. `uniqIf`).