### PR TITLE
Fix client reliability defects

### DIFF
--- a/client/src/main/scala/com/crobox/clickhouse/ClickhouseClient.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/ClickhouseClient.scala
@@ -133,7 +133,12 @@ class ClickhouseClient(
     executeRequestInternal(hostBalancer.nextHost, sql, queryIdentifier, settings, Option(entity), None)
   }
 
-  val serverVersion: ClickhouseServerVersion =
+  /**
+   * Resolved on first use, not at construction. This blocks on a query to the server, and doing that eagerly meant a
+   * client could not be constructed without a reachable ClickHouse -- it stalled the constructing thread for up to five
+   * seconds and then carried on with a guessed version. Callers that want it resolved up front can still touch it.
+   */
+  lazy val serverVersion: ClickhouseServerVersion =
     try {
       val path    = "crobox.clickhouse.server.version"
       val cfg     = configuration.getOrElse(ConfigFactory.load())
@@ -156,8 +161,12 @@ class ClickhouseClient(
       version
     } catch {
       case x: Throwable =>
-        val latest = ClickhouseServerVersion.latest
-        logger.error(s"Can't determine Clickhouse Server Version. Falling back to: $latest. Error: ${x.getMessage}", x)
-        latest
+        val assumed = ClickhouseServerVersion.fallback
+        logger.error(
+          s"Can't determine Clickhouse Server Version. Assuming: $assumed. Set `crobox.clickhouse.server.version` to " +
+            s"avoid guessing. Error: ${x.getMessage}",
+          x
+        )
+        assumed
     }
 }

--- a/client/src/main/scala/com/crobox/clickhouse/ClickhouseServerVersion.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/ClickhouseServerVersion.scala
@@ -15,5 +15,13 @@ object ClickhouseServerVersion {
   def apply(version: String): ClickhouseServerVersion =
     ClickhouseServerVersion(version.split('.').toSeq.map(_.filter(_.isDigit)).filter(_.trim.nonEmpty).map(_.toInt))
 
-  def latest: ClickhouseServerVersion = ClickhouseServerVersion(versions = Seq(22, 8, 15))
+  /**
+   * Assumed when the server's version cannot be determined. Not actually the latest release -- it is a floor, chosen as
+   * the oldest ClickHouse LTS this client is tested against, so that version-gated SQL generation defaults to what a
+   * supported server understands. Guessing is unavoidable here because tokenization needs a version synchronously.
+   */
+  def fallback: ClickhouseServerVersion = ClickhouseServerVersion(versions = Seq(25, 3, 0))
+
+  @deprecated("Renamed to `fallback`; it never meant the latest release. Will be removed in 2.0.", "1.3.1")
+  def latest: ClickhouseServerVersion = fallback
 }

--- a/client/src/main/scala/com/crobox/clickhouse/balancing/Connection.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/balancing/Connection.scala
@@ -11,6 +11,11 @@ object Connection {
         case "single-host"     => SingleHost
         case "balancing-hosts" => BalancingHosts
         case "cluster-aware"   => ClusterAware
+        case unknown           =>
+          throw new IllegalArgumentException(
+            s"Unknown crobox.clickhouse.client.connection.type [$unknown]; " +
+              "expected one of single-host, balancing-hosts, cluster-aware"
+          )
       }
   }
 

--- a/client/src/main/scala/com/crobox/clickhouse/balancing/HostBalancer.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/balancing/HostBalancer.scala
@@ -44,10 +44,18 @@ object HostBalancer extends ClickhouseHostBuilder {
           connectionHostFromConfig,
           connectionConfig.getString("cluster"),
           manager,
-          connectionConfig.getDuration("scanning-interval").getSeconds.seconds
-        )(system, config.getDuration("host-retrieval-timeout").getSeconds.seconds, ec)
+          connectionConfig.getDuration("scanning-interval").toMillis.millis
+        )(system, hostRetrievalTimeout(config), ec)
     }
   }
+
+  /**
+   * Timeout for asking the connection manager for a host. Falls back to the previous hardcoded value when the setting
+   * is absent, so a balancer built against a bare ActorSystem keeps working.
+   */
+  private[balancing] def hostRetrievalTimeout(config: Config): FiniteDuration =
+    if (config.hasPath("host-retrieval-timeout")) config.getDuration("host-retrieval-timeout").toMillis.millis
+    else 5.seconds
 
   def extractHost(connectionConfig: Config): Uri =
     toHost(

--- a/client/src/main/scala/com/crobox/clickhouse/balancing/HostBalancer.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/balancing/HostBalancer.scala
@@ -4,6 +4,7 @@ import com.crobox.clickhouse.balancing.Connection.{BalancingHosts, ClusterAware,
 import com.crobox.clickhouse.balancing.discovery.ConnectionManagerActor
 import com.crobox.clickhouse.balancing.discovery.health.ClickhouseHostHealth
 import com.crobox.clickhouse.internal.ClickhouseHostBuilder
+import com.crobox.clickhouse.internal.ConfigDuration
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.pekko.actor.ActorSystem
@@ -44,7 +45,7 @@ object HostBalancer extends ClickhouseHostBuilder {
           connectionHostFromConfig,
           connectionConfig.getString("cluster"),
           manager,
-          connectionConfig.getDuration("scanning-interval").toMillis.millis
+          ConfigDuration(connectionConfig, "scanning-interval")
         )(system, hostRetrievalTimeout(config), ec)
     }
   }
@@ -54,8 +55,7 @@ object HostBalancer extends ClickhouseHostBuilder {
    * is absent, so a balancer built against a bare ActorSystem keeps working.
    */
   private[balancing] def hostRetrievalTimeout(config: Config): FiniteDuration =
-    if (config.hasPath("host-retrieval-timeout")) config.getDuration("host-retrieval-timeout").toMillis.millis
-    else 5.seconds
+    ConfigDuration.orElse(config, "host-retrieval-timeout", 5.seconds)
 
   def extractHost(connectionConfig: Config): Uri =
     toHost(

--- a/client/src/main/scala/com/crobox/clickhouse/balancing/MultiHostBalancer.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/balancing/MultiHostBalancer.scala
@@ -16,7 +16,10 @@ case class MultiHostBalancer(hosts: Set[Uri], manager: ActorRef)(implicit system
     extends HostBalancer
     with ClickhouseHostBuilder {
 
-  private implicit val timeout: Timeout = durationToTimeout(5.seconds)
+  // Was a hardcoded 5 seconds, while ClusterAwareHostBalancer used `host-retrieval-timeout` -- one second by default
+  // -- for the very same ask. Both now read the same setting.
+  private implicit val timeout: Timeout =
+    durationToTimeout(HostBalancer.hostRetrievalTimeout(system.settings.config))
 
   manager ! ConnectionManagerActor.Connections(hosts)
 

--- a/client/src/main/scala/com/crobox/clickhouse/balancing/discovery/cluster/ClusterConnectionFlow.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/balancing/discovery/cluster/ClusterConnectionFlow.scala
@@ -55,7 +55,9 @@ private[clickhouse] object ClusterConnectionFlow
                   s"Please use the `SingleHostQueryBalancer` in that case."
               )
             }
-            Connections(result.map(ClickhouseHostBuilder.toHost(_, Some(8123))))
+            // The configured port, not a hardcoded 8123: `system.clusters` reports the native port, which is not the
+            // HTTP port we speak, so the only sensible assumption is that every node exposes HTTP where this one does.
+            Connections(result.map(ClickhouseHostBuilder.toHost(_, Some(host.effectivePort))))
           }
       }
   }

--- a/client/src/main/scala/com/crobox/clickhouse/balancing/discovery/health/ClickhouseHostHealth.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/balancing/discovery/health/ClickhouseHostHealth.scala
@@ -13,6 +13,7 @@ import com.crobox.clickhouse.internal.ClickhouseResponseParser
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
+import com.crobox.clickhouse.internal.ConfigDuration
 
 object ClickhouseHostHealth extends ClickhouseResponseParser {
 
@@ -38,15 +39,9 @@ object ClickhouseHostHealth extends ClickhouseResponseParser {
       executionContext: ExecutionContext
   ): Source[ClickhouseHostStatus, Cancellable] = {
     val healthCheckInterval: FiniteDuration =
-      system.settings.config
-        .getDuration("connection.health-check.interval")
-        .toMillis
-        .seconds
+      ConfigDuration(system.settings.config, "connection.health-check.interval")
     val healthCheckTimeout: FiniteDuration =
-      system.settings.config
-        .getDuration("connection.health-check.timeout")
-        .toMillis
-        .seconds
+      ConfigDuration(system.settings.config, "connection.health-check.timeout")
 
     val healthCachedPool = Http(system).cachedHostConnectionPool[Int](
       host.authority.host.address(),

--- a/client/src/main/scala/com/crobox/clickhouse/balancing/discovery/health/ClickhouseHostHealth.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/balancing/discovery/health/ClickhouseHostHealth.scala
@@ -40,12 +40,12 @@ object ClickhouseHostHealth extends ClickhouseResponseParser {
     val healthCheckInterval: FiniteDuration =
       system.settings.config
         .getDuration("connection.health-check.interval")
-        .getSeconds
+        .toMillis
         .seconds
     val healthCheckTimeout: FiniteDuration =
       system.settings.config
         .getDuration("connection.health-check.timeout")
-        .getSeconds
+        .toMillis
         .seconds
 
     val healthCachedPool = Http(system).cachedHostConnectionPool[Int](

--- a/client/src/main/scala/com/crobox/clickhouse/internal/ClickHouseExecutor.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/internal/ClickHouseExecutor.scala
@@ -58,12 +58,30 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
       progressQueue: Option[SourceQueueWithComplete[QueryProgress]] = None
   ): Future[String] = {
     val internalQueryIdentifier = queryIdentifier
-    executeWithRetries(settings.retries.getOrElse(queryRetries), progressQueue, settings) { () =>
+    val totalRetries            = settings.retries.getOrElse(queryRetries)
+
+    // Subscribed once per query and cancelled when the query settles. This used to happen inside
+    // executeRequestInternal via a bare runForeach, which materialised a BroadcastHub consumer that nothing ever
+    // cancelled -- one per request plus one per retry, each retained for the lifetime of the hub.
+    val progressSubscription = progressQueue.map(subscribeToProgress(internalQueryIdentifier, _))
+
+    executeWithRetries(totalRetries, totalRetries, progressQueue, settings) { () =>
       executeRequestInternal(hostBalancer.nextHost, query, internalQueryIdentifier, settings, entity, progressQueue)
     }.andThen { case _ =>
+      progressSubscription.foreach(_.shutdown())
       progressQueue.foreach(_.complete())
     }
   }
+
+  private def subscribeToProgress(
+      internalQueryIdentifier: String,
+      target: SourceQueueWithComplete[QueryProgress]
+  ): UniqueKillSwitch =
+    progressSource
+      .collect { case progress if progress.identifier == internalQueryIdentifier => progress.progress }
+      .viaMat(KillSwitches.single)(Keep.right)
+      .toMat(Sink.foreach(progress => target.offer(progress)))(Keep.left)
+      .run()
 
   protected def queryIdentifier: String =
     Random.alphanumeric.take(20).mkString("")
@@ -107,14 +125,7 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
       settings: QuerySettings,
       entity: Option[RequestEntity] = None,
       progressQueue: Option[SourceQueueWithComplete[QueryProgress]]
-  ): Future[String] = {
-    progressQueue.foreach(definedProgressQueue =>
-      progressSource.runForeach(progress =>
-        if (progress.identifier == queryIdentifier) {
-          definedProgressQueue.offer(progress.progress)
-        }
-      )
-    )
+  ): Future[String] =
     host.flatMap { actualHost =>
       val request = toRequest(
         actualHost,
@@ -127,33 +138,37 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
       )(config)
       processClickhouseResponse(singleRequest(request, progressQueue.isDefined), query, actualHost, progressQueue)
     }
-  }
 
   private def executeWithRetries(
       retries: Int,
+      totalRetries: Int,
       progressQueue: Option[SourceQueueWithComplete[QueryProgress]],
       settings: QuerySettings
   )(
       request: () => Future[String]
-  ): Future[String] =
+  ): Future[String] = {
+    // Against totalRetries, not the config value: settings.retries can override it per query, and reporting
+    // "retry 1 of 3" for a query configured with one retry is misleading.
+    val attempt = (totalRetries - retries) + 1
     request().recoverWith {
       case clickException: ClickhouseExecutionException if !clickException.retryable =>
         // TODO use more fine grained exceptions in the client and remove the match on `Exception`
         Future.failed(clickException)
       case e: StreamTcpException if retries > 0 =>
-        progressQueue.foreach(_.offer(QueryRetry(e, (queryRetries - retries) + 1)))
+        progressQueue.foreach(_.offer(QueryRetry(e, attempt)))
         logger.warn(s"Stream exception, retries left: $retries", e)
-        executeWithRetries(retries - 1, progressQueue, settings)(request)
+        executeWithRetries(retries - 1, totalRetries, progressQueue, settings)(request)
       case e: RuntimeException
           if e.getMessage.contains("The http server closed the connection unexpectedly") && retries > 0 =>
         logger.warn(s"Unexpected connection closure, retries left: $retries", e)
-        progressQueue.foreach(_.offer(QueryRetry(e, (queryRetries - retries) + 1)))
-        executeWithRetries(retries - 1, progressQueue, settings)(request)
+        progressQueue.foreach(_.offer(QueryRetry(e, attempt)))
+        executeWithRetries(retries - 1, totalRetries, progressQueue, settings)(request)
       case e: Exception if settings.idempotent.contains(true) && retries > 0 =>
         logger.warn(s"Query execution exception while executing idempotent query, retries left: $retries", e)
-        progressQueue.foreach(_.offer(QueryRetry(e, (queryRetries - retries) + 1)))
-        executeWithRetries(retries - 1, progressQueue, settings)(request)
+        progressQueue.foreach(_.offer(QueryRetry(e, attempt)))
+        executeWithRetries(retries - 1, totalRetries, progressQueue, settings)(request)
     }
+  }
 }
 
 object ClickHouseExecutor {}

--- a/client/src/main/scala/com/crobox/clickhouse/internal/ClickhouseResponseParser.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/internal/ClickhouseResponseParser.scala
@@ -12,7 +12,23 @@ import com.crobox.clickhouse.{ClickhouseChunkedException, ClickhouseException}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
+private[clickhouse] object ClickhouseResponseParser {
+
+  /**
+   * ClickHouse cannot report a failure in the status line once it has started streaming: a query that fails part way
+   * through its result still returns 200, without an `X-ClickHouse-Exception-Code` header, and appends the exception to
+   * the body. So the body is the only place that failure can be seen, and it has to be inspected.
+   *
+   * Matched on the shape ClickHouse actually appends -- `Code: <n>. DB::Exception` -- rather than a bare
+   * "DB::Exception" substring, so that a result row which merely contains that text is not mistaken for a failure. That
+   * was the concern recorded in https://github.com/ClickHouse/ClickHouse/issues/2999. Matching the whole body rather
+   * than a trailing window, since an exception message has no bounded length.
+   */
+  private[internal] val StreamedExceptionMarker = """Code: (\d+)\. DB::Exception""".r
+}
+
 private[clickhouse] trait ClickhouseResponseParser {
+  import ClickhouseResponseParser.StreamedExceptionMarker
 
   protected def processClickhouseResponse(
       responseFuture: Future[HttpResponse],
@@ -29,9 +45,9 @@ private[clickhouse] trait ClickhouseResponseParser {
           Unmarshaller
             .stringUnmarshaller(entity)
             .map { content =>
-              if (content.contains("DB::Exception")) { // FIXME this is quite a fragile way to detect failures, hopefully nobody will have a valid exception string in the result. Check https://github.com/yandex/ClickHouse/issues/2999
+              StreamedExceptionMarker.findFirstMatchIn(content).foreach { marker =>
                 throw ClickhouseException(
-                  "Found exception in the query return body",
+                  s"Query failed after the response had started streaming; ClickHouse error code ${marker.group(1)}",
                   query,
                   ClickhouseChunkedException(content),
                   StatusCodes.OK

--- a/client/src/main/scala/com/crobox/clickhouse/internal/ConfigDuration.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/internal/ConfigDuration.scala
@@ -1,0 +1,23 @@
+package com.crobox.clickhouse.internal
+
+import com.typesafe.config.Config
+
+import scala.concurrent.duration._
+
+/**
+ * Reads a duration out of config at millisecond resolution.
+ *
+ * This existed as `getDuration(path).getSeconds.seconds` written out at four separate sites, which floored anything
+ * below a second -- a `500 millis` health-check interval became `0`, a tight polling loop. Correcting four hand-written
+ * copies of the same expression is also how one of them ended up as `.toMillis.seconds`, inflating every value a
+ * thousandfold, so the expression now lives in one place with a test on it.
+ */
+private[clickhouse] object ConfigDuration {
+
+  def apply(config: Config, path: String): FiniteDuration =
+    config.getDuration(path).toMillis.millis
+
+  /** For settings a caller may not have in scope at all; see HostBalancer.hostRetrievalTimeout. */
+  def orElse(config: Config, path: String, default: FiniteDuration): FiniteDuration =
+    if (config.hasPath(path)) apply(config, path) else default
+}

--- a/client/src/main/scala/com/crobox/clickhouse/stream/ClickhouseSink.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/stream/ClickhouseSink.scala
@@ -9,6 +9,7 @@ import com.typesafe.scalalogging.LazyLogging
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import com.crobox.clickhouse.internal.ConfigDuration
 
 case class ClickhouseIndexingException(msg: String, cause: Throwable, payload: Seq[String], table: String)
     extends RuntimeException(msg, cause)
@@ -59,7 +60,7 @@ object ClickhouseSink extends LazyLogging {
       )
       .getOrElse(indexerGeneralConfig)
     val batchSize     = mergedIndexerConfig.getInt("batch-size")
-    val flushInterval = mergedIndexerConfig.getDuration("flush-interval").toMillis.millis
+    val flushInterval = ConfigDuration(mergedIndexerConfig, "flush-interval")
     Flow[TableOperation]
       .groupBy(Int.MaxValue, _.table)
       .groupedWithin(batchSize, flushInterval)

--- a/client/src/main/scala/com/crobox/clickhouse/stream/ClickhouseSink.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/stream/ClickhouseSink.scala
@@ -59,7 +59,7 @@ object ClickhouseSink extends LazyLogging {
       )
       .getOrElse(indexerGeneralConfig)
     val batchSize     = mergedIndexerConfig.getInt("batch-size")
-    val flushInterval = mergedIndexerConfig.getDuration("flush-interval").getSeconds.seconds
+    val flushInterval = mergedIndexerConfig.getDuration("flush-interval").toMillis.millis
     Flow[TableOperation]
       .groupBy(Int.MaxValue, _.table)
       .groupedWithin(batchSize, flushInterval)

--- a/client/src/test/scala/com/crobox/clickhouse/internal/ClickhouseResponseParserTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/internal/ClickhouseResponseParserTest.scala
@@ -1,0 +1,46 @@
+package com.crobox.clickhouse.internal
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * A query that fails once ClickHouse has started streaming still returns 200 with no `X-ClickHouse-Exception-Code`
+ * header -- the exception is appended to the body instead. So detection has to read the body, and how precisely it does
+ * that decides whether a legitimate result row can be mistaken for a failure.
+ */
+class ClickhouseResponseParserTest extends AnyFlatSpec with Matchers {
+
+  private def failureDetected(content: String): Boolean =
+    ClickhouseResponseParser.StreamedExceptionMarker.findFirstMatchIn(content).isDefined
+
+  it should "detect an exception appended after the response started streaming" in {
+    // Shape taken from a real mid-stream failure: rows, then the exception appended to the same 200 response.
+    val body =
+      """{"x":0}{"x":0}{"x":0}{"exception":"Code: 395. DB::Exception: boom: while executing 'FUNCTION throwIf'. """ +
+        """(FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) (version 25.3.8.10041)"}"""
+    failureDetected(body) shouldBe true
+  }
+
+  it should "detect it in the raw formats too, where the exception is appended as plain text" in {
+    failureDetected("0\n1\n2\nCode: 241. DB::Exception: Memory limit (total) exceeded") shouldBe true
+  }
+
+  it should "capture the ClickHouse error code" in {
+    val marker = ClickhouseResponseParser.StreamedExceptionMarker
+      .findFirstMatchIn("Code: 241. DB::Exception: Memory limit exceeded")
+    marker.map(_.group(1)) shouldBe Some("241")
+  }
+
+  it should "not treat a result row that merely mentions DB::Exception as a failure" in {
+    // The false positive the previous `content.contains("DB::Exception")` check was open to, and the reason for the
+    // FIXME it carried: querying stored log lines would trip it.
+    failureDetected("""{"message":"caught DB::Exception while handling request"}""") shouldBe false
+    failureDetected("DB::Exception") shouldBe false
+    failureDetected("""{"error_type":"DB::Exception","count":"17"}""") shouldBe false
+  }
+
+  it should "not fire on ordinary results" in {
+    failureDetected("""{"x":0}{"x":1}""") shouldBe false
+    failureDetected("") shouldBe false
+  }
+}

--- a/client/src/test/scala/com/crobox/clickhouse/internal/ConfigDurationTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/internal/ConfigDurationTest.scala
@@ -1,0 +1,44 @@
+package com.crobox.clickhouse.internal
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+
+/**
+ * Pins the numeric result, which is the point: this expression was previously written out at four sites, and nothing
+ * asserted on the value it produced. That let a truncate-to-second bug live for years, and let a thousandfold inflation
+ * pass local tests when it was corrected.
+ */
+class ConfigDurationTest extends AnyFlatSpec with Matchers {
+
+  private val config = ConfigFactory.parseString(
+    """
+      |whole = 10 seconds
+      |sub = 500 millis
+      |tiny = 1 millis
+      |minutes = 2 minutes
+      |""".stripMargin
+  )
+
+  it should "read a whole-second duration as itself" in {
+    ConfigDuration(config, "whole") shouldBe 10.seconds
+    ConfigDuration(config, "minutes") shouldBe 2.minutes
+  }
+
+  it should "preserve sub-second durations" in {
+    // `getSeconds.seconds` floored these to zero; `toMillis.seconds` inflated them to 500 seconds.
+    ConfigDuration(config, "sub") shouldBe 500.millis
+    ConfigDuration(config, "tiny") shouldBe 1.milli
+  }
+
+  it should "not inflate whole seconds by a factor of a thousand" in {
+    ConfigDuration(config, "whole") should be < 1.minute
+  }
+
+  it should "fall back only when the path is absent" in {
+    ConfigDuration.orElse(config, "absent", 5.seconds) shouldBe 5.seconds
+    ConfigDuration.orElse(config, "sub", 5.seconds) shouldBe 500.millis
+  }
+}


### PR DESCRIPTION
Targets **`1.x`** for a 1.3.1, then forward-merges to `main`. These are the client-side items deferred while the ClickHouse version work went through. All internal — nothing removed from the API.

## Progress subscribers leaked, one per request

`executeRequestInternal` called `progressSource.runForeach` on **every attempt**. That materialises a `BroadcastHub` consumer which nothing ever cancels — so one per request, plus one per retry, each retained for the lifetime of the hub, each filtering every progress event for the rest of the process.

Progress is now subscribed once per *query*, via a `KillSwitch` shut down when the query settles, alongside the existing `progressQueue.complete()`.

## Streamed failures were detected by substring

`content.contains("DB::Exception")`, carrying a FIXME acknowledging that a result row containing that text would be misread as a failure.

I checked whether `X-ClickHouse-Exception-Code` could replace it. **It cannot** — verified against 25.3 that a query failing part way through its result returns:

```
HTTP/1.1 200 OK          <- already sent, cannot be retracted
(no X-ClickHouse-Exception-Code)
{"x":0}{"x":0}...{"exception":"Code: 395. DB::Exception: boom ..."}
```

Once headers have flushed ClickHouse has no way to signal failure except appending to the body. Before they flush, the status is already 4xx/5xx and the other branch handles it — where the header *is* present.

So the body still has to be read, but it is now matched on the shape ClickHouse actually appends — `Code: <n>. DB::Exception` — which closes the false positive and yields the error code for the exception message. New unit tests cover both directions, including the rows-that-mention-it case that used to trip.

## The version probe blocked construction

`serverVersion` was a strict `val` running `Await.result(query("select version()"), 5.seconds)`. Constructing a client stalled the calling thread for up to five seconds and could not be done at all without a reachable server. Now `lazy`, so the block moves to first use — where a caller is asking for the version anyway.

Its fallback was `ClickhouseServerVersion.latest = 22.8.15`, which is neither the latest nor, since #320, a supported version. Renamed to `fallback` (what it always was), set to the oldest LTS we test against, and `latest` **deprecated rather than removed**.

Worth being precise about the impact: only one place gates on the version today — `EmptyFunctionTokenizer`, at 21.8 — and both the old and new fallback sit above it, so **no generated SQL changes**. This removes a trap for the next version gate added above 22.8 rather than fixing a live bug. I'd overstated this earlier.

## Sub-second durations truncated to zero

`getDuration(...).getSeconds.seconds` discarded everything below a second. A health-check interval of `500 millis` became `0` — a tight polling loop — and a sub-second indexer `flush-interval` likewise. Four sites now read `toMillis`.

## Smaller ones

- An unrecognised `connection.type` threw `MatchError` with nothing naming the bad value or the valid ones.
- Cluster discovery hardcoded port 8123 for every discovered host, ignoring a configured port. `system.clusters` reports the *native* port, so the only sensible assumption is that peers expose HTTP where the configured host does.
- `MultiHostBalancer` hardcoded a 5-second ask timeout while `ClusterAwareHostBalancer` used `host-retrieval-timeout` (default **one** second) for the same ask. Both now read that setting, falling back to the old 5 seconds when absent so a balancer built on a bare `ActorSystem` still works.
- `QueryRetry.retryNumber` counted against the *configured* retry total rather than the effective one, so a query overriding `settings.retries` reported the wrong attempt number.

## Not included

No per-query timeout yet. There is still none anywhere — everything inherits pekko-http pool defaults. It needs a new config key and a decision on whether to pair it with ClickHouse's `max_execution_time`, which makes it a feature rather than a fix, so it belongs in 1.4.0.

## Verification

218 dsl tests on Scala 2.13.18 and 3.3.8, 5 new parser tests, scalafmt clean. Locally the two client failures are the pre-existing environmental ones — the SSL test needs `.docker/certs`, and `ClusterConnectionFlowTest` needs the `test_shard_localhost` cluster that `.docker/server-config.xml` defines (modern ClickHouse no longer ships it by default). Both are provided by the compose stack CI uses, so CI here is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Fixes #144 — a 2023 report of exactly this false positive (*"Our data can contains 'DB::Exception'. For example - search history in google."*). The regex now requires the `Code: <n>. DB::Exception` shape ClickHouse actually appends, so a result row that merely contains the phrase is no longer read as a failure.