### PR TITLE
Added small improvement

### DIFF
--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/SplitMergeFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/SplitMergeFunctionTokenizer.scala
@@ -7,7 +7,20 @@ trait SplitMergeFunctionTokenizer {
 
   def tokenizeSplitMergeFunction(col: SplitMergeFunction[_])(implicit ctx: TokenizeContext): String = col match {
     case SplitByChar(sep: StringColMagnet[_], col: StringColMagnet[_]) =>
-      s"splitByChar(${tokenizeColumn(sep.column)},${tokenizeColumn(col.column)})"
+      // Some small optimizations
+      val separator = tokenizeColumn(sep.column)
+      if (separator.length == 3) {
+        val s = separator.charAt(1).toInt
+
+        // https://en.wikipedia.org/wiki/List_of_Unicode_characters
+        if (s >= 32 && s <= 126) {
+          s"splitByChar($separator,${tokenizeColumn(col.column)})"
+        } else {
+          s"splitByChar(char($s),${tokenizeColumn(col.column)})"
+        }
+      } else {
+        s"splitByString($separator,${tokenizeColumn(col.column)})"
+      }
     case SplitByString(sep: StringColMagnet[_], col: StringColMagnet[_]) =>
       s"splitByString(${tokenizeColumn(sep.column)},${tokenizeColumn(col.column)})"
     case ArrayStringConcat(col: ArrayColMagnet[_], sep: StringColMagnet[_]) =>

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/SplitMergeFunctionTokenizerTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/SplitMergeFunctionTokenizerTest.scala
@@ -1,0 +1,28 @@
+package com.crobox.clickhouse.dsl.language
+
+import com.crobox.clickhouse.dsl._
+import com.crobox.clickhouse.{dsl, DslTestSpec}
+
+class SplitMergeFunctionTokenizerTest extends DslTestSpec {
+  val FIELD_DELIMITER: Char = '\u001F'
+
+  it should "splitByChar using special character" in {
+
+    toSQL(select(dsl.splitByChar(FIELD_DELIMITER.toString, "abcd"))) should matchSQL(
+      "SELECT splitByChar(char(31),'abcd')"
+    )
+    toSQL(select(dsl.splitByChar(31.toChar.toString, "abcd"))) should matchSQL("SELECT splitByChar(char(31),'abcd')")
+    toSQL(select(dsl.splitByChar(32.toChar.toString, "abcd"))) should matchSQL("SELECT splitByChar(' ','abcd')")
+    toSQL(select(dsl.splitByChar(126.toChar.toString, "abcd"))) should matchSQL("SELECT splitByChar('~','abcd')")
+    toSQL(select(dsl.splitByChar(127.toChar.toString, "abcd"))) should matchSQL("SELECT splitByChar(char(127),'abcd')")
+    toSQL(select(dsl.splitByChar(128.toChar.toString, "abcd"))) should matchSQL("SELECT splitByChar(char(128),'abcd')")
+    toSQL(select(dsl.splitByChar(159.toChar.toString, "abcd"))) should matchSQL("SELECT splitByChar(char(159),'abcd')")
+
+    toSQL(select(dsl.splitByChar(",", "abcd"))) should matchSQL("SELECT splitByChar(',','abcd')")
+    toSQL(select(dsl.splitByChar("a", "abcd"))) should matchSQL("SELECT splitByChar('a','abcd')")
+    toSQL(select(dsl.splitByChar("ab", "abcd"))) should matchSQL("SELECT splitByString('ab','abcd')")
+    toSQL(select(dsl.splitByChar("L", "abcd"))) should matchSQL("SELECT splitByChar('L','abcd')")
+    toSQL(select(dsl.splitByChar("$", "abcd"))) should matchSQL("SELECT splitByChar('$','abcd')")
+    toSQL(select(dsl.splitByChar("-", "abcd"))) should matchSQL("SELECT splitByChar('-','abcd')")
+  }
+}


### PR DESCRIPTION
Small improvement. Although everything works fine, 'printing' SQL queries with a splitByChar using special ASCII characters result in unreadable code, i.e. ```splitByChar('',`abcd`)])```  This makes it impossible to copy 'n paste.

A better solution is to use the Clickhouse `char` functionality, i.e. char(31). Tested this and works