### PR TITLE
Added support for request compression

### DIFF
--- a/client/src/main/scala/com.crobox.clickhouse/ClickhouseClient.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/ClickhouseClient.scala
@@ -79,6 +79,9 @@ class ClickhouseClient(configuration: Option[Config] = None)
   def execute(sql: String, entity: String)(implicit settings: QuerySettings): Future[String] =
     executeRequest(sql, settings, Option(entity))
 
+  def execute(sql: String, entity: Array[Byte])(implicit settings: QuerySettings): Future[String] =
+    executeRequest(sql, settings, Option(entity))
+
   /**
    * Creates a stream of the SQL query that will delimit the result from Clickhouse on new-line
    *

--- a/client/src/main/scala/com.crobox.clickhouse/internal/ClickhouseQueryBuilder.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/ClickhouseQueryBuilder.scala
@@ -1,7 +1,7 @@
 package com.crobox.clickhouse.internal
 
 import akka.http.scaladsl.model.Uri.Query
-import akka.http.scaladsl.model.headers.{HttpEncodingRange, RawHeader}
+import akka.http.scaladsl.model.headers.{HttpEncodingRange, RawHeader, `Content-Encoding`}
 import akka.http.scaladsl.model.{HttpMethods, HttpRequest, RequestEntity, Uri}
 import com.crobox.clickhouse.internal.QuerySettings.ReadQueries
 import com.crobox.clickhouse.internal.progress.ProgressHeadersAsEventsStage
@@ -35,7 +35,9 @@ private[clickhouse] trait ClickhouseQueryBuilder extends LazyLogging {
           method = HttpMethods.POST,
           uri = urlQuery,
           entity = e,
-          headers = Headers ++ queryIdentifier.map(RawHeader(ProgressHeadersAsEventsStage.InternalQueryIdentifier, _))
+          headers = Headers ++
+            queryIdentifier.map(RawHeader(ProgressHeadersAsEventsStage.InternalQueryIdentifier, _)) ++
+            settings.requestCompressionType.map(`Content-Encoding`(_))
         )
       case None
           if settings.idempotent.contains(true)

--- a/client/src/main/scala/com.crobox.clickhouse/internal/QuerySettings.scala
+++ b/client/src/main/scala/com.crobox.clickhouse/internal/QuerySettings.scala
@@ -1,6 +1,7 @@
 package com.crobox.clickhouse.internal
 
 import akka.http.scaladsl.model.Uri.Query
+import akka.http.scaladsl.model.headers.HttpEncoding
 import com.crobox.clickhouse.internal.QuerySettings._
 import com.typesafe.config.Config
 
@@ -16,7 +17,8 @@ case class QuerySettings(readOnly: ReadOnlySetting = AllQueries,
                          httpCompression: Option[Boolean] = None,
                          settings: Map[String, String] = Map.empty,
                          idempotent: Option[Boolean] = None,
-                         retries: Option[Int] = None) {
+                         retries: Option[Int] = None,
+                         requestCompressionType: Option[HttpEncoding] = None) {
 
   def asQueryParams: Query =
     Query(

--- a/client/src/test/scala/com/crobox/clickhouse/ClickhouseClientAsyncSpec.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/ClickhouseClientAsyncSpec.scala
@@ -12,7 +12,8 @@ import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest._
 import org.scalatest.flatspec.AsyncFlatSpecLike
 import org.scalatest.matchers.should.Matchers
-
+import java.io.ByteArrayOutputStream
+import java.util.zip.GZIPOutputStream
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
@@ -57,5 +58,13 @@ abstract class ClickhouseClientAsyncSpec(val config: Config = ConfigFactory.load
         )
         succeed
       })
+  }
+
+  def compressGzip(content: String): Array[Byte] = {
+    val arrOutputStream = new ByteArrayOutputStream()
+    val zipOutputStream = new GZIPOutputStream(arrOutputStream)
+    zipOutputStream.write(content.getBytes)
+    zipOutputStream.close()
+    arrOutputStream.toByteArray
   }
 }

--- a/client/src/test/scala/com/crobox/clickhouse/ClickhouseClientAsyncSpec.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/ClickhouseClientAsyncSpec.scala
@@ -13,6 +13,7 @@ import org.scalatest._
 import org.scalatest.flatspec.AsyncFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets.UTF_8
 import java.util.zip.GZIPOutputStream
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -63,7 +64,7 @@ abstract class ClickhouseClientAsyncSpec(val config: Config = ConfigFactory.load
   def compressGzip(content: String): Array[Byte] = {
     val arrOutputStream = new ByteArrayOutputStream()
     val zipOutputStream = new GZIPOutputStream(arrOutputStream)
-    zipOutputStream.write(content.getBytes)
+    zipOutputStream.write(content.getBytes(UTF_8))
     zipOutputStream.close()
     arrOutputStream.toByteArray
   }


### PR DESCRIPTION
For cases when a lot of large insert requests are sent to the server, support for compressing the request to the server itself will be useful