### PR TITLE
Feature/retry idempotent queries

### DIFF
--- a/client/src/main/scala/com.crobox.clickhouse/ClickhouseClient.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/ClickhouseClient.scala
@@ -48,7 +48,7 @@ class ClickhouseClient(override val config: Config, val database: String = "defa
    * @return Future with the result that clickhouse returns
    */
   def query(sql: String)(implicit settings: QuerySettings = QuerySettings(ReadQueries)): Future[String] =
-    executeRequest(sql, settings.copy(readOnly = ReadQueries))
+    executeRequest(sql, settings.copy(readOnly = ReadQueries, idempotent = true))
 
   /**
    * Execute a read-only query on Clickhouse
@@ -59,7 +59,7 @@ class ClickhouseClient(override val config: Config, val database: String = "defa
   def queryWithProgress(sql: String)(
       implicit settings: QuerySettings = QuerySettings(ReadQueries)
   ): Source[QueryProgress, Future[String]] =
-    executeRequestWithProgress(sql, settings.copy(readOnly = ReadQueries))
+    executeRequestWithProgress(sql, settings.copy(readOnly = ReadQueries, idempotent = true))
 
   /**
    * Execute a query that is modifying the state of the database. e.g. INSERT, SET, CREATE TABLE.

--- a/client/src/main/scala/com.crobox.clickhouse/balancing/discovery/cluster/ClusterConnectionFlow.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/balancing/discovery/cluster/ClusterConnectionFlow.scala
@@ -40,7 +40,7 @@ private[clickhouse] object ClusterConnectionFlow
       .mapAsync(1)(host => {
         val query = s"SELECT host_address FROM system.clusters WHERE cluster='$cluster'"
         val request =
-          toRequest(host, query, None, QuerySettings(readOnly = ReadQueries), None, idempotent = true)(
+          toRequest(host, query, None, QuerySettings(readOnly = ReadQueries, idempotent = true), None)(
             system.settings.config
           )
         processClickhouseResponse(http.singleRequest(request, settings = settings), query, host, None)

--- a/client/src/main/scala/com.crobox.clickhouse/internal/ClickhouseQueryBuilder.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/ClickhouseQueryBuilder.scala
@@ -18,6 +18,7 @@ private[clickhouse] trait ClickhouseQueryBuilder extends LazyLogging {
     import akka.http.scaladsl.model.headers.`Accept-Encoding`
     immutable.Seq(`Accept-Encoding`(gzip, deflate))
   }
+  private val MaxUriSize = 16 * 1024
 
   protected def toRequest(uri: Uri,
                           query: String,
@@ -39,7 +40,7 @@ private[clickhouse] trait ClickhouseQueryBuilder extends LazyLogging {
           if settings.idempotent && settings.readOnly == ReadQueries && urlQuery
             .toString()
             .getBytes
-            .length < 16 * 1024 => //max url size
+            .length < MaxUriSize => //max url size
         logger.debug(s"Executing clickhouse idempotent query [$query] on host [${uri.toString()}]")
         HttpRequest(
           method = HttpMethods.GET,

--- a/client/src/main/scala/com.crobox.clickhouse/internal/ClickhouseQueryBuilder.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/ClickhouseQueryBuilder.scala
@@ -22,21 +22,19 @@ private[clickhouse] trait ClickhouseQueryBuilder extends LazyLogging {
                           query: String,
                           queryIdentifier: Option[String],
                           settings: QuerySettings,
-                          entity: Option[RequestEntity],
-                          idempotent: Boolean = false)(config: Config): HttpRequest =
+                          entity: Option[RequestEntity])(config: Config): HttpRequest = {
+    val urlQuery = uri.withQuery(Query(Query("query" -> query) ++ settings.withFallback(config).asQueryParams: _*))
     entity match {
       case Some(e) =>
         logger.debug(s"Executing clickhouse query [$query] on host [${uri
           .toString()}] with entity payload of length ${e.contentLengthOption}")
         HttpRequest(
           method = HttpMethods.POST,
-          uri = uri.withQuery(
-            Query(Query("query" -> query) ++ settings.withFallback(config).asQueryParams: _*)
-          ),
+          uri = urlQuery,
           entity = e,
           headers = Headers ++ queryIdentifier.map(RawHeader(ProgressHeadersAsEventsStage.InternalQueryIdentifier, _))
         )
-      case None if !idempotent =>
+      case None if !settings.idempotent || urlQuery.toString().getBytes.length >= 16 * 1024 => //max url size
         logger.debug(s"Executing clickhouse query [$query] on host [${uri.toString()}]")
         HttpRequest(
           method = HttpMethods.POST,
@@ -44,15 +42,20 @@ private[clickhouse] trait ClickhouseQueryBuilder extends LazyLogging {
           entity = query,
           headers = Headers ++ queryIdentifier.map(RawHeader(ProgressHeadersAsEventsStage.InternalQueryIdentifier, _))
         )
-      case None if idempotent =>
+      case None if settings.idempotent =>
         logger.debug(s"Executing clickhouse idempotent query [$query] on host [${uri.toString()}]")
         HttpRequest(
           method = HttpMethods.GET,
-          uri = uri.withQuery(
-            Query(Query("query" -> query) ++ settings.withFallback(config).asQueryParams: _*).filterNot(_._1 == "readonly")//get requests are readonly by default, if we send the readonly flag clickhouse will fail the request
+          uri = urlQuery.withQuery(
+            urlQuery
+              .query()
+              .filterNot(
+                _._1 == "readonly"
+              ) //get requests are readonly by default, if we send the readonly flag clickhouse will fail the request
           ),
           headers = Headers ++ queryIdentifier.map(RawHeader(ProgressHeadersAsEventsStage.InternalQueryIdentifier, _))
         )
     }
+  }
 
 }

--- a/client/src/main/scala/com.crobox.clickhouse/internal/QuerySettings.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/QuerySettings.scala
@@ -11,7 +11,8 @@ case class QuerySettings(readOnly: ReadOnlySetting = AllQueries,
                          queryId: Option[String] = None,
                          profile: Option[String] = None,
                          httpCompression: Option[Boolean] = None,
-                         settings: Map[String, String] = Map.empty) {
+                         settings: Map[String, String] = Map.empty,
+                         idempotent: Boolean = false) {
 
   def asQueryParams: Query =
     Query(
@@ -39,10 +40,9 @@ case class QuerySettings(readOnly: ReadOnlySetting = AllQueries,
       profile = profile.orElse(Try { config.getString(path("profile")) }.toOption),
       httpCompression = httpCompression.orElse(Try { config.getBoolean(path("http-compression")) }.toOption),
       settings = custom.entrySet().asScala.map(u => (u.getKey, custom.getString(u.getKey))).toMap
-        ++ settings
+      ++ settings
     )
   }
-
 
   private def path(setting: String) = s"crobox.clickhouse.client.settings.$setting"
 

--- a/client/src/test/scala/com/crobox/clickhouse/internal/ClickhouseExecutorTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/internal/ClickhouseExecutorTest.scala
@@ -5,21 +5,26 @@ import akka.stream.scaladsl.{Sink, SourceQueue}
 import akka.stream.{Materializer, StreamTcpException}
 import com.crobox.clickhouse.ClickhouseClientAsyncSpec
 import com.crobox.clickhouse.balancing.HostBalancer
-import com.crobox.clickhouse.internal.QuerySettings.ReadQueries
+import com.crobox.clickhouse.balancing.iterator.CircularIteratorSet
+import com.crobox.clickhouse.internal.QuerySettings.{AllQueries, ReadQueries}
 import com.crobox.clickhouse.internal.progress.QueryProgress.{QueryProgress, QueryRetry}
 import com.typesafe.config.Config
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class ClickhouseExecutorTest extends ClickhouseClientAsyncSpec {
-  private lazy val self                = this
-  private var response: Future[String] = Future.successful("")
+  private val balancingHosts                  = Seq(Uri("http://host1"), Uri("http://host2"), Uri("http://host3"), Uri("http://host4"))
+  private val hosts                           = new CircularIteratorSet(balancingHosts)
+  private lazy val self                       = this
+  private var response: Uri => Future[String] = _
   private lazy val executor = {
     new ClickHouseExecutor with ClickhouseResponseParser with ClickhouseQueryBuilder {
       override protected implicit val system: ActorSystem                = self.system
       override protected implicit val executionContext: ExecutionContext = system.dispatcher
       override protected val config: Config                              = self.config
-      override protected val hostBalancer: HostBalancer                  = HostBalancer(config)
+      override protected val hostBalancer: HostBalancer = new HostBalancer {
+        override def nextHost: Future[Uri] = Future.successful(hosts.next())
+      }
       override protected def processClickhouseResponse(
           responseFuture: Future[HttpResponse],
           query: String,
@@ -33,13 +38,13 @@ class ClickhouseExecutorTest extends ClickhouseClientAsyncSpec {
           implicit materializer: Materializer,
           executionContext: ExecutionContext
       ): Future[String] =
-        response
+        response(host)
     }
   }
 
-  it should "retry requests" in {
+  it should "retry all requests with stream tcp connection" in {
     val exception = new StreamTcpException("")
-    response = Future.failed(exception)
+    response = _ => Future.failed(exception)
     executor
       .executeRequestWithProgress("", QuerySettings(ReadQueries))
       .runWith(Sink.seq[QueryProgress])
@@ -47,6 +52,48 @@ class ClickhouseExecutorTest extends ClickhouseClientAsyncSpec {
         progress should contain theSameElementsAs Seq(QueryRetry(exception, 1),
                                                       QueryRetry(exception, 2),
                                                       QueryRetry(exception, 3))
+      })
+  }
+
+  it should "retry idempotent queries for all exceptions" in {
+    val exception = new IllegalArgumentException("please retry me")
+    response = _ => Future.failed(exception)
+    executor
+      .executeRequestWithProgress("", QuerySettings(AllQueries, idempotent = true))
+      .runWith(Sink.seq[QueryProgress])
+      .map(progress => {
+        progress should contain theSameElementsAs Seq(QueryRetry(exception, 1),
+                                                      QueryRetry(exception, 2),
+                                                      QueryRetry(exception, 3))
+      })
+  }
+
+  it should "not retry non idempotent queries for non connection exception" in {
+    val exception = new IllegalArgumentException("no retry")
+    response = _ => Future.failed(exception)
+    executor
+      .executeRequestWithProgress("", QuerySettings(AllQueries))
+      .runWith(Sink.seq[QueryProgress])
+      .map(progress => {
+        progress should contain theSameElementsAs Seq()
+      })
+  }
+
+  it should "execute retries on the next balancer host" in {
+    val exception   = new IllegalArgumentException("retry")
+    var servedHosts = Seq[Uri]()
+    response = uri => {
+      servedHosts = servedHosts :+ uri
+      Future.failed(exception)
+    }
+    executor
+      .executeRequestWithProgress("", QuerySettings(AllQueries, idempotent = true))
+      .runWith(Sink.seq[QueryProgress])
+      .map(progress => {
+        progress should contain theSameElementsAs Seq(QueryRetry(exception, 1),
+                                                      QueryRetry(exception, 2),
+                                                      QueryRetry(exception, 3))
+        servedHosts should contain theSameElementsAs balancingHosts
       })
   }
 }


### PR DESCRIPTION
- Added the ability to specify that a query is idempotent and safe to be retried (all read queries and for example inserts into replacingmergetree table engines)
- Retrying idempotent queries on all the exceptions
- Using get to execute read queries whenever possible
- When using `sink` we no longer call execute (which applies the retries), but do a single call directly to stream the source as body. The user should handle retries in that case by using akka stream retries.

In the future we might want to make the retry mechanism smarter and add an exponential back off but currently we retry each time on the next host from the balancer so it should be safe.