### PR TITLE
Streaming progress

### DIFF
--- a/client/src/main/scala/com.crobox.clickhouse/internal/ClickHouseExecutor.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/ClickHouseExecutor.scala
@@ -74,7 +74,7 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
   lazy val superPoolSettings: ConnectionPoolSettings = ConnectionPoolSettings(system)
     .withConnectionSettings(
       ClientConnectionSettings(system)
-        .withTransport(new ProgressHeadersAsBodyClientTransport(progressQueue))
+        .withTransport(new StreamingProgressClickhouseTransport(progressQueue))
     )
   private lazy val pool = Http().superPool[Promise[HttpResponse]](settings = superPoolSettings)
   protected lazy val bufferSize: Int =

--- a/client/src/main/scala/com.crobox.clickhouse/internal/ClickHouseExecutor.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/ClickHouseExecutor.scala
@@ -29,8 +29,10 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
   lazy val (progressQueue, progressSource) = {
     val builtSource = Source
       .queue[String](1000, OverflowStrategy.dropHead)
-      .map(queryAndProgress => {
+      .map[Option[ClickhouseQueryProgress]](queryAndProgress => {
         queryAndProgress.split("\n", 2).toList match {
+          case queryId :: ProgressHeadersAsEventsStage.AcceptedMark :: Nil =>
+            Some(ClickhouseQueryProgress(queryId, QueryAccepted))
           case queryId :: progressJson :: Nil =>
             Try {
               val parsedJson = JSON.parseFull(progressJson).map(_.asInstanceOf[Map[String, String]])
@@ -182,7 +184,7 @@ object ClickHouseExecutor {
   case class QueryFailed(cause: Throwable)                  extends QueryProgress
   case class QueryRetry(cause: Throwable, retryNumber: Int) extends QueryProgress
 
-  case class ClickhouseQueryProgress(identifier: String, progress: Progress)
+  case class ClickhouseQueryProgress(identifier: String, progress: QueryProgress)
   case class Progress(rowsRead: Long, bytesRead: Long, totalRows: Long) extends QueryProgress
 
   case class QuerySettings(readOnly: ReadOnlySetting,
@@ -220,7 +222,6 @@ object ClickHouseExecutor {
     private def path(setting: String) = s"crobox.clickhouse.client.settings.$setting"
 
   }
-
 
   object QuerySettings {
     sealed trait ReadOnlySetting {

--- a/client/src/main/scala/com.crobox.clickhouse/internal/ClickhouseClientTransport.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/ClickhouseClientTransport.scala
@@ -14,9 +14,8 @@ import scala.concurrent.Future
 /**
  * Clickhouse sends http progress headers with the name X-ClickHouse-Progress which cannot be handled in a streaming way in akka
  * In the request we include our own custom header `X-Internal-Identifier` so we can send the internal query id with the progress
-  * We expect to first find the request with the custom header and then receive the progress headers
-  * The progress headers are being intercepted by the transport and sent to an internal source as progress events with the internal query id which will be used to route them to the query progress source
-  * After the first progress header is received we send the end of headers mark so that akka can eagerly return the http response
+ * The progress headers are being intercepted by the transport and sent to an internal source as progress events with the internal query id which will be used to route them to the query progress source
+ * We just proxy the request/response and do not manipulate them in any way
  * */
 class ProgressHeadersAsBodyClientTransport(source: SourceQueue[String]) extends ClientTransport {
   override def connectTo(
@@ -38,27 +37,23 @@ class ProgressHeadersAsBodyClientTransport(source: SourceQueue[String]) extends 
 
 class ProgressHeadersAsEventsStage(source: SourceQueue[String])
     extends GraphStage[BidiShape[ByteString, ByteString, ByteString, ByteString]] {
+  import ProgressHeadersAsEventsStage._
+  private val clientInput  = Inlet[ByteString]("ProgressHeadersAsEvents.in1")
+  private val serverOutput = Outlet[ByteString]("ProgressHeadersAsEvents.out1")
+  private val serverInput  = Inlet[ByteString]("ProgressHeadersAsEvents.in2")
+  private val clientOutput = Outlet[ByteString]("ProgressHeadersAsEvents.out2")
 
-  val ClickhouseProgressHeader = "X-ClickHouse-Progress"
-
-  val in1                = Inlet[ByteString]("ProgressHeadersAsEvents.in1")
-  val out1               = Outlet[ByteString]("ProgressHeadersAsEvents.out1")
-  val in2                = Inlet[ByteString]("ProgressHeadersAsEvents.in2")
-  val out2               = Outlet[ByteString]("ProgressHeadersAsEvents.out2")
-  val Crlf               = "\r\n"
-  val LookAheadCRLFSplit = "(?<=\\r\\n)"
-
-  override val shape = BidiShape.of(in1, out1, in2, out2)
+  override val shape = BidiShape.of(clientInput, serverOutput, serverInput, clientOutput)
   override def createLogic(
       inheritedAttributes: Attributes
   ): GraphStageLogic = new GraphStageLogic(shape) with StageLogging {
     var queryId: Option[String] = None
-    var queryIsInProgress       = false
+    var queryMarkedAsAccepted   = false
     setHandler(
-      in1,
+      clientInput,
       new InHandler {
         override def onPush(): Unit = {
-          val byteString = grab(in1)
+          val byteString = grab(clientInput)
           if (byteString.containsSlice(ByteString(InternalQueryIdentifier))) {
             val incomingString  = byteString.utf8String
             val responseStrings = incomingString.split(Crlf)
@@ -66,72 +61,64 @@ class ProgressHeadersAsEventsStage(source: SourceQueue[String])
             if (queryIdHeader.isEmpty) {
               log.warning(s"Could not extract the query id from the containing $incomingString")
             }
-            if (queryIsInProgress) {
-              log.warning("The previous query was not terminated correctly")
-            }
-            queryId = queryIdHeader.map(header => header.stripPrefix(InternalQueryIdentifier + ":").trim)
+            queryId = queryIdHeader.map(header => {
+              queryMarkedAsAccepted = false
+              header.stripPrefix(InternalQueryIdentifier + ":").trim
+            })
           }
-          push(out1, byteString)
+          push(serverOutput, byteString)
         }
       }
     )
     setHandler(
-      in2,
+      serverInput,
       new InHandler {
         override def onPush(): Unit = {
-          val byteString = grab(in2)
+          val byteString = grab(serverInput)
+          push(clientOutput, byteString)
+          if (!queryMarkedAsAccepted && byteString.containsSlice(ByteString("HTTP/1.1 200 OK"))) {
+            source.offer(queryId.getOrElse("unknown") + "\n" + AcceptedMark)
+            queryMarkedAsAccepted = true
+          }
           if (byteString.containsSlice(ByteString(ClickhouseProgressHeader))) {
             if (queryId.isEmpty) {
               log.warning("Cannot handle progress with query id")
-            }
-            val incomingString                  = byteString.utf8String
-            val responseStrings                 = incomingString.split(LookAheadCRLFSplit)
-            val (otherHeaders, progressHeaders) = responseStrings.span(!_.contains(ClickhouseProgressHeader))
-            if (progressHeaders.isEmpty) {
-              log.warning(s"Could not extract the progress from the containing $incomingString")
-            }
-            if (!queryIsInProgress) {
-              queryIsInProgress = true
-              val endOfHeaders = ByteString(otherHeaders.mkString("") + Crlf)
-              push(out2, endOfHeaders)
             } else {
-              push(out2, ByteString(otherHeaders.mkString("")))
-            }
-            progressHeaders
-              .filter(_.contains(ClickhouseProgressHeader))
-              .map(_.stripPrefix(ClickhouseProgressHeader + ":"))
-              .map(progressJson => {
-                queryId.getOrElse("unknown") + "\n" + progressJson
-              })
-              .foreach(progress => {
-                source.offer(progress)
-              })
-          } else {
-            if (queryIsInProgress) {
-              queryIsInProgress = false
-              if (byteString.equals(ByteString(Crlf))) { //already marked the end of headers, this must be removed
-                pull(in2)
-              } else {
-                if (byteString.startsWith(Crlf)) {
-                  push(out2, byteString.drop(2)) //already marked the end of headers, this must be removed
-                } else {
-                  push(out2, byteString)
-                }
+              val incomingString  = byteString.utf8String
+              val responseStrings = incomingString.split(Crlf)
+              val progressHeaders = responseStrings.filter(_.contains(ClickhouseProgressHeader))
+              if (progressHeaders.isEmpty) {
+                log.warning(s"Could not extract the progress from the containing $incomingString")
               }
-            } else {
-              push(out2, byteString)
+              progressHeaders
+                .filter(_.contains(ClickhouseProgressHeader))
+                .map(_.stripPrefix(ClickhouseProgressHeader + ":"))
+                .map(progressJson => {
+                  queryId.getOrElse("unknown") + "\n" + progressJson
+                })
+                .foreach(progress => {
+                  source.offer(progress)
+                })
             }
           }
         }
       }
     )
-    setHandler(out1, new OutHandler {
+    setHandler(serverOutput, new OutHandler {
       override def onPull(): Unit =
-        pull(in1)
+        pull(clientInput)
     })
-    setHandler(out2, new OutHandler {
+    setHandler(clientOutput, new OutHandler {
       override def onPull(): Unit =
-        pull(in2)
+        pull(serverInput)
     })
   }
+}
+
+object ProgressHeadersAsEventsStage {
+
+  val ClickhouseProgressHeader = "X-ClickHouse-Progress"
+  val AcceptedMark             = "CLICKHOUSE_ACCEPTED"
+  val Crlf                     = "\r\n"
+
 }

--- a/client/src/main/scala/com.crobox.clickhouse/internal/ClickhouseClientTransport.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/ClickhouseClientTransport.scala
@@ -17,7 +17,7 @@ import scala.concurrent.Future
  * The progress headers are being intercepted by the transport and sent to an internal source as progress events with the internal query id which will be used to route them to the query progress source
  * We just proxy the request/response and do not manipulate them in any way
  * */
-class ProgressHeadersAsBodyClientTransport(source: SourceQueue[String]) extends ClientTransport {
+class StreamingProgressClickhouseTransport(source: SourceQueue[String]) extends ClientTransport {
   override def connectTo(
       host: String,
       port: Int,

--- a/client/src/main/scala/com.crobox.clickhouse/internal/ClickhouseResponseParser.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/ClickhouseResponseParser.scala
@@ -25,7 +25,6 @@ private[clickhouse] trait ClickhouseResponseParser {
       val encoding = response.encoding
       response match {
         case HttpResponse(StatusCodes.OK, _, entity, _) =>
-          progressQueue.foreach(_.offer(QueryAccepted))
           entityToString(entity, encoding, progressQueue)
             .map(content => {
               if (content.contains("DB::Exception")) { //FIXME this is quite a fragile way to detect failures, hopefully nobody will have a valid exception string in the result. Check https://github.com/yandex/ClickHouse/issues/2999


### PR DESCRIPTION
Simplified the streaming process applied to the akka client transport by just wiretapping the tcp connection and pushing the progress from the headers, without actually manipulating the response sent by clickhouse. 