### PR TITLE
Ensuring that we run just one health check at a time per host

### DIFF
--- a/client/src/main/scala/com.crobox.clickhouse/balancing/discovery/health/HostHealthChecker.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/balancing/discovery/health/HostHealthChecker.scala
@@ -1,5 +1,7 @@
 package com.crobox.clickhouse.balancing.discovery.health
 
+import java.util.concurrent.atomic.AtomicReference
+
 import akka.actor.{Actor, ActorRef, Props}
 import akka.http.scaladsl.model.Uri
 import akka.pattern.{ask, pipe}
@@ -7,33 +9,44 @@ import akka.util.Timeout
 import akka.util.Timeout.durationToTimeout
 import com.crobox.clickhouse.balancing.discovery.health.HostHealthChecker.Status.{Alive, Dead}
 import com.crobox.clickhouse.balancing.discovery.health.HostHealthChecker.{HostStatus, IsAlive}
-import com.crobox.clickhouse.internal.InternalExecutorActor.{Execute, HealthCheck}
-import com.typesafe.scalalogging.LazyLogging
+import com.crobox.clickhouse.internal.InternalExecutorActor.HealthCheck
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class HostHealthChecker(host: Uri, executor: ActorRef)(implicit val timeout: Timeout) extends Actor with LazyLogging {
+class HostHealthChecker(host: Uri, executor: ActorRef)(implicit val timeout: Timeout) extends Actor {
 
   import context.dispatcher
 
+  private val currentCheck = new AtomicReference[Future[HostStatus]](doHostCheck)
+
   override def receive = {
     case IsAlive() =>
-      (executor ? HealthCheck(host))
-        .mapTo[Seq[String]]
-        .map(result => {
-          if (result.equals(Seq("Ok."))) {
-            logger.trace(s"Host is alive for host ${host.toString()}")
-            HostStatus(host, Alive)
-          } else {
-            logger.warn(s"Host ${host.toString()} status is DEAD because of response $result")
-            HostStatus(host, Dead(new IllegalArgumentException(s"Got wrong result $result")))
-          }
-        })
-        .recover {
-          case ex: Throwable =>
-            HostStatus(host, Dead(ex))
-        } pipeTo sender
+      currentCheck.updateAndGet((current: Future[HostStatus]) => {
+        if (current.isCompleted) {
+          doHostCheck
+        } else {
+          current
+        }
+      }) pipeTo sender
+
   }
+
+  private def doHostCheck() =
+    (executor ? HealthCheck(host))
+      .mapTo[Seq[String]]
+      .map(result => {
+        if (result.equals(Seq("Ok."))) {
+          HostStatus(host, Alive)
+        } else {
+          HostStatus(host, Dead(new IllegalArgumentException(s"Got wrong result $result")))
+        }
+      })
+      .recover {
+        case ex: Throwable =>
+          HostStatus(host, Dead(ex))
+      }
+
 }
 
 object HostHealthChecker {

--- a/client/src/main/scala/com.crobox.clickhouse/internal/InternalExecutorActor.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/InternalExecutorActor.scala
@@ -1,7 +1,6 @@
 package com.crobox.clickhouse.internal
 
 import akka.actor.{Actor, ActorSystem, Props}
-import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model.{HttpMethods, HttpRequest, Uri}
 import akka.pattern.pipe
 import com.crobox.clickhouse.internal.InternalExecutorActor.{Execute, HealthCheck}

--- a/client/src/test/scala/com/crobox/clickhouse/balancing/discovery/health/HostHealthCheckerITTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/balancing/discovery/health/HostHealthCheckerITTest.scala
@@ -1,0 +1,25 @@
+package com.crobox.clickhouse.balancing.discovery.health
+
+import akka.http.scaladsl.model.Uri
+import akka.testkit.ImplicitSender
+import com.crobox.clickhouse.ClickhouseClientSpec
+import com.crobox.clickhouse.balancing.discovery.health.HostHealthChecker.Status.Alive
+import com.crobox.clickhouse.balancing.discovery.health.HostHealthChecker.{HostStatus, IsAlive}
+import com.crobox.clickhouse.internal.{ClickhouseHostBuilder, InternalExecutorActor}
+
+import scala.concurrent.duration._
+
+class HostHealthCheckerITTest extends ClickhouseClientSpec with ImplicitSender {
+
+  private val host: Uri = ClickhouseHostBuilder
+    .toHost("localhost", Some(8123))
+
+  val checker = system.actorOf(
+    HostHealthChecker.props(host, system.actorOf(InternalExecutorActor.props(config)), 5 seconds)
+  )
+
+  it should "return health" in {
+    checker ! IsAlive()
+    expectMsg(5 seconds, HostStatus(host, Alive))
+  }
+}

--- a/client/src/test/scala/com/crobox/clickhouse/balancing/discovery/health/HostHealthCheckerTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/balancing/discovery/health/HostHealthCheckerTest.scala
@@ -1,26 +1,58 @@
 package com.crobox.clickhouse.balancing.discovery.health
 
 import akka.http.scaladsl.model.Uri
-import akka.testkit.ImplicitSender
+import akka.testkit.{ImplicitSender, TestProbe}
 import com.crobox.clickhouse.ClickhouseClientSpec
-import com.crobox.clickhouse.balancing.discovery.health.HostHealthChecker.Status.Alive
+import com.crobox.clickhouse.balancing.discovery.health.HostHealthChecker.Status.{Alive, Dead}
 import com.crobox.clickhouse.balancing.discovery.health.HostHealthChecker.{HostStatus, IsAlive}
-import com.crobox.clickhouse.internal.{ClickhouseHostBuilder, InternalExecutorActor}
+import com.crobox.clickhouse.internal.ClickhouseHostBuilder
+import com.crobox.clickhouse.internal.InternalExecutorActor.HealthCheck
 
 import scala.concurrent.duration._
 
 class HostHealthCheckerTest extends ClickhouseClientSpec with ImplicitSender {
-
   private val host: Uri = ClickhouseHostBuilder
-    .toHost("localhost", Some(8123))
+    .toHost("host", None)
+  val executorProbe = TestProbe()
 
   val checker = system.actorOf(
-    HostHealthChecker.props(host, system.actorOf(InternalExecutorActor.props(config)), 5 seconds)
+    HostHealthChecker.props(host, executorProbe.ref, 5 seconds)
   )
-
-  it should "return health" in {
+  it should "cache a health check" in {
     checker ! IsAlive()
-    expectMsg(5 seconds, HostStatus(host, Alive))
+    checker ! IsAlive()
+    checker ! IsAlive()
+    executorProbe.expectMsgPF() {
+      case msg @ HealthCheck(`host`) =>
+        executorProbe.reply(Seq("Ok."))
+        msg
+    }
+    expectMsgAllOf(2 seconds, HostStatus(host, Alive), HostStatus(host, Alive), HostStatus(host, Alive))
+    executorProbe.expectNoMessage()
+  }
+
+  it should "run new health check when completed" in {
+    checker ! IsAlive()
+    executorProbe.expectMsgPF() {
+      case msg @ HealthCheck(`host`) =>
+        executorProbe.reply(Seq("Ok."))
+        msg
+    }
+    expectMsg(HostStatus(host, Alive))
+    checker ! IsAlive()
+    checker ! IsAlive()
+    executorProbe.expectMsgPF() {
+      case msg @ HealthCheck(`host`) =>
+        executorProbe.reply(Seq("nok."))
+        msg
+    }
+    expectMsgPF(1 second) {
+      case HostStatus(`host`, _: Dead) =>
+    }
+    expectMsgPF(1 second) {
+      case HostStatus(`host`, _: Dead) =>
+    }
+    executorProbe.expectNoMessage()
   }
 
 }


### PR DESCRIPTION
When healthchecks are timing out there were cases where the internal queues were filling with health queries.
We are now only doing at most one health check at the same time per host.