### PR TITLE
Make map aggregates and tuple access usable

### DIFF
--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/AggregationFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/AggregationFunctions.scala
@@ -189,8 +189,28 @@ trait SumFunctions { self: Magnets with AggregationFunctions =>
   case class Sum[T](tableColumn: TableColumn[T], modifier: SumModifier = SumModifier.Simple)
       extends AggregateFunction[Double](tableColumn)
 
-  case class SumMap[T, V](key: TableColumn[Seq[T]], value: TableColumn[Seq[V]])
-      extends AggregateFunction[(Seq[T], Seq[V])](key)
+  /**
+   * The `*Map` aggregates: given parallel key and value arrays, aggregate the values per key and return
+   * `(keys, values)`.
+   *
+   * The arrays are taken as [[ArrayColMagnet]] rather than `TableColumn[Seq[_]]` so that an array *expression* can be
+   * passed. `TableColumn` is covariant and the array functions produce `Iterable`, so an `arrayPushBack(...)` or
+   * `arrayOf(...)` is a `TableColumn[Iterable[T]]` and was rejected where a `TableColumn[Seq[T]]` was demanded -- you
+   * could only ever pass a stored column.
+   *
+   * Project the result with [[tupleElement]], or the [[mapKeys]] / [[mapValues]] shorthands.
+   */
+  case class SumMap[T, V](key: ArrayColMagnet[_ <: Iterable[T]], value: ArrayColMagnet[_ <: Iterable[V]])
+      extends AggregateFunction[(Seq[T], Seq[V])](key.column)
+
+  case class MinMap[T, V](key: ArrayColMagnet[_ <: Iterable[T]], value: ArrayColMagnet[_ <: Iterable[V]])
+      extends AggregateFunction[(Seq[T], Seq[V])](key.column)
+
+  case class MaxMap[T, V](key: ArrayColMagnet[_ <: Iterable[T]], value: ArrayColMagnet[_ <: Iterable[V]])
+      extends AggregateFunction[(Seq[T], Seq[V])](key.column)
+
+  case class AvgMap[T, V](key: ArrayColMagnet[_ <: Iterable[T]], value: ArrayColMagnet[_ <: Iterable[V]])
+      extends AggregateFunction[(Seq[T], Seq[V])](key.column)
 
   sealed trait SumModifier
 
@@ -204,7 +224,23 @@ trait SumFunctions { self: Magnets with AggregationFunctions =>
 
   def sumOverflown[T](tableColumn: TableColumn[T]): Sum[T] = Sum(tableColumn, SumModifier.WithOverflow)
 
-  def sumMap[T, V](key: TableColumn[Seq[T]], value: TableColumn[Seq[V]]): SumMap[T, V] = SumMap(key, value)
+  def sumMap[T, V](key: ArrayColMagnet[_ <: Iterable[T]], value: ArrayColMagnet[_ <: Iterable[V]]): SumMap[T, V] =
+    SumMap(key, value)
+
+  def minMap[T, V](key: ArrayColMagnet[_ <: Iterable[T]], value: ArrayColMagnet[_ <: Iterable[V]]): MinMap[T, V] =
+    MinMap(key, value)
+
+  def maxMap[T, V](key: ArrayColMagnet[_ <: Iterable[T]], value: ArrayColMagnet[_ <: Iterable[V]]): MaxMap[T, V] =
+    MaxMap(key, value)
+
+  def avgMap[T, V](key: ArrayColMagnet[_ <: Iterable[T]], value: ArrayColMagnet[_ <: Iterable[V]]): AvgMap[T, V] =
+    AvgMap(key, value)
+
+  /** The keys array of a `*Map` aggregate, i.e. `(sumMap(k, v)).1`. */
+  def mapKeys[T, V](map: AggregateFunction[(Seq[T], Seq[V])]): TupleElement[Seq[T]] = tupleElement[Seq[T]](map, 1)
+
+  /** The values array of a `*Map` aggregate, i.e. `(sumMap(k, v)).2`. */
+  def mapValues[T, V](map: AggregateFunction[(Seq[T], Seq[V])]): TupleElement[Seq[V]] = tupleElement[Seq[V]](map, 2)
 }
 
 trait Leveled { self: Magnets with AggregationFunctions =>

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/ArrayFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/ArrayFunctions.scala
@@ -85,6 +85,15 @@ trait ArrayFunctions { this: Magnets =>
   def emptyArrayToSingle[V](col: ArrayColMagnet[V]): EmptyArrayToSingle[V] = EmptyArrayToSingle[V](col)
   def range(n: NumericCol[_]): Range                                       = Range(n)
 
+  /**
+   * Array literal: `arrayOf(a, b)` tokenizes to `[a, b]`.
+   *
+   * Named `arrayOf` rather than `array` because `array` is already the aggregate-function combinator
+   * (`AggregationFunctions.array`), and `Array` collides with `scala.Array`. Without this, building a single-element
+   * array meant `arrayPushBack(emptyArrayString, x)`.
+   */
+  def arrayOf[V](columns: ConstOrColMagnet[V]*): Array[V] = Array(columns: _*)
+
   def arrayConcat[V](col1: ArrayColMagnet[V], columns: ArrayColMagnet[V]*): ArrayConcat[V] =
     ArrayConcat(col1, columns: _*)
   def arrayElement[V](col: ArrayColMagnet[_ <: Iterable[V]], n: NumericCol[_]): ArrayElement[V] = ArrayElement(col, n)

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/InFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/InFunctions.scala
@@ -20,7 +20,16 @@ trait InFunctions { self: Magnets =>
   // This is especially problematic when using TupleElement
 
   case class Tuple(coln: Seq[ConstOrColMagnet[_]]) extends ExpressionColumn[Nothing](EmptyColumn) with InFunction
-  case class TupleElement[T](tuple: Tuple, index: NumericCol[_])
+
+  /**
+   * Positional access into anything that evaluates to a tuple, not just a literal [[Tuple]].
+   *
+   * ClickHouse returns tuples from more than the tuple constructor -- the map aggregates (`sumMap`, `maxMap`, ...)
+   * return `(keys, values)`, and a higher-order function's lambda parameter can be bound to one. Requiring the concrete
+   * `Tuple` made both of those unreachable: there was no way to project `sumMap(...).2`, and casting a lambda parameter
+   * compiled but then threw at runtime, because the tokenizer binds lambda parameters to a `RefColumn`.
+   */
+  case class TupleElement[T](tuple: ConstOrColMagnet[_], index: NumericCol[_])
       extends ExpressionColumn[T](EmptyColumn)
       with InFunction
 
@@ -54,6 +63,8 @@ trait InFunctions { self: Magnets =>
   def notIn(l: ConstOrColMagnet[_], r: InFuncRHMagnet, global: Boolean): ExpressionColumn[Boolean] =
     if (global) globalNotIn(l, r) else notIn(l, r)
 
-  def tuple(coln: ConstOrColMagnet[_]*): Tuple                             = Tuple(coln)
-  def tupleElement[T](tuple: Tuple, index: NumericCol[_]): TupleElement[T] = TupleElement[T](tuple, index)
+  def tuple(coln: ConstOrColMagnet[_]*): Tuple = Tuple(coln)
+
+  def tupleElement[T](tuple: ConstOrColMagnet[_], index: NumericCol[_]): TupleElement[T] =
+    TupleElement[T](tuple, index)
 }

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/AggregationFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/AggregationFunctionTokenizer.scala
@@ -64,7 +64,10 @@ trait AggregationFunctionTokenizer { this: ClickhouseTokenizerModule =>
           s"${levels.mkString(ctx.delimiter)})(${tokenizeColumn(column)}${modifierValue.map(ctx.delimiter + _).getOrElse("")}"
         )
       case Sum(column, modifier)   => (s"sum${tokenizeSumModifier(modifier)}", tokenizeColumn(column))
-      case SumMap(key, value)      => (s"sumMap", tokenizeColumns(Seq(key, value)))
+      case SumMap(key, value)      => ("sumMap", tokenizeColumns(Seq(key.column, value.column)))
+      case MinMap(key, value)      => ("minMap", tokenizeColumns(Seq(key.column, value.column)))
+      case MaxMap(key, value)      => ("maxMap", tokenizeColumns(Seq(key.column, value.column)))
+      case AvgMap(key, value)      => ("avgMap", tokenizeColumns(Seq(key.column, value.column)))
       case Uniq(columns, modifier) =>
         (s"uniq${tokenizeUniqModifier(modifier)}", columns.map(tokenizeColumn).mkString(ctx.delimiter))
       case f: AggregateFunction[_] =>

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/InFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/InFunctionTokenizer.scala
@@ -7,8 +7,10 @@ trait InFunctionTokenizer {
 
   def tokenizeInFunction(col: InFunction)(implicit ctx: TokenizeContext): String = col match {
     case t: Tuple => s"(${t.coln.map(col => tokenizeColumn(col.column)).mkString(", ")})" // Tuple Creation Operator
+    // Access operator. The operand is parenthesised because it is not always a bare identifier -- for a map aggregate
+    // it is a whole function call, and `sumMap(a, b).2` is a syntax error where `(sumMap(a, b)).2` is not.
     case t: TupleElement[_] =>
-      s"${tokenizeColumn(t.tuple.column)}.${tokenizeColumn(t.index.column)})" // Access Operators
+      s"(${tokenizeColumn(t.tuple.column)}).${tokenizeColumn(t.index.column)}"
     case col: InFunctionCol[_] => tokenizeInFunctionCol(col)
   }
 

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/MapAggregationTokenizerTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/MapAggregationTokenizerTest.scala
@@ -1,0 +1,62 @@
+package com.crobox.clickhouse.dsl.language
+
+import com.crobox.clickhouse.DslTestSpec
+import com.crobox.clickhouse.dsl._
+
+/**
+ * The `*Map` aggregates and positional tuple access had no coverage at all, which is how the tuple-access operator came
+ * to emit an unbalanced parenthesis. These assert the generated SQL, because that is the only place this DSL's mistakes
+ * show up -- a wrong tokenizer still type-checks.
+ */
+class MapAggregationTokenizerTest extends DslTestSpec {
+
+  it should "tokenize sumMap over a stored array column" in {
+    // `numbers` is a NativeColumn[Seq[Int]]; accepting ArrayColMagnet must not break stored Seq columns.
+    toSQL(select(sumMap(numbers, numbers) as "m"), false) should matchSQL(
+      "SELECT sumMap(numbers, numbers) AS m"
+    )
+  }
+
+  it should "tokenize minMap, maxMap and avgMap" in {
+    toSQL(select(minMap(numbers, numbers) as "m"), false) should matchSQL("SELECT minMap(numbers, numbers) AS m")
+    toSQL(select(maxMap(numbers, numbers) as "m"), false) should matchSQL("SELECT maxMap(numbers, numbers) AS m")
+    toSQL(select(avgMap(numbers, numbers) as "m"), false) should matchSQL("SELECT avgMap(numbers, numbers) AS m")
+  }
+
+  it should "accept an array expression, not only a stored column" in {
+    // The point of taking ArrayColMagnet: an inline array is typed Iterable, and because TableColumn is covariant it
+    // could never satisfy a TableColumn[Seq[_]] parameter.
+    toSQL(select(sumMap(arrayOf(col2), arrayOf(col2)) as "m"), false) should matchSQL(
+      "SELECT sumMap([column_2], [column_2]) AS m"
+    )
+  }
+
+  it should "parenthesise the operand of tuple access" in {
+    // `sumMap(a, b).2` is a ClickHouse syntax error; `(sumMap(a, b)).2` is not.
+    toSQL(select(mapValues(sumMap(numbers, numbers)) as "v"), false) should matchSQL(
+      "SELECT (sumMap(numbers, numbers)).2 AS v"
+    )
+    toSQL(select(mapKeys(sumMap(numbers, numbers)) as "k"), false) should matchSQL(
+      "SELECT (sumMap(numbers, numbers)).1 AS k"
+    )
+  }
+
+  it should "still tokenize tuple access over a tuple literal" in {
+    toSQL(select(tupleElement[String](tuple(col1, col2), 1) as "e"), false) should matchSQL(
+      "SELECT ((column_1, column_2)).1 AS e"
+    )
+  }
+
+  it should "project a map aggregate through a higher-order function" in {
+    // The shape this was all for: one value per key, then reduced. Previously impossible -- a lambda parameter is bound
+    // to a RefColumn, so tuple access inside one could not be expressed.
+    val perKey = arraySum2[Int, Int](
+      (total, count) => total / count,
+      mapValues(sumMap(numbers, numbers)),
+      mapValues(sumMap(numbers, numbers))
+    )
+    toSQL(select(perKey as "v"), false) should matchSQL(
+      "SELECT arraySum((x,y) -> x / y, (sumMap(numbers, numbers)).2, (sumMap(numbers, numbers)).2) AS v"
+    )
+  }
+}


### PR DESCRIPTION
Four gaps in the DSL that together made a per-key aggregate impossible to express. Found the hard way — trying to write "revenue once per transaction" against a real dataset, hitting each wall in turn.

## What was broken

**Tuple access only accepted the concrete `Tuple` case class.**

```scala
def tupleElement[T](tuple: Tuple, index: NumericCol[_]): TupleElement[T]
```

That rules out both places ClickHouse actually hands you a tuple:

- a `*Map` aggregate's `(keys, values)` result — `SumMap` is an `AggregateFunction[(Seq[T], Seq[V])]`, not a `Tuple`, so there was no way to reach its values array;
- a higher-order function's lambda parameter. This one failed **at runtime**, not compile time: `HigherOrderFunctionTokenizer` binds lambda parameters to a `RefColumn`, so `asInstanceOf[Tuple]` type-checks and then throws `ClassCastException: RefColumn cannot be cast to InFunctions$Tuple`.

`TupleElement` now takes any column. The `FIXME` already sitting above it — *"especially problematic when using TupleElement"* — was right.

**The tuple access operator emitted an unbalanced parenthesis.**

```scala
s"${tokenizeColumn(t.tuple.column)}.${tokenizeColumn(t.index.column)})"   // → "x.2)"
```

Nothing caught it, because neither `tupleElement` nor `sumMap` had a single test. It now emits `(x).2` — parenthesised deliberately, since the operand is not always a bare identifier and `sumMap(a, b).2` is a ClickHouse syntax error.

**`sumMap` demanded `TableColumn[Seq[_]]` while every array function produces `Iterable`.** `TableColumn[+V]` is covariant, so `TableColumn[Iterable[T]]` is not a `TableColumn[Seq[T]]` — an array you had just built with `arrayPushBack`/`arrayOf` could never be passed, only a stored column. The `*Map` aggregates now take `ArrayColMagnet[_ <: Iterable[_]]`, the idiom the array functions already use; stored `Seq` columns keep working through the same implicit (covered by a test).

**No array literal constructor.** The `Array` AST existed with no way to build one: `array` is the aggregate-function combinator and `Array` collides with `scala.Array`. Added `arrayOf(...)`.

## Added

- `minMap`, `maxMap`, `avgMap` alongside `sumMap`
- `mapKeys` / `mapValues` for projecting their result
- `arrayOf(...)` array literal

## Verification

The emitted SQL

```sql
arraySum((rev, cnt) -> rev / cnt,
         (sumMap([k], [v])).2,
         (sumMap([k], [1])).2)
```

computes **1,423,974** on a two-day production replay, where the per-event `sum` it replaces reports **1,989,267** — a 40% overstatement caused by transactions that fire the purchase event more than once (13,777 events for 9,885 distinct transactions in that window).

Tests are generated-SQL assertions, which is the only thing that catches a wrong tokenizer here — a mistokenized expression still type-checks and returns a plausible number.

Green on **2.13.18 and 3.3.8**: 218 tests, 27 suites, `scalafmtCheckAll` clean.

## Note for review

`TupleElement`'s field type changed from `Tuple` to `ConstOrColMagnet[_]`, and the `*Map` case-class fields from `TableColumn[Seq[_]]` to `ArrayColMagnet[_ <: Iterable[_]]`. Source-compatible for anyone using the `tupleElement` / `sumMap` constructor functions; binary-incompatible, and a direct pattern match on those case classes would need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)