### PR TITLE
Support expression columns in JOIN ON

### DIFF
--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/JoinExpressionOnIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/JoinExpressionOnIT.scala
@@ -1,0 +1,42 @@
+package com.crobox.clickhouse.dsl
+
+import com.crobox.clickhouse.DslITSpec
+import com.crobox.clickhouse.DslITSpec.IntResult
+import com.crobox.clickhouse.dsl.JoinQuery.{AllLeftJoin, InnerJoin}
+
+import java.util.UUID
+
+class JoinExpressionOnIT extends DslITSpec {
+
+  override val table1Entries: Seq[Table1Entry] = Seq(
+    Table1Entry(UUID.randomUUID(), numbers = Seq(1, 2, 3))
+  )
+  override val table2Entries: Seq[Table2Entry] = Seq(
+    Table2Entry(UUID.randomUUID(), "a", 1, "x", None),
+    Table2Entry(UUID.randomUUID(), "b", 3, "y", None)
+  )
+
+  // ClickHouse < 24 rejects `arrayJoin(...)` in `JOIN ON` with INVALID_JOIN_ON_EXPRESSION (Code 403).
+  it should "join with arrayJoin(leftCol(...)) on an expression LHS (INNER JOIN)" in {
+    assumeMinimalClickhouseVersion(24)
+    val query =
+      select(col2)
+        .from(OneTestTable)
+        .join(InnerJoin, TwoTestTable)
+        .on((arrayJoin(leftCol(numbers)), "=", col2))
+    val resultRows = queryExecutor.execute[IntResult](query).futureValue.rows
+    resultRows.length shouldBe 2
+  }
+
+  // ALL LEFT JOIN keeps unmatched arrayJoin'd left rows → 3 (matches 1 and 3, plus unmatched 2).
+  it should "join with arrayJoin(leftCol(...)) on an expression LHS (ALL LEFT JOIN)" in {
+    assumeMinimalClickhouseVersion(24)
+    val query =
+      select(col2)
+        .from(OneTestTable)
+        .join(AllLeftJoin, TwoTestTable)
+        .on((arrayJoin(leftCol(numbers)), "=", col2))
+    val resultRows = queryExecutor.execute[IntResult](query).futureValue.rows
+    resultRows.length shouldBe 3
+  }
+}

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/JoinQuery.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/JoinQuery.scala
@@ -45,7 +45,17 @@ object JoinQuery {
   case object AsOfLeftJoin  extends JoinType
   case object SemiLeftJoin  extends JoinType
   case object SemiRightJoin extends JoinType
+
+  sealed trait JoinSide
+  case object Left  extends JoinSide
+  case object Right extends JoinSide
 }
+
+/**
+ * Qualifies a column with the LEFT or RIGHT side of the enclosing `JoinQuery.on`. Constructed via `leftCol` / `rightCol`
+ * in `package object dsl`; only valid inside `JoinQuery.on` — used outside an ON, tokenization throws `AssertionError`.
+ */
+case class JoinSideQualified[V](side: JoinSide, inner: TableColumn[V]) extends TableColumn[V](inner.name)
 
 /**
  * @param joinType
@@ -76,6 +86,12 @@ case class JoinCondition(left: Column, operator: String, right: Column) {
 object JoinCondition {
   val SupportedOperators = Set(">", ">=", "<", "<=", "=")
 
-  def apply(column: Column): JoinCondition                   = JoinCondition(column, "=", column)
+  def apply(column: Column): JoinCondition = {
+    require(
+      !column.isInstanceOf[JoinSideQualified[_]],
+      "leftCol/rightCol cannot be used as a single-arg JoinCondition"
+    )
+    JoinCondition(column, "=", column)
+  }
   def apply(triple: (Column, String, Column)): JoinCondition = JoinCondition(triple._1, triple._2, triple._3)
 }

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -15,7 +15,8 @@ case class TokenizeContext(
     var joinNr: Int = 0,
     var tableAliases: Map[Table, String] = Map.empty,
     var useTableAlias: Boolean = false,
-    delimiter: String = ", "
+    delimiter: String = ", ",
+    var joinOnScope: Option[(String, String)] = None
 ) {
 
   def incrementJoinNumber(): Unit = joinNr += 1
@@ -156,6 +157,14 @@ trait ClickhouseTokenizerModule
       case alias: AliasedColumn[_] =>
         val originalColumnToken = tokenizeColumn(alias.original)
         if (originalColumnToken.isEmpty) alias.quoted else s"$originalColumnToken AS ${alias.quoted}"
+      case q: JoinSideQualified[_] =>
+        val (leftAlias, rightAlias) = ctx.joinOnScope
+          .getOrElse(throw new AssertionError("leftCol/rightCol only valid inside JoinQuery.on"))
+        val alias = q.side match {
+          case Left  => leftAlias
+          case Right => rightAlias
+        }
+        s"$alias.${tokenizeColumn(q.inner)}"
       case tuple: TupleColumn[_]    => s"(${tuple.elements.map(tokenizeColumn).mkString(ctx.delimiter)})"
       case col: ExpressionColumn[_] => tokenizeExpressionColumn(col)
       case col: Column              => col.quoted
@@ -322,17 +331,45 @@ trait ClickhouseTokenizerModule
 
         if (`using`.nonEmpty) {
           // TOKENIZE USING
+          assert(
+            !using.exists(_.isInstanceOf[JoinSideQualified[_]]),
+            "leftCol/rightCol not valid in JoinQuery.using"
+          )
           if (`using`.size == 1) s"USING ${using.head.name}"
           else s"USING (${using.map(_.name).mkString(ctx.delimiter)})"
         } else if (query.on.nonEmpty) {
           // TOKENIZE ON. If the fromClause is a TABLE, we need to check on aliases!
-          "ON " + query.on
-            .map { cond =>
-              val left = verifyOnCondition(select, from, cond.left)
-              s"${ctx.leftAlias(from.alias)}.$left ${cond.operator} ${ctx.rightAlias(query.other.alias)}.${cond.right.name}"
-            }
-            .mkString(" AND ")
+          ctx.joinOnScope = Some((ctx.leftAlias(from.alias), ctx.rightAlias(query.other.alias)))
+          try
+            "ON " + query.on
+              .map { cond =>
+                val left  = tokenizeJoinSide(Left, select, from, cond.left)
+                val right = tokenizeJoinSide(Right, select, from, cond.right)
+                s"$left ${cond.operator} $right"
+              }
+              .mkString(" AND ")
+          finally ctx.joinOnScope = None
         } else ""
+    }
+  }
+
+  private def tokenizeJoinSide(side: JoinSide, select: Option[SelectQuery], from: FromQuery, col: Column)(implicit
+      ctx: TokenizeContext
+  ): String = {
+    val (leftA, rightA) = ctx.joinOnScope.get
+    val sideAlias       = side match {
+      case Left  => leftA
+      case Right => rightA
+    }
+    col match {
+      case _: JoinSideQualified[_]  => tokenizeColumn(col)
+      case _: ExpressionColumn[_]   => tokenizeColumn(col)
+      case _: Column                =>
+        val name = side match {
+          case Left  => verifyOnCondition(select, from, col)
+          case Right => col.name
+        }
+        s"$sideAlias.$name"
     }
   }
 

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/package.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/package.scala
@@ -1,5 +1,6 @@
 package com.crobox.clickhouse
 
+import com.crobox.clickhouse.dsl.JoinQuery.{Left, Right}
 import com.crobox.clickhouse.dsl.column.ClickhouseColumnFunctions
 import com.crobox.clickhouse.dsl.execution.{QueryExecutor, QueryResult}
 import com.crobox.clickhouse.dsl.marshalling.{QueryValue, QueryValueFormats}
@@ -93,4 +94,10 @@ package object dsl extends ClickhouseColumnFunctions with QueryFactory with Quer
     case Nil => defaultValue
     case _   => Conditional(cases, defaultValue, multiIf = true)
   }
+
+  /** Qualifies a column with the LEFT side of the enclosing `JoinQuery.on`. Only valid inside `JoinQuery.on`. */
+  def leftCol[V](col: TableColumn[V]): JoinSideQualified[V] = JoinSideQualified(Left, col)
+
+  /** Qualifies a column with the RIGHT side of the enclosing `JoinQuery.on`. Only valid inside `JoinQuery.on`. */
+  def rightCol[V](col: TableColumn[V]): JoinSideQualified[V] = JoinSideQualified(Right, col)
 }

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/JoinQueryTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/JoinQueryTest.scala
@@ -171,4 +171,80 @@ class JoinQueryTest extends DslTestSpec with TableDrivenPropertyChecks {
          |FORMAT JSON""".stripMargin
     )
   }
+
+  it should "reject leftCol/rightCol in single-arg JoinCondition" in {
+    an[IllegalArgumentException] shouldBe thrownBy(JoinCondition(leftCol(itemId)))
+    an[IllegalArgumentException] shouldBe thrownBy(JoinCondition(rightCol(itemId)))
+  }
+
+  it should "fail when leftCol/rightCol is used outside JoinQuery.on (SELECT)" in {
+    val query = select(leftCol(itemId)).from(OneTestTable)
+    an[AssertionError] shouldBe thrownBy(toSql(query.internalQuery))
+  }
+
+  it should "fail when leftCol/rightCol is used outside JoinQuery.on (WHERE)" in {
+    val query = select(itemId).from(OneTestTable).where(leftCol(itemId).isEq(itemId))
+    an[AssertionError] shouldBe thrownBy(toSql(query.internalQuery))
+  }
+
+  it should "emit arrayJoin(leftCol(...)) verbatim on LEFT, plain column on RIGHT" in {
+    val query =
+      select(dsl.all)
+        .from(OneTestTable)
+        .join(AllLeftJoin, TwoTestTable)
+        .on((arrayJoin(leftCol(numbers)), "=", col2))
+    toSql(query.internalQuery) should matchSQL(
+      s"SELECT * FROM ${OneTestTable.quoted} AS L1 " +
+        s"ALL LEFT JOIN (SELECT * FROM ${TwoTestTable.quoted}) AS R1 " +
+        s"ON arrayJoin(L1.numbers) = R1.column_2 FORMAT JSON"
+    )
+  }
+
+  it should "qualify same-named columns with leftCol/rightCol" in {
+    val query =
+      select(dsl.all)
+        .from(OneTestTable)
+        .join(InnerJoin, TwoTestTable)
+        .on((leftCol(itemId), "=", rightCol(itemId)))
+    toSql(query.internalQuery) should matchSQL(
+      s"SELECT * FROM ${OneTestTable.quoted} AS L1 " +
+        s"INNER JOIN (SELECT * FROM ${TwoTestTable.quoted}) AS R1 " +
+        s"ON L1.item_id = R1.item_id FORMAT JSON"
+    )
+  }
+
+  it should "honour custom from-alias when using leftCol" in {
+    val query =
+      select(dsl.all)
+        .from(OneTestTable)
+        .as("ott_alias")
+        .join(InnerJoin, TwoTestTable)
+        .on((leftCol(itemId), "=", rightCol(itemId)))
+    toSql(query.internalQuery) should matchSQL(
+      s"SELECT * FROM ${OneTestTable.quoted} AS ott_alias " +
+        s"INNER JOIN (SELECT * FROM ${TwoTestTable.quoted}) AS R1 " +
+        s"ON ott_alias.item_id = R1.item_id FORMAT JSON"
+    )
+  }
+
+  it should "fail when leftCol/rightCol is used in JoinQuery.using" in {
+    val query =
+      select(itemId)
+        .from(OneTestTable)
+        .join(InnerJoin, TwoTestTable) using leftCol(itemId)
+    an[AssertionError] shouldBe thrownBy(toSql(query.internalQuery))
+  }
+
+  it should "recurse through double-wrapped leftCol(rightCol(col))" in {
+    val query =
+      select(dsl.all)
+        .from(OneTestTable)
+        .join(InnerJoin, TwoTestTable)
+        .on((leftCol(rightCol(itemId)), "=", itemId))
+    toSql(query.internalQuery) should matchSQL(
+      s"SELECT * FROM ${OneTestTable.quoted} AS L1 " +
+        s"INNER JOIN (SELECT * FROM ${TwoTestTable.quoted}) AS R1 " +
+        s"ON L1.R1.item_id = R1.item_id FORMAT JSON"
+    )
+  }
 }


### PR DESCRIPTION
## Summary

Allows `arrayJoin(...)` and other expression columns on either side of `JoinQuery.on`, and adds `leftCol` / `rightCol` to qualify same-named columns.

Previously the tokenizer prefixed each ON operand with `L<n>.` / `R<n>.` using `col.name`, which collapsed `ExpressionColumn` to `L1.NULL` (since `EmptyColumn.name = "NULL"`). The tokenizer now branches per kind: plain `TableColumn` keeps the auto-prefix, `ExpressionColumn` is emitted verbatim, and `JoinSideQualified` resolves to the current join's L/R alias (respecting custom from-aliases).

## API additions

- `leftCol[V](col: TableColumn[V])` / `rightCol[V](col: TableColumn[V])` in `package object dsl` — qualify a column with the LEFT/RIGHT side of the enclosing `JoinQuery.on`.
- `case class JoinSideQualified[V](side: JoinSide, inner: TableColumn[V]) extends TableColumn[V](inner.name)` — the type produced by `leftCol` / `rightCol`. Preserves `V` so it composes with magnets (e.g., `arrayJoin(leftCol(ref[Seq[String]](...)))`).
- `JoinSideQualified` is handled in `tokenizeColumn` and a new `tokenizeJoinSide` helper.
- `JoinCondition.apply(column: Column)` rejects `JoinSideQualified` (single-arg form would imply LEFT = LEFT or RIGHT = RIGHT — never user intent).
- `tokenizeJoinKeys`' USING branch rejects `JoinSideQualified` (only valid in ON).

## Examples

### `arrayJoin` on the LEFT side of ON

```scala
select(dsl.all)
  .from(OneTestTable)
  .join(AllLeftJoin, TwoTestTable)
  .on((arrayJoin(leftCol(numbers)), "=", col2))
```

```sql
SELECT * FROM one_table AS L1
ALL LEFT JOIN (SELECT * FROM two_table) AS R1
ON arrayJoin(L1.numbers) = R1.column_2
```

### Same-named columns on both sides

```scala
select(dsl.all)
  .from(OneTestTable)
  .join(InnerJoin, TwoTestTable)
  .on((leftCol(itemId), "=", rightCol(itemId)))
```

```sql
SELECT * FROM one_table AS L1
INNER JOIN (SELECT * FROM two_table) AS R1
ON L1.item_id = R1.item_id
```

### Custom from-alias honoured by `leftCol`

```scala
select(dsl.all)
  .from(OneTestTable).as("ott_alias")
  .join(InnerJoin, TwoTestTable)
  .on((leftCol(itemId), "=", rightCol(itemId)))
```

```sql
SELECT * FROM one_table AS ott_alias
INNER JOIN (SELECT * FROM two_table) AS R1
ON ott_alias.item_id = R1.item_id
```

## Follow-ups

> [!WARNING]
> IT (`JoinExpressionOnIT`) is gated by `assumeMinimalClickhouseVersion(24)` and is canceled on the repo's default CH 23.8 image — `arrayJoin` in `JOIN ON` errors with `INVALID_JOIN_ON_EXPRESSION (Code 403)` on 23.8 but works on 24.8+ (verified manually). Bumping `CLICKHOUSE_VERSION` in `.docker/docker-compose.yml` requires resolving the 24+ `default` user password change, out of scope here.

> [!NOTE]
> Audit: all sibling tokenizers in `dsl/.../language/` pattern-match on specific function case classes and recurse via `tokenizeColumn(...)`, so `JoinSideQualified` flows through transparently. No other file needed changes.

## References

- https://clickhouse.com/docs/sql-reference/functions/array-join
- https://clickhouse.com/docs/sql-reference/statements/select/join