### PR TITLE
Async unordered sink inserts

### DIFF
--- a/client/src/main/scala/com.crobox.clickhouse/stream/ClickhouseSink.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/stream/ClickhouseSink.scala
@@ -33,7 +33,7 @@ object ClickhouseSink extends LazyLogging {
       .groupBy(Int.MaxValue, _.table)
       .groupedWithin(mergedIndexerConfig.getInt("batch-size"),
                      mergedIndexerConfig.getDuration("flush-interval").getSeconds seconds)
-      .mapAsync(mergedIndexerConfig.getInt("concurrent-requests"))(inserts => {
+      .mapAsyncUnordered(mergedIndexerConfig.getInt("concurrent-requests"))(inserts => {
         val table       = inserts.head.table
         val buildTable  = if (table.contains(".")) table else client.table(table)
         val insertQuery = s"INSERT INTO $buildTable FORMAT JSONEachRow"


### PR DESCRIPTION
Changed the use of mapAsync to asyncUnordered for the insert sync as we are not interested in the order and elements can be drained in any order