### PR TITLE
Health check improvements

### DIFF
--- a/client/src/main/scala/com.crobox.clickhouse/balancing/ClusterAwareHostBalancer.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/balancing/ClusterAwareHostBalancer.scala
@@ -4,9 +4,9 @@ import akka.actor.{ActorRef, ActorSystem}
 import akka.http.scaladsl.model.Uri
 import akka.pattern.ask
 import akka.util.Timeout
+import com.crobox.clickhouse.balancing.discovery.ConnectionConfig
 import com.crobox.clickhouse.balancing.discovery.ConnectionManagerActor.GetConnection
 import com.crobox.clickhouse.balancing.discovery.cluster.ClusterConnectionProviderActor.ScanHosts
-import com.crobox.clickhouse.discovery.ConnectionConfig
 
 import scala.concurrent.Future
 import scala.concurrent.duration._

--- a/client/src/main/scala/com.crobox.clickhouse/balancing/discovery/cluster/ClusterConnectionProviderActor.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/balancing/discovery/cluster/ClusterConnectionProviderActor.scala
@@ -5,9 +5,9 @@ import akka.pattern.{ask, pipe}
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import akka.util.Timeout.durationToTimeout
+import com.crobox.clickhouse.balancing.discovery.ConnectionConfig
 import com.crobox.clickhouse.balancing.discovery.ConnectionManagerActor.Connections
 import com.crobox.clickhouse.balancing.discovery.cluster.ClusterConnectionProviderActor.ScanHosts
-import com.crobox.clickhouse.discovery.ConnectionConfig
 import com.crobox.clickhouse.internal.ClickhouseHostBuilder
 import com.crobox.clickhouse.internal.InternalExecutorActor.Execute
 
@@ -35,7 +35,8 @@ class ClusterConnectionProviderActor(manager: ActorRef, executor: ActorRef) exte
   }
 
   def resolveHosts(config: ConnectionConfig): Future[Connections] =
-    (executor ? Execute(config.host, s"SELECT host_address FROM system.clusters WHERE cluster='${config.cluster}'"))
+    (executor ? Execute(config.host,
+                        Some(s"SELECT host_address FROM system.clusters WHERE cluster='${config.cluster}'")))
       .mapTo[Seq[String]]
       .map(_.toSet)
       .map(result => {

--- a/client/src/main/scala/com.crobox.clickhouse/balancing/discovery/cluster/ClusterConnectionProviderActor.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/balancing/discovery/cluster/ClusterConnectionProviderActor.scala
@@ -35,8 +35,7 @@ class ClusterConnectionProviderActor(manager: ActorRef, executor: ActorRef) exte
   }
 
   def resolveHosts(config: ConnectionConfig): Future[Connections] =
-    (executor ? Execute(config.host,
-                        Some(s"SELECT host_address FROM system.clusters WHERE cluster='${config.cluster}'")))
+    (executor ? Execute(config.host, s"SELECT host_address FROM system.clusters WHERE cluster='${config.cluster}'"))
       .mapTo[Seq[String]]
       .map(_.toSet)
       .map(result => {

--- a/client/src/main/scala/com.crobox.clickhouse/balancing/discovery/health/HostHealthChecker.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/balancing/discovery/health/HostHealthChecker.scala
@@ -18,21 +18,20 @@ class HostHealthChecker(host: Uri, executor: ActorRef)(implicit val timeout: Tim
 
   override def receive = {
     case IsAlive() =>
-      (executor ? Execute(host, "SELECT 1"))
+      (executor ? Execute(host, None))
         .mapTo[Seq[String]]
         .map(result => {
-          if (result.equals(Seq("1"))) {
+          if (result.equals(Seq("Ok."))) {
             logger.trace(s"Host is alive for host ${host.toString()}")
             HostStatus(host, Alive)
           } else {
             logger.warn(s"Host ${host.toString()} status is DEAD because of response $result")
-            HostStatus(host, Dead)
+            HostStatus(host, Dead(new IllegalArgumentException(s"Got wrong result $result")))
           }
         })
         .recover {
           case ex: Throwable =>
-            logger.error(s"Host ${host.toString()} status is DEAD because of exception", ex)
-            HostStatus(host, Dead)
+            HostStatus(host, Dead(ex))
         } pipeTo sender
   }
 }
@@ -44,13 +43,19 @@ object HostHealthChecker {
 
   case class IsAlive()
 
-  trait Status
+  sealed trait Status {
+    val code: String
+  }
 
   object Status {
 
-    case object Alive extends Status
+    case object Alive extends Status {
+      override val code: String = "ok"
+    }
 
-    case object Dead extends Status
+    case class Dead(reason: Throwable) extends Status {
+      override val code: String = "nok"
+    }
   }
 
   case class HostStatus(host: Uri, status: Status)

--- a/client/src/main/scala/com.crobox.clickhouse/balancing/discovery/health/HostHealthChecker.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/balancing/discovery/health/HostHealthChecker.scala
@@ -7,7 +7,7 @@ import akka.util.Timeout
 import akka.util.Timeout.durationToTimeout
 import com.crobox.clickhouse.balancing.discovery.health.HostHealthChecker.Status.{Alive, Dead}
 import com.crobox.clickhouse.balancing.discovery.health.HostHealthChecker.{HostStatus, IsAlive}
-import com.crobox.clickhouse.internal.InternalExecutorActor.Execute
+import com.crobox.clickhouse.internal.InternalExecutorActor.{Execute, HealthCheck}
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.concurrent.duration._
@@ -18,7 +18,7 @@ class HostHealthChecker(host: Uri, executor: ActorRef)(implicit val timeout: Tim
 
   override def receive = {
     case IsAlive() =>
-      (executor ? Execute(host, None))
+      (executor ? HealthCheck(host))
         .mapTo[Seq[String]]
         .map(result => {
           if (result.equals(Seq("Ok."))) {

--- a/client/src/main/scala/com.crobox.clickhouse/balancing/discovery/package.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/balancing/discovery/package.scala
@@ -1,4 +1,4 @@
-package com.crobox.clickhouse
+package com.crobox.clickhouse.balancing
 
 import akka.http.scaladsl.model.Uri
 

--- a/client/src/main/scala/com.crobox.clickhouse/internal/ClickHouseExecutor.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/ClickHouseExecutor.scala
@@ -15,7 +15,7 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
   this: ClickhouseResponseParser with ClickhouseQueryBuilder =>
 
   protected implicit val system: ActorSystem
-  private implicit lazy val materializer: Materializer = ActorMaterializer()
+  protected implicit lazy val materializer: Materializer = ActorMaterializer()
 
   override protected def config: Config
 
@@ -26,8 +26,8 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
     .queue[(HttpRequest, Promise[HttpResponse])](bufferSize, OverflowStrategy.dropNew)
     .via(pool)
     .toMat(Sink.foreach {
-      case ((Success(resp), p)) => p.success(resp)
-      case ((Failure(e), p))    => p.failure(e)
+      case (Success(resp), p) => p.success(resp)
+      case (Failure(e), p)    => p.failure(e)
     })(Keep.left)
     .run
 

--- a/client/src/main/scala/com.crobox.clickhouse/internal/ClickhouseResponseParser.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/ClickhouseResponseParser.scala
@@ -24,7 +24,7 @@ private[clickhouse] trait ClickhouseResponseParser {
           entityToString(entity, encoding).flatMap(
             response =>
               Future.failed(
-                new ClickhouseException(s"Server [$host] returned code $code; $response", query, statusCode = code)
+                ClickhouseException(s"Server [$host] returned code $code; $response", query, statusCode = code)
             )
           )
       }

--- a/client/src/main/scala/com.crobox.clickhouse/internal/InternalExecutorActor.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/InternalExecutorActor.scala
@@ -1,7 +1,8 @@
 package com.crobox.clickhouse.internal
 
 import akka.actor.{Actor, ActorSystem, Props}
-import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.Uri.Query
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest, Uri}
 import akka.pattern.pipe
 import com.crobox.clickhouse.internal.InternalExecutorActor.Execute
 import com.typesafe.config.Config
@@ -17,10 +18,16 @@ class InternalExecutorActor(override protected val config: Config)
   override implicit val system: ActorSystem = context.system
 
   override def receive = {
-    case Execute(uri: Uri, query: String) =>
+    case Execute(uri: Uri, Some(query)) =>
       val eventualResponse = executeRequest(Future.successful(uri), query)
-      eventualResponse.map(response => response.split("\n").toSeq) pipeTo sender
+      splitResponse(eventualResponse) pipeTo sender
+    case Execute(uri: Uri, None) =>
+      val request = HttpRequest(method = HttpMethods.GET, uri = uri)
+      splitResponse(handleResponse(singleRequest(request), "health check", uri)) pipeTo sender
   }
+
+  private def splitResponse(eventualResponse: Future[String]) =
+    eventualResponse.map(response => response.split("\n").toSeq)
 
   override protected lazy val bufferSize = 100
   override protected implicit val executionContext: ExecutionContext =
@@ -31,5 +38,5 @@ object InternalExecutorActor {
 
   def props(config: Config) = Props(new InternalExecutorActor(config))
 
-  case class Execute(host: Uri, query: String)
+  case class Execute(host: Uri, query: Option[String])
 }

--- a/client/src/main/scala/com.crobox.clickhouse/internal/InternalExecutorActor.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/InternalExecutorActor.scala
@@ -4,7 +4,7 @@ import akka.actor.{Actor, ActorSystem, Props}
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model.{HttpMethods, HttpRequest, Uri}
 import akka.pattern.pipe
-import com.crobox.clickhouse.internal.InternalExecutorActor.Execute
+import com.crobox.clickhouse.internal.InternalExecutorActor.{Execute, HealthCheck}
 import com.typesafe.config.Config
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -18,10 +18,10 @@ class InternalExecutorActor(override protected val config: Config)
   override implicit val system: ActorSystem = context.system
 
   override def receive = {
-    case Execute(uri: Uri, Some(query)) =>
+    case Execute(uri: Uri, query) =>
       val eventualResponse = executeRequest(Future.successful(uri), query)
       splitResponse(eventualResponse) pipeTo sender
-    case Execute(uri: Uri, None) =>
+    case HealthCheck(uri: Uri) =>
       val request = HttpRequest(method = HttpMethods.GET, uri = uri)
       splitResponse(handleResponse(singleRequest(request), "health check", uri)) pipeTo sender
   }
@@ -38,5 +38,6 @@ object InternalExecutorActor {
 
   def props(config: Config) = Props(new InternalExecutorActor(config))
 
-  case class Execute(host: Uri, query: Option[String])
+  case class Execute(host: Uri, query: String)
+  case class HealthCheck(host: Uri)
 }

--- a/client/src/test/scala/com/crobox/clickhouse/balancing/ConnectionManagerActorTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/balancing/ConnectionManagerActorTest.scala
@@ -20,7 +20,7 @@ class ConnectionManagerActorTest extends ClickhouseClientAsyncSpec {
     val urisWithDead = uris.+(
       (ClickhouseHostBuilder
          .toHost("deadConnection", None),
-       HostAliveMock.props(Seq(Dead)) _)
+       HostAliveMock.props(Seq(Dead(new IllegalArgumentException))) _)
     )
     val manager =
       system.actorOf(ConnectionManagerActor.props(uri => urisWithDead(uri)(uri), config))
@@ -33,7 +33,7 @@ class ConnectionManagerActorTest extends ClickhouseClientAsyncSpec {
     val urisWithDead = uris.+(
       (ClickhouseHostBuilder
          .toHost("deadConnection", None),
-       HostAliveMock.props(Seq(Dead, Alive, Alive, Alive, Alive)) _)
+       HostAliveMock.props(Seq(Dead(new IllegalArgumentException), Alive, Alive, Alive, Alive)) _)
     )
     val manager =
       system.actorOf(ConnectionManagerActor.props(uri => urisWithDead(uri)(uri), config))

--- a/client/src/test/scala/com/crobox/clickhouse/balancing/discovery/cluster/ClusterConnectionProviderActorTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/balancing/discovery/cluster/ClusterConnectionProviderActorTest.scala
@@ -17,7 +17,7 @@ class ClusterConnectionProviderActorTest extends ClickhouseClientSpec {
     val cluster = "test_cluster"
     provider ! ScanHosts(ConnectionConfig(ClickhouseHostBuilder.toHost("localhost", Some(8123)), cluster))
     internalExecutor.expectMsgPF() {
-      case Execute(_, Some(query)) if query.contains(cluster) =>
+      case Execute(_, query) if query.contains(cluster) =>
         internalExecutor.reply(hosts.toSeq)
     }
     expectMsg(

--- a/client/src/test/scala/com/crobox/clickhouse/balancing/discovery/cluster/ClusterConnectionProviderActorTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/balancing/discovery/cluster/ClusterConnectionProviderActorTest.scala
@@ -2,9 +2,9 @@ package com.crobox.clickhouse.balancing.discovery.cluster
 
 import akka.testkit.TestProbe
 import com.crobox.clickhouse.ClickhouseClientSpec
+import com.crobox.clickhouse.balancing.discovery.ConnectionConfig
 import com.crobox.clickhouse.balancing.discovery.ConnectionManagerActor.Connections
 import com.crobox.clickhouse.balancing.discovery.cluster.ClusterConnectionProviderActor.ScanHosts
-import com.crobox.clickhouse.discovery.ConnectionConfig
 import com.crobox.clickhouse.internal.ClickhouseHostBuilder
 import com.crobox.clickhouse.internal.InternalExecutorActor.Execute
 

--- a/client/src/test/scala/com/crobox/clickhouse/balancing/discovery/cluster/ClusterConnectionProviderActorTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/balancing/discovery/cluster/ClusterConnectionProviderActorTest.scala
@@ -17,7 +17,7 @@ class ClusterConnectionProviderActorTest extends ClickhouseClientSpec {
     val cluster = "test_cluster"
     provider ! ScanHosts(ConnectionConfig(ClickhouseHostBuilder.toHost("localhost", Some(8123)), cluster))
     internalExecutor.expectMsgPF() {
-      case Execute(_, query) if query.contains(cluster) =>
+      case Execute(_, Some(query)) if query.contains(cluster) =>
         internalExecutor.reply(hosts.toSeq)
     }
     expectMsg(

--- a/client/src/test/scala/com/crobox/clickhouse/balancing/discovery/health/HostHealthCheckerTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/balancing/discovery/health/HostHealthCheckerTest.scala
@@ -20,7 +20,7 @@ class HostHealthCheckerTest extends ClickhouseClientSpec with ImplicitSender {
 
   it should "return health" in {
     checker ! IsAlive()
-    expectMsg(HostStatus(host, Alive))
+    expectMsg(5 seconds, HostStatus(host, Alive))
   }
 
 }

--- a/client/src/test/scala/com/crobox/clickhouse/balancing/discovery/health/HostHealthCheckerTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/balancing/discovery/health/HostHealthCheckerTest.scala
@@ -15,7 +15,7 @@ class HostHealthCheckerTest extends ClickhouseClientSpec with ImplicitSender {
     .toHost("localhost", Some(8123))
 
   val checker = system.actorOf(
-    HostHealthChecker.props(host, system.actorOf(InternalExecutorActor.props(config)), 2 seconds)
+    HostHealthChecker.props(host, system.actorOf(InternalExecutorActor.props(config)), 5 seconds)
   )
 
   it should "return health" in {

--- a/client/src/test/scala/com/crobox/clickhouse/balancing/discovery/health/HostHealthCheckerTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/balancing/discovery/health/HostHealthCheckerTest.scala
@@ -1,0 +1,26 @@
+package com.crobox.clickhouse.balancing.discovery.health
+
+import akka.http.scaladsl.model.Uri
+import akka.testkit.ImplicitSender
+import com.crobox.clickhouse.ClickhouseClientSpec
+import com.crobox.clickhouse.balancing.discovery.health.HostHealthChecker.Status.Alive
+import com.crobox.clickhouse.balancing.discovery.health.HostHealthChecker.{HostStatus, IsAlive}
+import com.crobox.clickhouse.internal.{ClickhouseHostBuilder, InternalExecutorActor}
+
+import scala.concurrent.duration._
+
+class HostHealthCheckerTest extends ClickhouseClientSpec with ImplicitSender {
+
+  private val host: Uri = ClickhouseHostBuilder
+    .toHost("localhost", Some(8123))
+
+  val checker = system.actorOf(
+    HostHealthChecker.props(host, system.actorOf(InternalExecutorActor.props(config)), 2 seconds)
+  )
+
+  it should "return health" in {
+    checker ! IsAlive()
+    expectMsg(HostStatus(host, Alive))
+  }
+
+}


### PR DESCRIPTION
Using non query health checks to verify the status of the server as to not pollute the query log with `SELECT 1` queries.

Also improved logging for health failures.

