### PR TITLE
Sending progress from headers in the progress queue

### DIFF
--- a/client/src/main/resources/reference.conf
+++ b/client/src/main/resources/reference.conf
@@ -33,7 +33,6 @@ crobox.clickhouse {
         user = "default"
         password = ""
       }
-      progress-headers = false
       profile = "default"
       http-compression = ${?crobox.clickhouse.client.http-compression} //backwards compatibility
       http-compression = false

--- a/client/src/main/scala/com.crobox.clickhouse/ClickhouseClient.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/ClickhouseClient.scala
@@ -95,7 +95,7 @@ class ClickhouseClient(override val config: Config, val database: String = "defa
   def sourceByteString(sql: String): Source[ByteString, NotUsed] =
     Source
       .fromFuture(hostBalancer.nextHost.flatMap { host =>
-        singleRequest(toRequest(host, sql, QuerySettings(ReadQueries)))
+        singleRequest(toRequest(host, sql, None, QuerySettings(ReadQueries)))
       })
       .flatMapConcat(response => response.entity.withoutSizeLimit().dataBytes)
 

--- a/client/src/main/scala/com.crobox.clickhouse/ClickhouseException.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/ClickhouseException.scala
@@ -8,3 +8,4 @@ import akka.http.scaladsl.model.StatusCode
  */
 case class ClickhouseException(message: String, query: String, cause: Throwable = null, statusCode: StatusCode)
     extends RuntimeException(message + s", query $query", cause)
+case class ClickhouseChunkedException(message: String) extends RuntimeException(message)

--- a/client/src/main/scala/com.crobox.clickhouse/internal/ClickHouseExecutor.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/ClickHouseExecutor.scala
@@ -2,19 +2,23 @@ package com.crobox.clickhouse.internal
 
 import akka.Done
 import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.settings.{ClientConnectionSettings, ConnectionPoolSettings}
+import akka.http.scaladsl.{ClientTransport, Http}
 import akka.stream._
-import akka.stream.scaladsl.{Keep, Sink, Source, SourceQueueWithComplete}
+import akka.stream.scaladsl.{BidiFlow, BroadcastHub, Flow, Keep, Sink, Source, SourceQueue, SourceQueueWithComplete}
+import akka.stream.stage._
+import akka.util.ByteString
 import com.crobox.clickhouse.balancing.HostBalancer
 import com.crobox.clickhouse.internal.ClickHouseExecutor.QuerySettings.ReadOnlySetting
-import com.crobox.clickhouse.internal.ClickHouseExecutor.{QueryProgress, QueryRetry, QuerySettings}
+import com.crobox.clickhouse.internal.ClickHouseExecutor._
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.concurrent.{Future, Promise}
-import scala.util.{Failure, Success, Try}
+import scala.util.parsing.json.JSON
+import scala.util.{Failure, Random, Success, Try}
 
 private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
   this: ClickhouseResponseParser with ClickhouseQueryBuilder =>
@@ -24,9 +28,58 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
   protected val hostBalancer: HostBalancer
   protected def config: Config
 
-  private lazy val pool = Http().superPool[Promise[HttpResponse]]()
+  lazy val (progressQueue, progressSource) = {
+    val builtSource = Source
+      .queue[String](1000, OverflowStrategy.dropHead)
+      .map(queryAndProgress => {
+        queryAndProgress.split("\n", 2).toList match {
+          case queryId :: progressJson :: Nil =>
+            Try {
+              val parsedJson = JSON.parseFull(progressJson).map(_.asInstanceOf[Map[String, String]])
+              if (parsedJson.isEmpty || parsedJson.get.size != 3) {
+                throw new IllegalAccessException(s"Cannot extract progress from $parsedJson")
+              } else {
+                val jsonMap = parsedJson.get
+                ClickhouseQueryProgress(
+                  queryId,
+                  Progress(jsonMap("read_rows").toLong, jsonMap("read_bytes").toLong, jsonMap("total_rows").toLong)
+                )
+              }
+            } match {
+              case Success(value) => Some(value)
+              case Failure(exception) =>
+                logger.warn(s"Failed to parse json $progressJson", exception)
+                None
+            }
+          case other @ _ =>
+            logger.warn(s"Could not get progress from $other")
+            None
+
+        }
+      })
+      .collect {
+        case Some(progress) => progress
+      }
+      .withAttributes(ActorAttributes.supervisionStrategy({
+        case ex @ _ =>
+          logger.warn("Failed in the progress streaming", ex)
+          Supervision.Resume
+      }))
+      .toMat(BroadcastHub.sink)(Keep.both)
+      .run()
+    builtSource._2.runWith(Sink.ignore) //ensure we have one sink draining the progress
+    builtSource
+  }
+
+  lazy val superPoolSettings: ConnectionPoolSettings = ConnectionPoolSettings(system)
+    .withConnectionSettings(
+      ClientConnectionSettings(system)
+        .withTransport(new ProgressHeadersAsBodyClientTransport(progressQueue))
+    )
+  private lazy val pool = Http().superPool[Promise[HttpResponse]](settings = superPoolSettings)
   protected lazy val bufferSize: Int =
     config.getInt("crobox.clickhouse.client.buffer-size")
+
   private lazy val (queue, completion) = Source
     .queue[(HttpRequest, Promise[HttpResponse])](bufferSize, OverflowStrategy.dropNew)
     .via(pool)
@@ -41,12 +94,15 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
   def executeRequest(query: String,
                      settings: QuerySettings,
                      entity: Option[RequestEntity] = None,
-                     progressQueue: Option[SourceQueueWithComplete[QueryProgress]] = None): Future[String] =
+                     progressQueue: Option[SourceQueueWithComplete[QueryProgress]] = None): Future[String] = {
+    val queryIdentifier = Random.alphanumeric.take(20).mkString("")
+    logger.info(s"Executing request with identifier $queryIdentifier")
     executeWithRetries(queryRetries, progressQueue) { () =>
-      executeRequestInternal(hostBalancer.nextHost, query, settings, entity, progressQueue)
+      executeRequestInternal(hostBalancer.nextHost, query, queryIdentifier, settings, entity, progressQueue)
     }.andThen {
       case _ => progressQueue.foreach(_.complete())
     }
+  }
 
   def executeRequestWithProgress(query: String,
                                  settings: QuerySettings,
@@ -79,11 +135,26 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
 
   protected def executeRequestInternal(host: Future[Uri],
                                        query: String,
+                                       queryIdentifier: String,
                                        settings: QuerySettings,
                                        entity: Option[RequestEntity] = None,
                                        progressQueue: Option[SourceQueueWithComplete[QueryProgress]]): Future[String] =
     host.flatMap(actualHost => {
-      val request = toRequest(actualHost, query, settings.withFallback(config), entity)
+      val request = toRequest(actualHost,
+                              query,
+                              Some(queryIdentifier),
+                              settings.withFallback(config),
+                              entity,
+                              progressQueue.isDefined)
+      progressQueue.foreach(definedProgressQueue => {
+        progressSource.runForeach(
+          progress =>
+            if (progress.identifier == queryIdentifier) {
+              definedProgressQueue.offer(progress.progress)
+          }
+        )
+      })
+
       processClickhouseResponse(singleRequest(request), query, actualHost, progressQueue)
     })
 
@@ -105,12 +176,17 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
 }
 
 object ClickHouseExecutor {
+  val InternalQueryIdentifier = "X-Internal-Identifier"
+
   sealed trait QueryProgress
   case object QueryAccepted                                 extends QueryProgress
   case object QueryFinished                                 extends QueryProgress
   case object QueryRejected                                 extends QueryProgress
   case class QueryFailed(cause: Throwable)                  extends QueryProgress
   case class QueryRetry(cause: Throwable, retryNumber: Int) extends QueryProgress
+
+  case class ClickhouseQueryProgress(identifier: String, progress: Progress)
+  case class Progress(rowsRead: Long, bytesRead: Long, totalRows: Long) extends QueryProgress
 
   case class QuerySettings(readOnly: ReadOnlySetting,
                            authentication: Option[(String, String)] = None,
@@ -140,13 +216,138 @@ object ClickHouseExecutor {
           val authConfig = config.getConfig(path("authentication"))
           (authConfig.getString("user"), authConfig.getString("password"))
         }.toOption),
-        progressHeaders = progressHeaders.orElse(Try { config.getBoolean(path("progress-headers")) }.toOption),
         profile = profile.orElse(Try { config.getString(path("profile")) }.toOption),
         httpCompression = httpCompression.orElse(Try { config.getBoolean(path("http-compression")) }.toOption)
       )
 
     private def path(setting: String) = s"crobox.clickhouse.client.settings.$setting"
 
+  }
+
+  /**
+   * Clickhouse send http progress headers with the name X-ClickHouse-Progress which cannot be handled in a streaming matter in akka
+   * In the request we include our own custom header `X-Internal-Identifier` so we can send the internal query id with the progress
+   * We expect to first find the request with the custom header and then receive the progress headers
+   *  The progress headers are being intercepted by the transport and send to the source as progress events with the internal query id
+   * After the first progress header is received we send the end of headers character so that akka can eagerly return the http response
+   * */
+  class ProgressHeadersAsBodyClientTransport(source: SourceQueue[String]) extends ClientTransport {
+    override def connectTo(
+        host: String,
+        port: Int,
+        settings: ClientConnectionSettings
+    )(implicit system: ActorSystem): Flow[
+      ByteString,
+      ByteString,
+      Future[Http.OutgoingConnection]
+    ] =
+      BidiFlow
+        .fromGraph(new ProgressHeadersAsEventsStage(source))
+        .joinMat(
+          ClientTransport.TCP
+            .connectTo(host, port, settings)
+        )((_, result) => result)
+  }
+
+  class ProgressHeadersAsEventsStage(source: SourceQueue[String])
+      extends GraphStage[BidiShape[ByteString, ByteString, ByteString, ByteString]] {
+
+    val ClickhouseProgressHeader = "X-ClickHouse-Progress"
+
+    val in1                = Inlet[ByteString]("ProgressHeadersAsEvents.in1")
+    val out1               = Outlet[ByteString]("ProgressHeadersAsEvents.out1")
+    val in2                = Inlet[ByteString]("ProgressHeadersAsEvents.in2")
+    val out2               = Outlet[ByteString]("ProgressHeadersAsEvents.out2")
+    val Crlf               = "\r\n"
+    val LookAheadCRLFSplit = "(?<=\\r\\n)"
+
+    override val shape = BidiShape.of(in1, out1, in2, out2)
+    override def createLogic(
+        inheritedAttributes: Attributes
+    ): GraphStageLogic = new GraphStageLogic(shape) with StageLogging {
+      var queryId: Option[String] = None
+      var queryIsInProgress       = false
+      setHandler(
+        in1,
+        new InHandler {
+          override def onPush(): Unit = {
+            val byteString = grab(in1)
+            if (byteString.containsSlice(ByteString(InternalQueryIdentifier))) {
+              val incomingString  = byteString.utf8String
+              val responseStrings = incomingString.split(Crlf)
+              val queryIdHeader   = responseStrings.find(_.contains(InternalQueryIdentifier))
+              if (queryIdHeader.isEmpty) {
+                log.warning(s"Could not extract the query id from the containing $incomingString")
+              }
+              if (queryIsInProgress) {
+                log.warning("The previous query was not terminated correctly")
+              }
+              queryId = queryIdHeader.map(header => header.stripPrefix(InternalQueryIdentifier + ":").trim)
+            }
+            push(out1, byteString)
+          }
+        }
+      )
+      setHandler(
+        in2,
+        new InHandler {
+          override def onPush(): Unit = {
+            val byteString = grab(in2)
+            if (byteString.containsSlice(ByteString(ClickhouseProgressHeader))) {
+              if (queryId.isEmpty) {
+                log.warning("Cannot handle progress with query id")
+              }
+              val incomingString             = byteString.utf8String
+              val responseStrings            = incomingString.split(LookAheadCRLFSplit)
+              val (progressHeaders, theRest) = responseStrings.partition(_.contains(ClickhouseProgressHeader))
+              if (progressHeaders.isEmpty) {
+                log.warning(s"Could not extract the progress from the containing $incomingString")
+              }
+              if (!queryIsInProgress) {
+                queryIsInProgress = true
+                val endOfHeaders = if (theRest.isEmpty) {
+                  ByteString(Crlf)
+                } else ByteString(theRest.mkString("") + Crlf)
+                push(out2, endOfHeaders)
+              } else {
+                push(out2, ByteString(theRest.mkString("")))
+              }
+              progressHeaders
+                .map(_.stripPrefix(ClickhouseProgressHeader + ":"))
+                .map(progressJson => {
+                  queryId.getOrElse("unknown") + "\n" + progressJson
+                })
+                .foreach(progress => {
+                  source.offer(progress)
+                })
+            } else {
+              if (queryIsInProgress) {
+                queryIsInProgress = false
+                if (byteString.equals(ByteString(Crlf))) {//already marked the end of headers, this must be removed
+                  pull(in2)
+                } else {
+                  if (byteString.startsWith(Crlf)) {
+                    push(out2, byteString.drop(2))//already marked the end of headers, this must be removed
+                  } else {
+                    push(out2, byteString)
+                  }
+                }
+              } else {
+                push(out2, byteString)
+              }
+            }
+          }
+        }
+      )
+      setHandler(out1, new OutHandler {
+        override def onPull(): Unit =
+          pull(in1)
+      })
+      setHandler(out2, new OutHandler {
+        override def onPull(): Unit =
+          pull(in2)
+      })
+    }
   }
 
   object QuerySettings {

--- a/client/src/main/scala/com.crobox.clickhouse/internal/ClickHouseExecutor.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/ClickHouseExecutor.scala
@@ -37,7 +37,7 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
             Try {
               val parsedJson = JSON.parseFull(progressJson).map(_.asInstanceOf[Map[String, String]])
               if (parsedJson.isEmpty || parsedJson.get.size != 3) {
-                throw new IllegalAccessException(s"Cannot extract progress from $parsedJson")
+                throw new IllegalArgumentException(s"Cannot extract progress from $parsedJson")
               } else {
                 val jsonMap = parsedJson.get
                 ClickhouseQueryProgress(
@@ -322,11 +322,11 @@ object ClickHouseExecutor {
             } else {
               if (queryIsInProgress) {
                 queryIsInProgress = false
-                if (byteString.equals(ByteString(Crlf))) {//already marked the end of headers, this must be removed
+                if (byteString.equals(ByteString(Crlf))) { //already marked the end of headers, this must be removed
                   pull(in2)
                 } else {
                   if (byteString.startsWith(Crlf)) {
-                    push(out2, byteString.drop(2))//already marked the end of headers, this must be removed
+                    push(out2, byteString.drop(2)) //already marked the end of headers, this must be removed
                   } else {
                     push(out2, byteString)
                   }

--- a/client/src/main/scala/com.crobox.clickhouse/internal/ClickHouseExecutor.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/ClickHouseExecutor.scala
@@ -62,7 +62,7 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
       }
       .withAttributes(ActorAttributes.supervisionStrategy({
         case ex @ _ =>
-          logger.warn("Failed in the progress streaming", ex)
+          logger.warn("Detected failure in the query progress stream, resuming operation.", ex)
           Supervision.Resume
       }))
       .toMat(BroadcastHub.sink)(Keep.both)
@@ -96,7 +96,6 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
                      entity: Option[RequestEntity] = None,
                      progressQueue: Option[SourceQueueWithComplete[QueryProgress]] = None): Future[String] = {
     val queryIdentifier = Random.alphanumeric.take(20).mkString("")
-    logger.info(s"Executing request with identifier $queryIdentifier")
     executeWithRetries(queryRetries, progressQueue) { () =>
       executeRequestInternal(hostBalancer.nextHost, query, queryIdentifier, settings, entity, progressQueue)
     }.andThen {

--- a/client/src/main/scala/com.crobox.clickhouse/internal/InternalExecutorActor.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/InternalExecutorActor.scala
@@ -23,7 +23,12 @@ class InternalExecutorActor(override protected val config: Config)
   override def receive = {
     case Execute(uri: Uri, query) =>
       val eventualResponse =
-        executeRequestInternal(Future.successful(uri), query, QuerySettings(ReadQueries).withFallback(config), None, None)
+        executeRequestInternal(Future.successful(uri),
+                               query,
+                               "internal",
+                               QuerySettings(ReadQueries).withFallback(config),
+                               None,
+                               None)
       splitResponse(eventualResponse) pipeTo sender
     case HealthCheck(uri: Uri) =>
       val request = HttpRequest(method = HttpMethods.GET, uri = uri)

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/execution/ClickhouseQueryExecutorIT.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/execution/ClickhouseQueryExecutorIT.scala
@@ -6,7 +6,6 @@ import com.crobox.clickhouse.internal.ClickHouseExecutor.{QueryAccepted, QueryFi
 import com.crobox.clickhouse.testkit.ClickhouseClientSpec
 import com.crobox.clickhouse.{DslLanguage, TestSchemaClickhouseQuerySpec}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Seconds, Span}
 import spray.json.DefaultJsonProtocol._
 
 class ClickhouseQueryExecutorIT
@@ -15,12 +14,8 @@ class ClickhouseQueryExecutorIT
     with ScalaFutures
     with DslLanguage {
   import scala.concurrent.ExecutionContext.Implicits.global
-  implicit override val patienceConfig =
-    PatienceConfig(timeout = scaled(Span(10, Seconds)), interval = scaled(Span(20, Millis)))
-
   implicit val materializer = ActorMaterializer()
   case class Result(one: Int)
-
   object Result {
     implicit val format = jsonFormat1(Result.apply)
   }


### PR DESCRIPTION
Added custom akka http client transport which receives all the streaming parts of the http request/response cycle.
Use the client transport to identify the queries by a custom internal header, and intercept the clickhouse progress headers and route them to a global progress queue, from where the events are consumed by individual query progress queue.

Currently we modify the http response and send the end of headers mark as soon as we see the first progress header, but it might be worth it to just identify the response status code and publish the query accepted event directly instead. This way we would reduce the complexity which is introduce by the manipulation of the http response.