### PR TITLE
fix DB::Exception: Missing columns: 'version'

### DIFF
--- a/client/src/main/scala/com/crobox/clickhouse/ClickhouseClient.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/ClickhouseClient.scala
@@ -129,7 +129,7 @@ class ClickhouseClient(configuration: Option[Config] = None)
         ClickhouseServerVersion(cfg.getString(path))
       } else {
         Await.result(
-          query("select version")(QuerySettings(ReadQueries).copy(retries = Option(0)))
+          query("select version()")(QuerySettings(ReadQueries).copy(retries = Option(0)))
             .recover {
               case x: ClickhouseException =>
                 val key = "(version "


### PR DESCRIPTION
"SELECT version" not working, there is only "version()" function exists. This causes an exception in logs and incorrect version detection (=> always using default latest version 22.8.15).

Affected for client version 1.0.3 and later

You could see log example below:
```
<Error> executeQuery: Code: 47, e.displayText() = DB::Exception: Missing columns: 'version' while processing query: 'SELECT version', required columns: 'version', source columns: 'dummy' (version 20.8.18.32 (official build)) (from <hidden_hostname>:51350) (in query: select version ), Stack trace (when copying this message, always include the lines below):

<Error> DynamicQueryHandler: Code: 47, e.displayText() = DB::Exception: Missing columns: 'version' while processing query: 'SELECT version', required columns: 'version', source columns: 'dummy', Stack trace (when copying this message, always include the lines below):
```

Clickhouse documentation: https://clickhouse.com/docs/en/sql-reference/functions/other-functions#version