### PR TITLE
Tokenize higher arithmetic functions

### DIFF
--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ArithmeticFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ArithmeticFunctionTokenizer.scala
@@ -34,16 +34,18 @@ trait ArithmeticFunctionTokenizer { this: ClickhouseTokenizerModule =>
   private def tokenizeWithOperator(col: ArithmeticFunctionOp[_], operator: String)(implicit
       ctx: TokenizeContext
   ): String = {
-    val left = col.left.column match {
-      case afo: ArithmeticFunctionOp[_] => s"(${tokenizeArithmeticFunctionOperator(afo)})"
-      case numericCol => tokenizeColumn(numericCol)
-    }
-    val right = col.right.column match {
-      case afo: ArithmeticFunctionOp[_] => s"(${tokenizeArithmeticFunctionOperator(afo)})"
-      case numericCol => tokenizeColumn(numericCol)
-    }
+    val left  = tokenizeTableColumn(col.left.column)
+    val right = tokenizeTableColumn(col.right.column)
     left + " " + operator + " " + right
   }
+
+  private def tokenizeTableColumn(column: TableColumn[_])(implicit
+      ctx: TokenizeContext
+  ): String =
+    column match {
+      case afo: ArithmeticFunctionOp[_] => s"(${tokenizeArithmeticFunctionOperator(afo)})"
+      case numericCol                   => tokenizeColumn(numericCol)
+    }
 
   private def tokenizeAsFunction(col: ArithmeticFunctionOp[_], fn: String)(implicit ctx: TokenizeContext): String =
     s"$fn(${tokenizeColumn(col.left.column)}, ${tokenizeColumn(col.right.column)})"

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ArithmeticFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ArithmeticFunctionTokenizer.scala
@@ -33,8 +33,17 @@ trait ArithmeticFunctionTokenizer { this: ClickhouseTokenizerModule =>
 
   private def tokenizeWithOperator(col: ArithmeticFunctionOp[_], operator: String)(implicit
       ctx: TokenizeContext
-  ): String =
-    tokenizeColumn(col.left.column) + " " + operator + " " + tokenizeColumn(col.right.column)
+  ): String = {
+    val left = col.left.column match {
+      case afo: ArithmeticFunctionOp[_] => s"(${tokenizeArithmeticFunctionOperator(afo)})"
+      case numericCol => tokenizeColumn(numericCol)
+    }
+    val right = col.right.column match {
+      case afo: ArithmeticFunctionOp[_] => s"(${tokenizeArithmeticFunctionOperator(afo)})"
+      case numericCol => tokenizeColumn(numericCol)
+    }
+    left + " " + operator + " " + right
+  }
 
   private def tokenizeAsFunction(col: ArithmeticFunctionOp[_], fn: String)(implicit ctx: TokenizeContext): String =
     s"$fn(${tokenizeColumn(col.left.column)}, ${tokenizeColumn(col.right.column)})"

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/ArithmeticFunctionTokenizerTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/ArithmeticFunctionTokenizerTest.scala
@@ -17,8 +17,9 @@ class ArithmeticFunctionTokenizerTest extends DslTestSpec {
     toSQL(select(plus(1, 2)), false) should matchSQL("SELECT 1 + 2")
   }
 
-  it should "tokenize add functions" in {
+  it should "tokenize functions with precedence" in {
     toSQL(select(plus(plus(1, 2), 3)), false) should matchSQL("SELECT (1 + 2) + 3")
     toSQL(select(plus(plus(1, 2), divide(3, 4))), false) should matchSQL("SELECT (1 + 2) + (3 / 4)")
+    toSQL(select(divide(multiply(minus(1, 0.9), 100.0), 0.2)), false) should matchSQL("SELECT ((1 - 0.9) * 100.0) / 0.2")
   }
 }

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/ArithmeticFunctionTokenizerTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/ArithmeticFunctionTokenizerTest.scala
@@ -1,0 +1,24 @@
+package com.crobox.clickhouse.dsl.language
+
+import com.crobox.clickhouse.DslTestSpec
+import com.crobox.clickhouse.dsl._
+
+class ArithmeticFunctionTokenizerTest extends DslTestSpec {
+
+  it should "tokenize divide" in {
+    toSQL(select(divide(1, 2)), false) should matchSQL("SELECT 1 / 2")
+  }
+
+  it should "tokenize divide functions" in {
+    toSQL(select(divide(divide(1, 2), divide(3, 4))), false) should matchSQL("SELECT (1 / 2) / (3 / 4)")
+  }
+
+  it should "tokenize add" in {
+    toSQL(select(plus(1, 2)), false) should matchSQL("SELECT 1 + 2")
+  }
+
+  it should "tokenize add functions" in {
+    toSQL(select(plus(plus(1, 2), 3)), false) should matchSQL("SELECT (1 + 2) + 3")
+    toSQL(select(plus(plus(1, 2), divide(3, 4))), false) should matchSQL("SELECT (1 + 2) + (3 / 4)")
+  }
+}


### PR DESCRIPTION
Since arithmetic functions have precedence, we should reflect that in tokenized modules. 

See tokenizer tests for some samples