### PR TITLE
Guard InternalQuery's field inventory before adding clauses

### DIFF
--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/Query.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/Query.scala
@@ -62,8 +62,9 @@ sealed case class InternalQuery(
    */
   def :+>(other: InternalQuery): InternalQuery =
     // Named arguments deliberately: this was positional and passed only 10 of the 11 fields, so `unionAll` silently
-    // defaulted to empty and every merge discarded unions. Named arguments make the next added field a compile error
-    // here rather than a silent drop.
+    // defaulted to empty and every merge discarded unions. Naming them stops that particular slip recurring, but it
+    // does NOT make a newly added field a compile error here -- an unmentioned field just takes its default and
+    // disappears from every merge. `InternalQueryFieldsTest` is what catches that.
     InternalQuery(
       select = select.orElse(other.select),
       from = from.orElse(other.from),

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/InternalQueryFieldsTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/InternalQueryFieldsTest.scala
@@ -1,0 +1,110 @@
+package com.crobox.clickhouse.dsl
+
+import com.crobox.clickhouse.DslTestSpec
+
+import scala.util.{Failure, Success}
+
+/**
+ * Guards the field inventory of [[InternalQuery]] rather than any SQL it produces.
+ *
+ * Adding a clause means adding a field, and only one of the places that field has to be handled is checked by the
+ * compiler: `toRawSql` destructures positionally, so it stops building. `:+>` and `+` both name their arguments, so an
+ * unmentioned field just takes its default -- a merge quietly discards it, and a genuine conflict quietly passes. That
+ * is how `unionAll` came to be dropped from every merge for as long as it existed.
+ *
+ * [[FieldCount]] is the tripwire that sends the author here; the tests below are what actually verify the merge.
+ */
+class InternalQueryFieldsTest extends DslTestSpec {
+
+  /**
+   * Adding a field to [[InternalQuery]] means updating all four of these:
+   *   1. `ClickhouseTokenizerModule.toRawSql` -- its positional pattern stops compiling, so this one is automatic
+   *   2. `InternalQuery.:+>` -- otherwise the field is silently dropped by every merge
+   *   3. `InternalQuery.+` -- otherwise two queries that conflict on it merge without complaint
+   *   4. this constant, plus setting the field in [[populated]] and adding it to [[singleFieldQueries]]
+   */
+  private val FieldCount = 11
+
+  private val condition = col3 isEq "a"
+
+  /** Every field set to something distinguishable from its default. */
+  private val populated = InternalQuery(
+    select = Option(SelectQuery(Seq(itemId))),
+    from = Option(TableFromQuery(TwoTestTable)),
+    prewhere = Option(condition),
+    where = Option(condition),
+    groupBy = Option(GroupByQuery(usingColumns = Seq(itemId))),
+    having = Option(condition),
+    join = Option(JoinQuery(JoinQuery.InnerJoin, TableFromQuery(ThreeTestTable), `using` = Seq(itemId))),
+    orderBy = Seq((itemId, DESC)),
+    limit = Option(Limit(10, 5)),
+    limitBy = Option(LimitBy(1, 0, Seq(itemId))),
+    unionAll = Seq(select(itemId).from(OneTestTable))
+  )
+
+  /** One query per field, carrying only that field, so a missing conflict check shows up as a merge that succeeds. */
+  private val singleFieldQueries: Seq[(String, InternalQuery)] = Seq(
+    "select"   -> InternalQuery(select = populated.select),
+    "from"     -> InternalQuery(from = populated.from),
+    "prewhere" -> InternalQuery(prewhere = populated.prewhere),
+    "where"    -> InternalQuery(where = populated.where),
+    "groupBy"  -> InternalQuery(groupBy = populated.groupBy),
+    "having"   -> InternalQuery(having = populated.having),
+    "join"     -> InternalQuery(join = populated.join),
+    "orderBy"  -> InternalQuery(orderBy = populated.orderBy),
+    "limit"    -> InternalQuery(limit = populated.limit),
+    "limitBy"  -> InternalQuery(limitBy = populated.limitBy),
+    "unionAll" -> InternalQuery(unionAll = populated.unionAll)
+  )
+
+  /** Names the fields that differ, because an InternalQuery's `toString` is far too long to diff by eye. */
+  private def differingFields(actual: InternalQuery, expected: InternalQuery): Seq[String] =
+    expected.productElementNames.toSeq.zipWithIndex.collect {
+      case (name, i) if actual.productElement(i) != expected.productElement(i) =>
+        s"$name (got ${actual.productElement(i)}, expected ${expected.productElement(i)})"
+    }
+
+  it should "not gain a field without every merge path being updated" in {
+    withClue(
+      "InternalQuery's field count changed. Read the comment on FieldCount: the new field also has to be handled in " +
+        ":+> and in +, and set in `populated` and `singleFieldQueries`, or merging will silently drop it.\n"
+    ) {
+      InternalQuery().productArity shouldBe FieldCount
+    }
+    singleFieldQueries.map(_._1) should contain theSameElementsAs populated.productElementNames.toSeq
+  }
+
+  it should "carry every field through a merge, from either side" in {
+    withClue("dropped when merging into an empty query: ") {
+      differingFields(populated :+> InternalQuery(), populated) shouldBe empty
+    }
+    withClue("dropped when an empty query is merged into: ") {
+      differingFields(InternalQuery() :+> populated, populated) shouldBe empty
+    }
+  }
+
+  it should "detect a conflict on any single field" in {
+    val unchecked = singleFieldQueries.collect { case (name, query) if (query + query).isSuccess => name }
+    withClue(s"these fields merged without complaint despite conflicting, so + is missing a check: $unchecked\n") {
+      unchecked shouldBe empty
+    }
+  }
+
+  it should "merge cleanly when the two sides share no field" in {
+    val left  = InternalQuery(select = populated.select, where = populated.where)
+    val right = InternalQuery(from = populated.from, limit = populated.limit)
+    left + right match {
+      case Success(merged) =>
+        differingFields(
+          merged,
+          InternalQuery(
+            select = populated.select,
+            from = populated.from,
+            where = populated.where,
+            limit = populated.limit
+          )
+        ) shouldBe empty
+      case Failure(error) => fail(s"disjoint parts should merge, got: ${error.getMessage}")
+    }
+  }
+}


### PR DESCRIPTION
Phase 0 of #328. No behaviour change — one corrected comment and one new test file. It lands first because every later phase adds `InternalQuery` fields, and doing that is currently less safe than it looks.

## The problem

#328 notes that only the tokenizer arm is compiler-checked. That's right, and the consequences are worse than it sounds:

| Place a new field must be handled | What happens if you forget |
|---|---|
| `toRawSql`'s positional pattern | **compile error** — caught for you |
| `InternalQuery.:+>` | silently takes its default; every merge drops the field |
| `InternalQuery.+` | no conflict check; two queries that clash merge anyway |

This is not hypothetical. `unionAll` was dropped from every merge for as long as the field existed, because `:+>` was positional and passed only 10 of 11 arguments.

The comment on `:+>` claimed that naming the arguments made the next added field *"a compile error here rather than a silent drop"*. It doesn't — named arguments with defaults compile fine. That's corrected, and the guarantee it promised is now actually provided by a test.

## The guard

`InternalQueryFieldsTest` layers four checks:

- **Arity canary** — fires when the field count changes. Its message names the four places to update, so the tripwire also carries the instructions.
- **Merge round-trip**, both directions, reporting *which field* was dropped by name. An `InternalQuery` `toString` is ~1KB, so a bare `shouldBe` produces two walls of text with the difference buried; this prints `settings (got List(), expected List((max_threads,1)))`.
- **Per-field conflict check** — one query per field carrying only that field, asserting `q + q` fails. Names any field `+` forgot to guard.
- **Disjoint merge** — so the conflict check can't pass trivially by rejecting everything.

The canary is deliberately the only thing that fires on its own. The other three need the new field set in `populated` and `singleFieldQueries`, which is what the canary's message tells the author to do.

## Verification

Green tests prove nothing about a guard, so I added a twelfth field and watched the chain fire in order:

1. `toRawSql` fails to compile — `wrong number of arguments for pattern`.
2. Patch the pattern minimally, as an author would to get building. Canary fails with its guidance message.
3. Follow that guidance (update the constant, `populated`, `singleFieldQueries`) but leave `:+>` and `+` alone — round-trip fails naming the dropped field, and the conflict test reports `List(settings)`.
4. Fix `:+>` and `+` — green.

Then reverted the experiment.

- `scalafmtCheckAll` clean; `+compile +Test/compile +It/compile` green on 2.13 and 3.3.
- 244 unit tests (240 + 4 new) and 121 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)