### PR TITLE
Deterministic intervals for TimeSeries

### DIFF
--- a/client/src/main/scala/com.crobox.clickhouse/time/MultiInterval.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/time/MultiInterval.scala
@@ -80,25 +80,9 @@ object MultiInterval {
 
         ref.withMillis((detWeeks * Week.standardMillis) + (Day.standardMillis * 4) - tzOffset)
       case MultiDuration(value, Month) =>
-        val ref = start.withTimeAtStartOfDay.withDayOfMonth(1)
-
-        val months = (ref.getYear * 12) + ref.getMonthOfYear
-        val detRelMonths = (months - 1) - (months % value)
-
-        val detMonthOfYearZeroBased = detRelMonths % 12
-        val detYear = (detRelMonths - detMonthOfYearZeroBased) / 12
-
-        ref.withYear(detYear).withMonthOfYear(detMonthOfYearZeroBased + 1)
+        toStartOfMonth(start, value)
       case MultiDuration(value, Quarter) =>
-        val ref = start.withTimeAtStartOfDay.withDayOfMonth(1)
-
-        val months = (ref.getYear * 12) + ref.getMonthOfYear
-        val detRelMonths = (months - 1) - (months % (value*3))
-
-        val detMonthOfYearZeroBased = detRelMonths % 12
-        val detYear = (detRelMonths - detMonthOfYearZeroBased) / 12
-
-        ref.withYear(detYear).withMonthOfYear(detMonthOfYearZeroBased + 1)
+        toStartOfMonth(start, value * 3)
       case MultiDuration(value, Year) =>
         val ref = start.withTimeAtStartOfDay
           .withDayOfYear(1)
@@ -110,6 +94,18 @@ object MultiInterval {
         start
       case d => throw new IllegalArgumentException(s"Invalid duration: $d")
     }
+
+  private def toStartOfMonth(start: IntervalStart, value: Int) = {
+    val ref = start.withTimeAtStartOfDay.withDayOfMonth(1)
+
+    val months = (ref.getYear * 12) + ref.getMonthOfYear
+    val detRelMonths = (months - 1) - (months % (value))
+
+    val detMonthOfYearZeroBased = detRelMonths % 12
+    val detYear = (detRelMonths - detMonthOfYearZeroBased) / 12
+
+    ref.withYear(detYear).withMonthOfYear(detMonthOfYearZeroBased + 1)
+  }
 
   private def calculateQuarterStart(month: Int) =
     if (month <= 3) 1

--- a/client/src/main/scala/com.crobox.clickhouse/time/MultiInterval.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/time/MultiInterval.scala
@@ -72,6 +72,7 @@ object MultiInterval {
         val ref = start.withTimeAtStartOfDay.withDayOfWeek(DateTimeConstants.MONDAY)
         val tzOffset = ref.getZone.getOffset(ref.withZone(DateTimeZone.UTC))
 
+        //Week 1 (since epoch) starts at the 5th of January 1970, hence we subtract the 4 days of week 0
         val msWeek1 = ref.getMillis - (Day.standardMillis * 4) + tzOffset
 
         val weeks = msWeek1 / Week.standardMillis

--- a/client/src/test/scala/com/crobox/clickhouse/balancing/discovery/health/HostHealthCheckerTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/balancing/discovery/health/HostHealthCheckerTest.scala
@@ -29,7 +29,7 @@ class HostHealthCheckerTest extends ClickhouseClientSpec with ImplicitSender {
         msg
     }
     expectMsgAllOf(duration, HostStatus(host, Alive), HostStatus(host, Alive), HostStatus(host, Alive))
-    executorProbe.expectNoMessage()
+    executorProbe.expectNoMessage(1.seconds)
   }
 
   it should "run new health check when completed" in {
@@ -53,7 +53,7 @@ class HostHealthCheckerTest extends ClickhouseClientSpec with ImplicitSender {
     expectMsgPF(duration) {
       case HostStatus(`host`, _: Dead) =>
     }
-    executorProbe.expectNoMessage()
+    executorProbe.expectNoMessage(1.seconds)
   }
 
 }

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/AggregationFunctions.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/AggregationFunctions.scala
@@ -82,10 +82,22 @@ object AggregateFunction {
     def max[V](tableColumn: TableColumn[V]) =
       Max(tableColumn)
 
+    /**
+      * This function will push back the timestamp represented by tableColumn to the start of this interval,
+      * this happens deterministically.
+      *
+      * Meaning that as long as the duration is the same, your groups will be in the same from/to timestamps
+      *
+      * This is useful for aggregating results by periods of time (group by month, 2 months, days, etc.)
+      *
+      * @param tableColumn
+      * @param interval
+      * @return
+      */
     def timeSeries(tableColumn: TableColumn[Long],
-                   interval: MultiInterval,
-                   dateColumn: Option[TableColumn[DateTime]] = None) =
-      TimeSeries(tableColumn, interval, dateColumn)
+      interval: MultiInterval,
+      dateColumn: Option[TableColumn[DateTime]] = None) =
+      TimeSeries(tableColumn, interval)
 
     def groupUniqArray[V](tableColumn: TableColumn[V]) =
       GroupUniqArray(tableColumn)
@@ -262,7 +274,5 @@ case class Min[V](tableColumn: TableColumn[V]) extends AggregateFunction[V](tabl
 
 case class Max[V](tableColumn: TableColumn[V]) extends AggregateFunction[V](tableColumn)
 
-case class TimeSeries(tableColumn: TableColumn[Long],
-                      interval: MultiInterval,
-                      dateColumn: Option[TableColumn[DateTime]])
-    extends AggregateFunction[Long](tableColumn)
+case class TimeSeries(tableColumn: TableColumn[Long], interval: MultiInterval)
+  extends AggregateFunction[Long](tableColumn)

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/AggregationFunctions.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/AggregationFunctions.scala
@@ -94,9 +94,7 @@ object AggregateFunction {
       * @param interval
       * @return
       */
-    def timeSeries(tableColumn: TableColumn[Long],
-      interval: MultiInterval,
-      dateColumn: Option[TableColumn[DateTime]] = None) =
+    def timeSeries(tableColumn: TableColumn[Long], interval: MultiInterval) =
       TimeSeries(tableColumn, interval)
 
     def groupUniqArray[V](tableColumn: TableColumn[V]) =

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -243,9 +243,9 @@ trait ClickhouseTokenizerModule extends TokenizerModule {
     val dateZone = determineZoneId(interval.rawStart)
 
     def toNthMonth(nth: Int) = {
-      val startOfMonth = fast"toStartOfMonth(toDateTime($column / 1000) , '$dateZone')"
+      val startOfMonth = fast"toStartOfMonth(toDateTime($column / 1000), '$dateZone')"
       if (nth == 1) {
-        fast"toDateTime($startOfMonth,'$dateZone')"
+        fast"toDateTime($startOfMonth, '$dateZone')"
       } else {
         fast"toDateTime(addMonths($startOfMonth, 0 - (toRelativeMonthNum(toDateTime($column / 1000), '$dateZone') % $nth)), '$dateZone')"
       }

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -10,8 +10,8 @@ import com.crobox.clickhouse.dsl.TableColumn.AnyTableColumn
 import com.crobox.clickhouse.dsl.Uniq.UniqModifier
 import com.crobox.clickhouse.dsl._
 import com.crobox.clickhouse.dsl.language.TokenizerModule.Database
-import com.crobox.clickhouse.time.TimeUnit.{Quarter, Total, Year}
-import com.crobox.clickhouse.time.{MultiDuration, SimpleDuration, TimeUnit}
+import com.crobox.clickhouse.time.TimeUnit.{apply => _, _}
+import com.crobox.clickhouse.time.{MultiDuration, SimpleDuration}
 import com.dongxiguo.fastring.Fastring.Implicits._
 import com.google.common.base.Strings
 import com.typesafe.scalalogging.Logger
@@ -239,24 +239,46 @@ trait ClickhouseTokenizerModule extends TokenizerModule {
   }
 
   private def tokenizeDuration(timeSeries: TimeSeries, column: String) = {
+    
+    def toNthMonth(nth: Int, dateZone: String) =
+      fast"addMonths(toStartOfMonth(toDateTime($column / 1000), '$dateZone'), 0 - (toRelativeMonthNum(toDateTime($column / 1000), '$dateZone') % $nth))"
+    
     val interval = timeSeries.interval
+    
+    val dateZone = determineZoneId(interval.rawStart)
+    
     interval.duration match {
-      case MultiDuration(value, TimeUnit.Month) =>
-        val dateZone = determineZoneId(interval.rawStart)
-        fast"concat(toString(intDiv(toRelativeMonthNum(toDateTime($column / 1000),'$dateZone'), $value) * $value),'_$dateZone')"
-      case MultiDuration(_, Quarter) =>
-        val dateZone = determineZoneId(interval.rawStart)
-        fast"concat(toString(toStartOfQuarter(toDateTime($column / 1000),'$dateZone')),'_$dateZone')"
-      case MultiDuration(_, Year) =>
-        val dateZone = determineZoneId(interval.rawStart)
-        fast"concat(toString(toStartOfYear(toDateTime($column / 1000),'$dateZone')),'_$dateZone')"
+      case MultiDuration(1, Year) =>
+        fast"toStartOfYear(toDateTime($column / 1000), '$dateZone')"
+      case MultiDuration(1, Month) =>
+        fast"toStartOfMonth(toDateTime($column / 1000), '$dateZone')"
+      case MultiDuration(1, Week) =>
+        fast"toMonday(toDateTime($column / 1000), '$dateZone'))"
+      case MultiDuration(1, Day) =>
+        fast"toStartOfDay(toDateTime($column / 1000), '$dateZone'))"
+      case MultiDuration(1, Hour) =>
+        fast"toStartOfHour(toDateTime($column / 1000), '$dateZone'))"
+      case MultiDuration(1, Minute) =>
+        fast"toStartOfMinute(toDateTime($column / 1000), '$dateZone'))"
+      case MultiDuration(1, Second) =>
+        fast"toDateTime($column / 1000, '$dateZone')"
+      case MultiDuration(nth, Year) =>
+        fast"addYears(toStartOfYear(toDateTime($column / 1000), '$dateZone'), 0 - (toYear(toDateTime($column / 1000), '$dateZone') % $nth))"
+      case MultiDuration(nth, Quarter) =>
+        toNthMonth(nth * 3,dateZone)
+      case MultiDuration(nth, Month) =>
+        toNthMonth(nth,dateZone)
+      case MultiDuration(nth, Week) =>
+        fast"addWeeks(toMonday(toDateTime($column / 1000), '$dateZone'), 0 - (toRelativeWeekNum(toDateTime($column / 1000), '$dateZone') % $nth))"
+      case MultiDuration(nth, Day) =>
+        fast"addDays(toStartOfDay(toDateTime($column / 1000), '$dateZone'), 0 - (toRelativeDayNum(toDateTime($column / 1000), '$dateZone') % $nth))"
+      case MultiDuration(nth, Hour) =>
+        fast"addHours(toStartOfHour(toDateTime($column / 1000), '$dateZone'), 0 - (toRelativeHourNum(toDateTime($column / 1000), '$dateZone') % $nth))"
+      case MultiDuration(nth, Minute) =>
+        fast"addMinutes(toStartOfMinute(toDateTime($column / 1000), '$dateZone'), 0 - (toRelativeMinuteNum(toDateTime($column / 1000), '$dateZone') % $nth))"
+      case MultiDuration(nth, Second) =>
+        fast"addSeconds(toDateTime($column / 1000, '$dateZone'), 0 - (toRelativeSecondNum(toDateTime($column / 1000), '$dateZone') % $nth))"
       case SimpleDuration(Total) => fast"${interval.getStartMillis}"
-      //        handles seconds/minutes/hours/days/weeks
-      case multiDuration: MultiDuration =>
-        //        for fixed duration we calculate the milliseconds for the start of a sub interval relative to our predefined interval start. The first subinterval start would be `interval.startOfInterval()`
-        //        if using weeks this would give the milliseconds of the start of the first day of the week, for days it would be the start of the day and so on.
-        val intervalStartMillis = interval.startOfInterval().getMillis
-        fast"((intDiv($column - $intervalStartMillis, ${multiDuration.millis()}) * ${multiDuration.millis()}) + $intervalStartMillis)"
     }
   }
 

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -243,45 +243,43 @@ trait ClickhouseTokenizerModule extends TokenizerModule {
     val dateZone = determineZoneId(interval.rawStart)
 
     def toNthMonth(nth: Int) = {
-      val startOfMonth = fast"toStartOfMonth(toDateTime($column / 1000), '$dateZone')"
+      val startOfMonth = fast"toStartOfMonth(toDateTime($column / 1000) , '$dateZone')"
       if (nth == 1) {
-        startOfMonth
+        fast"toDateTime($startOfMonth,'$dateZone')"
       } else {
-        fast"addMonths($startOfMonth, 0 - (toRelativeMonthNum(toDateTime($column / 1000), '$dateZone') % $nth))"
+        fast"toDateTime(addMonths($startOfMonth, 0 - (toRelativeMonthNum(toDateTime($column / 1000), '$dateZone') % $nth)), '$dateZone')"
       }
     }
     
     interval.duration match {
       case MultiDuration(1, Year) =>
-        fast"toStartOfYear(toDateTime($column / 1000), '$dateZone')"
-      case MultiDuration(1, Month) =>
-        fast"toStartOfMonth(toDateTime($column / 1000), '$dateZone')"
+        fast"toDateTime(toStartOfYear(toDateTime($column / 1000), '$dateZone'), '$dateZone')"
       case MultiDuration(1, Week) =>
-        fast"toMonday(toDateTime($column / 1000), '$dateZone'))"
+        fast"toDateTime(toMonday(toDateTime($column / 1000), '$dateZone'), '$dateZone')"
       case MultiDuration(1, Day) =>
-        fast"toStartOfDay(toDateTime($column / 1000), '$dateZone'))"
+        fast"toStartOfDay(toDateTime($column / 1000), '$dateZone')"
       case MultiDuration(1, Hour) =>
-        fast"toStartOfHour(toDateTime($column / 1000), '$dateZone'))"
+        fast"toStartOfHour(toDateTime($column / 1000), '$dateZone')"
       case MultiDuration(1, Minute) =>
-        fast"toStartOfMinute(toDateTime($column / 1000), '$dateZone'))"
+        fast"toStartOfMinute(toDateTime($column / 1000), '$dateZone')"
       case MultiDuration(1, Second) =>
         fast"toDateTime($column / 1000, '$dateZone')"
       case MultiDuration(nth, Year) =>
-        fast"addYears(toStartOfYear(toDateTime($column / 1000), '$dateZone'), 0 - (toYear(toDateTime($column / 1000), '$dateZone') % $nth))"
+        fast"toDateTime(addYears(toStartOfYear(toDateTime($column / 1000), '$dateZone'), 0 - (toYear(toDateTime($column / 1000), '$dateZone') % $nth)), '$dateZone')"
       case MultiDuration(nth, Quarter) =>
-        toNthMonth(1 + ((nth - 1) * 3))
+        toNthMonth(nth * 3)
       case MultiDuration(nth, Month) =>
         toNthMonth(nth)
       case MultiDuration(nth, Week) =>
-        fast"addWeeks(toMonday(toDateTime($column / 1000), '$dateZone'), 0 - (toRelativeWeekNum(toDateTime($column / 1000), '$dateZone') % $nth))"
+        fast"toDateTime(addWeeks(toMonday(toDateTime($column / 1000), '$dateZone'), 0 - ((toRelativeWeekNum(toDateTime($column / 1000), '$dateZone') - 1) % $nth)), '$dateZone')"
       case MultiDuration(nth, Day) =>
-        fast"addDays(toStartOfDay(toDateTime($column / 1000), '$dateZone'), 0 - (toRelativeDayNum(toDateTime($column / 1000), '$dateZone') % $nth))"
+        fast"addDays(toStartOfDay(toDateTime($column / 1000), '$dateZone'), 0 - (toRelativeDayNum(toDateTime($column / 1000), '$dateZone') % $nth), '$dateZone')"
       case MultiDuration(nth, Hour) =>
-        fast"addHours(toStartOfHour(toDateTime($column / 1000), '$dateZone'), 0 - (toRelativeHourNum(toDateTime($column / 1000), '$dateZone') % $nth))"
+        fast"addHours(toStartOfHour(toDateTime($column / 1000), '$dateZone'), 0 - (toRelativeHourNum(toDateTime($column / 1000), '$dateZone') % $nth), '$dateZone')"
       case MultiDuration(nth, Minute) =>
-        fast"addMinutes(toStartOfMinute(toDateTime($column / 1000), '$dateZone'), 0 - (toRelativeMinuteNum(toDateTime($column / 1000), '$dateZone') % $nth))"
+        fast"addMinutes(toStartOfMinute(toDateTime($column / 1000), '$dateZone'), 0 - (toRelativeMinuteNum(toDateTime($column / 1000), '$dateZone') % $nth), '$dateZone')"
       case MultiDuration(nth, Second) =>
-        fast"addSeconds(toDateTime($column / 1000, '$dateZone'), 0 - (toRelativeSecondNum(toDateTime($column / 1000), '$dateZone') % $nth))"
+        fast"addSeconds(toDateTime($column / 1000, '$dateZone'), 0 - (toRelativeSecondNum(toDateTime($column / 1000), '$dateZone') % $nth), '$dateZone')"
       case SimpleDuration(Total) => fast"${interval.getStartMillis}"
     }
   }

--- a/dsl/src/main/scala/com.crobox.clickhouse/dsl/marshalling/ClickhouseJsonSupport.scala
+++ b/dsl/src/main/scala/com.crobox.clickhouse/dsl/marshalling/ClickhouseJsonSupport.scala
@@ -16,7 +16,8 @@ trait ClickhouseJsonSupport {
 
     val month                        = """(\d+)_(.*)""".r
     val date                         = """(.+)_(.*)""".r
-    val timestamp                    = """^(\d{13})$""".r
+    val msTimestamp                  = """^(\d{13})$""".r
+    val timestamp                    = """^(\d{10})$""".r
     val RelativeMonthsSinceUnixStart = 23641
 
     val UnixStartTimeWithoutTimeZone            = "1970-01-01T00:00:00.000"
@@ -48,7 +49,8 @@ trait ClickhouseJsonSupport {
                 .parseDateTime(dateOnly)
                 .withZoneRetainFields(DateTimeZone.forID(timezoneId))
                 .withZone(DateTimeZone.UTC)
-            case timestamp(millis) => new DateTime(millis.toLong, DateTimeZone.UTC)
+            case msTimestamp(millis) => new DateTime(millis.toLong, DateTimeZone.UTC)
+            case timestamp(secs) => new DateTime(secs.toLong * 1000, DateTimeZone.UTC)
             case _ =>
               try {
                 formatter.parseDateTime(value)

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerTest.scala
@@ -193,13 +193,9 @@ class ClickhouseTokenizerTest extends ClickhouseClientSpec with TestSchema with 
 
   "build time series" should "use zone name for monthly" in {
     this.tokenizeTimeSeries(
-      TimeSeries(
-        timestampColumn,
-        MultiInterval(DateTime.now(DateTimeZone.forOffsetHours(2)),
-                      DateTime.now(DateTimeZone.forOffsetHours(2)),
-                      MultiDuration(TimeUnit.Month)),
-        None
-      )
-    ) shouldBe """concat(toString(intDiv(toRelativeMonthNum(toDateTime(ts / 1000),'Africa/Maputo'), 1) * 1),'_Africa/Maputo')"""
+      TimeSeries(timestampColumn, MultiInterval(DateTime.now(DateTimeZone.forOffsetHours(2)),
+                            DateTime.now(DateTimeZone.forOffsetHours(2)),
+                            MultiDuration(TimeUnit.Month)))
+    ) shouldBe """toStartOfMonth(toDateTime(ts / 1000), 'Africa/Maputo')"""
   }
 }

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerTest.scala
@@ -196,6 +196,6 @@ class ClickhouseTokenizerTest extends ClickhouseClientSpec with TestSchema with 
       TimeSeries(timestampColumn, MultiInterval(DateTime.now(DateTimeZone.forOffsetHours(2)),
                             DateTime.now(DateTimeZone.forOffsetHours(2)),
                             MultiDuration(TimeUnit.Month)))
-    ) shouldBe """toStartOfMonth(toDateTime(ts / 1000), 'Africa/Maputo')"""
+    ) shouldBe "toDateTime(toStartOfMonth(toDateTime(ts / 1000), 'Africa/Maputo'), 'Africa/Maputo')"
   }
 }


### PR DESCRIPTION
TimeSeries will now shift back the provided timestamp to the start of the provided interval in a deterministic way. 

This allows for both persisting as well as selecting the same intervals within a multi interval under any condition.

The reference point for all intervals is that of the "GetRelativeXXXNum" functions in clickhouse.