### PR TITLE
Add ARRAY JOIN, SAMPLE, query-level SETTINGS and PASTE JOIN

### DIFF
--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/QueryIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/QueryIT.scala
@@ -18,6 +18,29 @@ class QueryIT extends DslITSpec {
     Seq(Table1Entry(oneId), Table1Entry(randomUUID), Table1Entry(randomUUID), Table1Entry(randomUUID))
   override val table2Entries = Seq(Table2Entry(oneId, randomString, Random.nextInt(1000) + 1, randomString, None))
 
+  // The clause has always rendered; until QueryResult carried `totals` the extra row the server sends was discarded.
+  it should "read back the row GROUP BY WITH TOTALS adds" in {
+    case class Totals(itemId: String, total: Int)
+    implicit val totalsFormat: RootJsonFormat[Totals] =
+      jsonFormat[String, Int, Totals](Totals.apply, "item_id", "total")
+
+    // toInt32, because count() is a UInt64 and this client pins output_format_json_quote_64bit_integers = 1, so a
+    // bare count() arrives as a JSON string.
+    val query  = select(itemId, toInt32(count()) as "total").from(TwoTestTable).groupBy(itemId).withTotals
+    val result = queryExecutor.execute[Totals](query).futureValue
+
+    result.totals.map(_.total) should be(Some(result.rows.map(_.total).sum))
+  }
+
+  it should "leave totals empty for a query that did not ask for them" in {
+    case class Totals(itemId: String, total: Int)
+    implicit val totalsFormat: RootJsonFormat[Totals] =
+      jsonFormat[String, Int, Totals](Totals.apply, "item_id", "total")
+
+    val query = select(itemId, toInt32(count()) as "total").from(TwoTestTable).groupBy(itemId)
+    queryExecutor.execute[Totals](query).futureValue.totals should be(None)
+  }
+
   it should "map as result" in {
 
     case class Result(columnResult: String, empty: Int)

--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
@@ -159,7 +159,33 @@ class SqlValidationITSpec extends DslITSpec {
     )
   )
 
-  private val constructs: Seq[Construct] = astConstructs ++ joinShapes
+  /**
+   * Whole-query clause shapes, so they live here rather than in [[astConstructs]] -- the coverage ratchet matches those
+   * names against the declarations in `dsl/column`, and a clause has no node there.
+   */
+  private val clauseShapes: Seq[Construct] = Seq(
+    Construct("array join", select(shieldId).from(OneTestTable).withArrayJoin(numbers as "n")),
+    Construct("left array join", select(shieldId).from(OneTestTable).withLeftArrayJoin(numbers as "n")),
+    Construct(
+      "array join alongside a join, where it has to follow the left table's alias",
+      select(shieldId as itemId)
+        .from(OneTestTable)
+        .withArrayJoin(numbers as "n")
+        .join(JoinQuery.InnerJoin, TwoTestTable) using itemId
+    ),
+    Construct("query-level settings", select(shieldId).from(OneTestTable).settings("max_threads" -> "1")),
+    Construct(
+      "settings before a union",
+      select(shieldId).from(OneTestTable).settings("max_threads" -> "1").unionAll(select(shieldId).from(OneTestTable))
+    ),
+    Construct("paste join", select(itemId).from(TwoTestTable).join(JoinQuery.PasteJoin, ThreeTestTable)),
+    // Syntax only: the IT tables are Engine.Memory, and resolving SAMPLE against a table with no sampling key fails
+    // with SAMPLING_NOT_SUPPORTED before the analyzer gets to the clause itself.
+    Construct("sample", select(shieldId).from(OneTestTable).sample(0.1), Syntax),
+    Construct("sample with an offset", select(shieldId).from(OneTestTable).sample(0.1, Option(0.5)), Syntax)
+  )
+
+  private val constructs: Seq[Construct] = astConstructs ++ joinShapes ++ clauseShapes
 
   /** `EXPLAIN QUERY TREE` needs the analyzer, the default since 24.3 and so on every supported server. */
   private def explainOf(level: ValidationLevel): String = level match {

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/FromQuery.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/FromQuery.scala
@@ -1,16 +1,36 @@
 package com.crobox.clickhouse.dsl
 
+/**
+ * How much of a table to read.
+ *
+ * `rate` is either a fraction in (0, 1] or a row count above 1, matching ClickHouse's own overloading of the argument.
+ * Only meaningful on a table whose engine declares a `SAMPLE BY` expression -- the server rejects it otherwise with
+ * SAMPLING_NOT_SUPPORTED.
+ */
+case class Sample(rate: Double, offset: Option[Double] = None)
+
 sealed trait FromQuery extends Query with OperationalQuery {
   override val internalQuery: InternalQuery = InternalQuery(from = Some(this))
   val alias: Option[String]
   val finalized: Boolean
+  val sampling: Option[Sample]
 }
 
 sealed case class InnerFromQuery(innerQuery: OperationalQuery, alias: Option[String] = None) extends FromQuery {
 
   /** Queries can never have 'final' clause: Illegal FINAL */
   override val finalized = false
+
+  /**
+   * Nor SAMPLE, which reads a table's sampling key. Named like `finalized`, so it cannot collide with
+   * OperationalQuery's `sample(rate, offset)`.
+   */
+  override val sampling: Option[Sample] = None
 }
 
-sealed case class TableFromQuery[T <: Table](table: T, alias: Option[String] = None, finalized: Boolean = false)
-    extends FromQuery
+sealed case class TableFromQuery[T <: Table](
+    table: T,
+    alias: Option[String] = None,
+    finalized: Boolean = false,
+    sampling: Option[Sample] = None
+) extends FromQuery

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/JoinQuery.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/JoinQuery.scala
@@ -16,6 +16,9 @@ object JoinQuery {
   case object FullOuterJoin  extends JoinType
   case object CrossJoin      extends JoinType
 
+  /** Concatenates by row position rather than by key, so it takes neither ON nor USING. */
+  case object PasteJoin extends JoinType
+
   // CUSTOM CLICKHOUSE JOIN
   case object AllInnerJoin  extends JoinType
   case object AllLeftJoin   extends JoinType

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/OperationalQuery.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/OperationalQuery.scala
@@ -75,6 +75,55 @@ trait OperationalQuery extends Query {
 
   def asFinal(`final`: Boolean): OperationalQuery = if (`final`) asFinal else this
 
+  /**
+   * `SAMPLE rate [OFFSET offset]`, where `rate` is a fraction in (0, 1] or a row count above 1.
+   *
+   * Only valid on a table whose engine declares a `SAMPLE BY` expression; the server rejects it otherwise. Rejected
+   * here on a subquery for the same reason [[asFinal]] is -- there is no sampling key to read.
+   */
+  def sample(rate: Double, offset: Option[Double] = None): OperationalQuery =
+    OperationalQuery(
+      internalQuery.from
+        .map {
+          case _: InnerFromQuery =>
+            throw new IllegalArgumentException("It's ILLEGAL to set SAMPLE on a (sub)query FROM query")
+          case table: TableFromQuery[_] =>
+            internalQuery.copy(from = Option(table.copy(sampling = Option(Sample(rate, offset)))))
+        }
+        .getOrElse(internalQuery)
+    )
+
+  /**
+   * `ARRAY JOIN`, unfolding each array column into one row per element. Rows with an empty array are dropped.
+   *
+   * Named `withArrayJoin` rather than `arrayJoin`, matching [[withRollup]] and [[withTotals]]: an inherited member
+   * shadows an imported one, so an `arrayJoin` here would hide the `arrayJoin` *function* from every subclass of this
+   * trait.
+   */
+  def withArrayJoin(columns: Column*): OperationalQuery =
+    addArrayJoin(columns, left = false)
+
+  /** `LEFT ARRAY JOIN`, which keeps a row whose array is empty rather than dropping it. */
+  def withLeftArrayJoin(columns: Column*): OperationalQuery =
+    addArrayJoin(columns, left = true)
+
+  private def addArrayJoin(columns: Seq[Column], left: Boolean): OperationalQuery = {
+    val existing = internalQuery.arrayJoin.map(_.columns).getOrElse(Seq.empty)
+    OperationalQuery(
+      internalQuery.copy(arrayJoin = Option(ArrayJoinQuery(existing ++ columns, left)))
+    )
+  }
+
+  /**
+   * Query-level `SETTINGS`, which unlike `QuerySettings` applies to this query alone rather than the whole HTTP
+   * request, and so can differ per subquery. Values are emitted verbatim: a string setting has to arrive quoted, as in
+   * `settings("log_comment" -> "'hi'")`.
+   */
+  def settings(setting: (String, String), settings: (String, String)*): OperationalQuery =
+    OperationalQuery(
+      internalQuery.copy(settings = internalQuery.settings ++ (setting +: settings))
+    )
+
   def groupBy(columns: Column*): OperationalQuery = {
     val internalGroupBy = internalQuery.groupBy.getOrElse(GroupByQuery())
     val newGroupBy      = Some(internalGroupBy.copy(usingColumns = internalGroupBy.usingColumns ++ columns))

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/Query.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/Query.scala
@@ -23,6 +23,13 @@ case class Limit(size: Long = 100, offset: Long = 0)
 
 case class LimitBy(limit: Long, offset: Long = 0, expressions: Seq[Column])
 
+/**
+ * `ARRAY JOIN`, which unfolds an array column into one row per element.
+ *
+ * `left` selects `LEFT ARRAY JOIN`, which keeps rows whose array is empty instead of dropping them.
+ */
+case class ArrayJoinQuery(columns: Seq[Column], left: Boolean = false)
+
 trait OrderingDirection
 
 case object ASC extends OrderingDirection
@@ -37,10 +44,14 @@ sealed case class InternalQuery(
     groupBy: Option[GroupByQuery] = None,
     having: Option[TableColumn[Boolean]] = None,
     join: Option[JoinQuery] = None,
+    arrayJoin: Option[ArrayJoinQuery] = None,
     orderBy: Seq[(Column, OrderingDirection)] = Seq.empty,
     limit: Option[Limit] = None,
     limitBy: Option[LimitBy] = None,
-    unionAll: Seq[OperationalQuery] = Seq.empty
+    unionAll: Seq[OperationalQuery] = Seq.empty,
+    // Ordered rather than a Map: map iteration order is unspecified, which would make the emitted SQL vary between
+    // runs for the same query.
+    settings: Seq[(String, String)] = Seq.empty
 ) {
 
   def isValid: Boolean = {
@@ -73,10 +84,12 @@ sealed case class InternalQuery(
       groupBy = groupBy.orElse(other.groupBy),
       having = having.orElse(other.having),
       join = join.orElse(other.join),
+      arrayJoin = arrayJoin.orElse(other.arrayJoin),
       orderBy = if (orderBy.nonEmpty) orderBy else other.orderBy,
       limit = limit.orElse(other.limit),
       limitBy = limitBy.orElse(other.limitBy),
-      unionAll = if (unionAll.nonEmpty) unionAll else other.unionAll
+      unionAll = if (unionAll.nonEmpty) unionAll else other.unionAll,
+      settings = if (settings.nonEmpty) settings else other.settings
     )
 
   /**
@@ -114,10 +127,12 @@ sealed case class InternalQuery(
     noConflict("groupBy", groupBy, other.groupBy)
     noConflict("having", having, other.having)
     noConflict("join", join, other.join)
+    noConflict("arrayJoin", arrayJoin, other.arrayJoin)
     noSeqConflict("orderBy", orderBy, other.orderBy)
     noConflict("limit", limit, other.limit)
     noConflict("limitBy", limitBy, other.limitBy)
     noSeqConflict("unionAll", unionAll, other.unionAll)
+    noSeqConflict("settings", settings, other.settings)
 
     :+>(other)
   }

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/execution/package.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/execution/package.scala
@@ -10,7 +10,17 @@ package object execution {
 
   case class ResultMeta(columnTypes: Seq[ResultColumnType])
 
-  case class QueryResult[V](rows: Seq[V], meta: Option[ResultMeta] = None, statistic: Option[Statistic] = None) {
+  /**
+   * @param totals
+   *   the single aggregate row `GROUP BY ... WITH TOTALS` adds to the response, shaped like any other row. Empty for
+   *   every query that did not ask for it.
+   */
+  case class QueryResult[V](
+      rows: Seq[V],
+      meta: Option[ResultMeta] = None,
+      statistic: Option[Statistic] = None,
+      totals: Option[V] = None
+  ) {
 
     def size: Int = rows.size
   }
@@ -45,7 +55,9 @@ package object execution {
         case Seq(JsNumber(limit), JsNumber(rowsRead)) => Some(Statistic(rowsRead.longValue, limit.longValue))
         case _                                        => None
       }
-      QueryResult(rows, meta, statistic)
+      // Present only for `WITH TOTALS`, and read with the same reader as the rows since the server shapes it as one.
+      val totals = jsObject.fields.get("totals").map(_.convertTo[V])
+      QueryResult(rows, meta, statistic, totals)
     }
   }
 }

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -130,11 +130,31 @@ trait ClickhouseTokenizerModule
 
   private[language] def toRawSql(query: InternalQuery)(implicit ctx: TokenizeContext): String =
     query match {
-      case InternalQuery(select, from, prewhere, where, groupBy, having, join, orderBy, limit, limitBy, union) =>
+      // Clause order follows https://clickhouse.com/docs/sql-reference/statements/select -- SAMPLE is rendered by
+      // tokenizeFrom, since it belongs to the table expression alongside FINAL.
+      case InternalQuery(
+            select,
+            from,
+            prewhere,
+            where,
+            groupBy,
+            having,
+            join,
+            arrayJoin,
+            orderBy,
+            limit,
+            limitBy,
+            union,
+            settings
+          ) =>
+        // The left table's alias is emitted by tokenizeJoin, and ARRAY JOIN has to land between that alias and the
+        // JOIN keyword, so it is threaded through rather than placed here. Without a join there is no alias to follow.
+        val arrayJoinSql = tokenizeArrayJoin(arrayJoin)
         Seq(
           tokenizeSelect(select),
           tokenizeFrom(from),
-          tokenizeJoin(select, from, join),
+          if (join.isDefined) "" else arrayJoinSql,
+          tokenizeJoin(select, from, join, arrayJoinSql),
           tokenizeFiltering(prewhere, "PREWHERE"),
           tokenizeFiltering(where, "WHERE"),
           tokenizeGroupBy(groupBy),
@@ -142,9 +162,28 @@ trait ClickhouseTokenizerModule
           tokenizeOrderBy(orderBy),
           tokenizeLimitBy(limitBy),
           tokenizeLimit(limit),
+          tokenizeSettings(settings),
           tokenizeUnionAll(union)
         ).filter(_.nonEmpty).mkString(" ")
     }
+
+  private def tokenizeArrayJoin(arrayJoin: Option[ArrayJoinQuery])(implicit ctx: TokenizeContext): String =
+    arrayJoin match {
+      case Some(ArrayJoinQuery(columns, _)) if columns.isEmpty => ""
+      case Some(ArrayJoinQuery(columns, left))                 =>
+        val keyword = if (left) "LEFT ARRAY JOIN" else "ARRAY JOIN"
+        // tokenizeColumns, not tokenizeColumnsAliased: ARRAY JOIN introduces the alias rather than referring to one.
+        s"$keyword ${tokenizeColumns(columns)}"
+      case None => ""
+    }
+
+  /**
+   * Query-level `SETTINGS`, which is what makes a setting expressible per subquery -- `QuerySettings` can only apply to
+   * a whole HTTP request. Values are emitted verbatim, so a string setting has to arrive already quoted.
+   */
+  private def tokenizeSettings(settings: Seq[(String, String)]): String =
+    if (settings.isEmpty) ""
+    else settings.map { case (key, value) => s"$key = $value" }.mkString("SETTINGS ", Tokens.Delimiter, "")
 
   private def tokenizeUnionAll(unions: Seq[OperationalQuery])(implicit ctx: TokenizeContext): String =
     if (unions.nonEmpty) unions.map(q => s"UNION ALL ${toRawSql(q.internalQuery)}").mkString(" ") else ""
@@ -177,7 +216,15 @@ trait ClickhouseTokenizerModule
     val prefix = if (withPrefix) "FROM" else ""
     val alias  = from.flatMap(_.alias.map(s => " AS " + ClickhouseStatement.quoteIdentifier(s))).getOrElse("")
     val asF    = if (from.exists(_.finalized)) " FINAL" else ""
-    s"$prefix $fromClause $alias $asF".trim
+    // After FINAL, not before: `SAMPLE 0.5 FINAL` is a syntax error.
+    val sample = from.flatMap(_.sampling).map(tokenizeSample).getOrElse("")
+    s"$prefix $fromClause $alias $asF $sample".trim
+  }
+
+  private def tokenizeSample(sample: Sample): String = {
+    def number(value: Double): String =
+      if (value == value.floor && value.abs < 1e15) value.toLong.toString else value.toString
+    s"SAMPLE ${number(sample.rate)}" + sample.offset.map(offset => s" OFFSET ${number(offset)}").getOrElse("")
   }
 
   protected def tokenizeColumn(column: Column)(implicit ctx: TokenizeContext): String = {
@@ -308,7 +355,12 @@ trait ClickhouseTokenizerModule
   }
 
   //  Table joins are tokenized as select * because of https://github.com/yandex/ClickHouse/issues/635
-  private def tokenizeJoin(select: Option[SelectQuery], from: Option[FromQuery], join: Option[JoinQuery])(implicit
+  private def tokenizeJoin(
+      select: Option[SelectQuery],
+      from: Option[FromQuery],
+      join: Option[JoinQuery],
+      arrayJoin: String
+  )(implicit
       ctx: TokenizeContext
   ): String =
     join match {
@@ -327,6 +379,7 @@ trait ClickhouseTokenizerModule
         val rightAlias = s"AS ${ctx.rightAlias(query.other.alias, joinNr)}"
 
         s""" $leftAlias
+           | $arrayJoin
            | ${if (query.global) "GLOBAL " else ""}
            | ${tokenizeJoinType(query.joinType)}
            | $right $rightAlias
@@ -345,9 +398,10 @@ trait ClickhouseTokenizerModule
       case _           => false
     }
     query.joinType match {
-      case CrossJoin =>
-        require(`using`.isEmpty, "When using CrossJoin, no using columns should be provided")
-        require(query.on.isEmpty, "When using CrossJoin, no on conditions should be provided")
+      case CrossJoin | PasteJoin =>
+        val name = if (query.joinType == PasteJoin) "PasteJoin" else "CrossJoin"
+        require(`using`.isEmpty, s"When using $name, no using columns should be provided")
+        require(query.on.isEmpty, s"When using $name, no on conditions should be provided")
         ""
       case _ =>
         require(`using`.nonEmpty || query.on.nonEmpty, s"No USING or ON provided for joinType: ${query.joinType}")
@@ -427,6 +481,7 @@ trait ClickhouseTokenizerModule
       case RightOuterJoin => "RIGHT OUTER JOIN"
       case FullOuterJoin  => "FULL OUTER JOIN"
       case CrossJoin      => "CROSS JOIN"
+      case PasteJoin      => "PASTE JOIN"
 
       // custom clickhouse
       case AllInnerJoin  => "ALL INNER JOIN"

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/InternalQueryFieldsTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/InternalQueryFieldsTest.scala
@@ -23,7 +23,7 @@ class InternalQueryFieldsTest extends DslTestSpec {
    *   3. `InternalQuery.+` -- otherwise two queries that conflict on it merge without complaint
    *   4. this constant, plus setting the field in [[populated]] and adding it to [[singleFieldQueries]]
    */
-  private val FieldCount = 11
+  private val FieldCount = 13
 
   private val condition = col3 isEq "a"
 
@@ -36,25 +36,29 @@ class InternalQueryFieldsTest extends DslTestSpec {
     groupBy = Option(GroupByQuery(usingColumns = Seq(itemId))),
     having = Option(condition),
     join = Option(JoinQuery(JoinQuery.InnerJoin, TableFromQuery(ThreeTestTable), `using` = Seq(itemId))),
+    arrayJoin = Option(ArrayJoinQuery(Seq(numbers))),
     orderBy = Seq((itemId, DESC)),
     limit = Option(Limit(10, 5)),
     limitBy = Option(LimitBy(1, 0, Seq(itemId))),
-    unionAll = Seq(select(itemId).from(OneTestTable))
+    unionAll = Seq(select(itemId).from(OneTestTable)),
+    settings = Seq("max_threads" -> "1")
   )
 
   /** One query per field, carrying only that field, so a missing conflict check shows up as a merge that succeeds. */
   private val singleFieldQueries: Seq[(String, InternalQuery)] = Seq(
-    "select"   -> InternalQuery(select = populated.select),
-    "from"     -> InternalQuery(from = populated.from),
-    "prewhere" -> InternalQuery(prewhere = populated.prewhere),
-    "where"    -> InternalQuery(where = populated.where),
-    "groupBy"  -> InternalQuery(groupBy = populated.groupBy),
-    "having"   -> InternalQuery(having = populated.having),
-    "join"     -> InternalQuery(join = populated.join),
-    "orderBy"  -> InternalQuery(orderBy = populated.orderBy),
-    "limit"    -> InternalQuery(limit = populated.limit),
-    "limitBy"  -> InternalQuery(limitBy = populated.limitBy),
-    "unionAll" -> InternalQuery(unionAll = populated.unionAll)
+    "select"    -> InternalQuery(select = populated.select),
+    "from"      -> InternalQuery(from = populated.from),
+    "prewhere"  -> InternalQuery(prewhere = populated.prewhere),
+    "where"     -> InternalQuery(where = populated.where),
+    "groupBy"   -> InternalQuery(groupBy = populated.groupBy),
+    "having"    -> InternalQuery(having = populated.having),
+    "join"      -> InternalQuery(join = populated.join),
+    "arrayJoin" -> InternalQuery(arrayJoin = populated.arrayJoin),
+    "orderBy"   -> InternalQuery(orderBy = populated.orderBy),
+    "limit"     -> InternalQuery(limit = populated.limit),
+    "limitBy"   -> InternalQuery(limitBy = populated.limitBy),
+    "unionAll"  -> InternalQuery(unionAll = populated.unionAll),
+    "settings"  -> InternalQuery(settings = populated.settings)
   )
 
   /** Names the fields that differ, because an InternalQuery's `toString` is far too long to diff by eye. */

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/QueryClausesTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/QueryClausesTest.scala
@@ -1,0 +1,150 @@
+package com.crobox.clickhouse.dsl
+
+import com.crobox.clickhouse.DslTestSpec
+
+/**
+ * Clause-level rendering: that each clause appears at all, and in the position ClickHouse's grammar requires. Position
+ * is the part worth asserting -- a clause emitted in the wrong slot still type-checks and still reads plausibly, and
+ * `SAMPLE 0.5 FINAL` is a syntax error where `FINAL SAMPLE 0.5` is not.
+ *
+ * https://clickhouse.com/docs/sql-reference/statements/select
+ */
+class QueryClausesTest extends DslTestSpec {
+
+  private def sql(query: OperationalQuery): String = toSql(query.internalQuery, None)
+
+  "ARRAY JOIN" should "unfold a single column" in {
+    sql(select(shieldId).from(OneTestTable).withArrayJoin(numbers)) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} ARRAY JOIN numbers"
+    )
+  }
+
+  it should "render LEFT ARRAY JOIN" in {
+    sql(select(shieldId).from(OneTestTable).withLeftArrayJoin(numbers)) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} LEFT ARRAY JOIN numbers"
+    )
+  }
+
+  it should "carry an alias, which is how the unfolded column gets named" in {
+    sql(select(shieldId).from(OneTestTable).withArrayJoin(numbers as "n")) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} ARRAY JOIN numbers AS n"
+    )
+  }
+
+  it should "accumulate columns across calls rather than replacing them" in {
+    val query = select(shieldId).from(OneTestTable).withArrayJoin(numbers as "n").withArrayJoin(numbers as "m")
+    sql(query) should matchSQL(s"SELECT shield_id FROM ${OneTestTable.quoted} ARRAY JOIN numbers AS n, numbers AS m")
+  }
+
+  it should "sit between FROM and WHERE" in {
+    val query = select(shieldId).from(OneTestTable).withArrayJoin(numbers).where(shieldId isEq "a")
+    sql(query) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} ARRAY JOIN numbers WHERE shield_id = 'a'"
+    )
+  }
+
+  // Uses a real Array column, so this asserts a query the server also accepts -- see the matching entry in
+  // SqlValidationITSpec. The alias has to land on the FROM table before ARRAY JOIN, not after it.
+  it should "sit after the left table's alias and before JOIN" in {
+    val query = select(shieldId as itemId)
+      .from(OneTestTable)
+      .withArrayJoin(numbers as "n")
+      .join(JoinQuery.InnerJoin, TwoTestTable) using itemId
+    sql(query) should matchSQL(
+      s"SELECT shield_id AS item_id FROM ${OneTestTable.quoted} AS L1 ARRAY JOIN numbers AS n " +
+        s"INNER JOIN (SELECT * FROM ${TwoTestTable.quoted}) AS R1 ON L1.shield_id = R1.item_id"
+    )
+  }
+
+  it should "render nothing when no columns were given" in {
+    sql(select(shieldId).from(OneTestTable).withArrayJoin()) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted}"
+    )
+  }
+
+  "SAMPLE" should "render a fractional rate" in {
+    sql(select(shieldId).from(OneTestTable).sample(0.1)) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} SAMPLE 0.1"
+    )
+  }
+
+  it should "render a row count without a spurious decimal point" in {
+    sql(select(shieldId).from(OneTestTable).sample(1000)) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} SAMPLE 1000"
+    )
+  }
+
+  it should "render an offset" in {
+    sql(select(shieldId).from(OneTestTable).sample(0.1, Option(0.5))) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} SAMPLE 0.1 OFFSET 0.5"
+    )
+  }
+
+  // `SAMPLE 0.5 FINAL` is rejected by the server; only this order parses.
+  it should "come after FINAL, not before" in {
+    sql(select(shieldId).from(OneTestTable).asFinal.sample(0.1)) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} FINAL SAMPLE 0.1"
+    )
+  }
+
+  it should "be refused on a subquery, which has no sampling key" in {
+    an[IllegalArgumentException] should be thrownBy
+    select(shieldId).from(select(shieldId).from(OneTestTable)).sample(0.1)
+  }
+
+  "SETTINGS" should "render a single setting" in {
+    sql(select(shieldId).from(OneTestTable).settings("max_threads" -> "1")) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} SETTINGS max_threads = 1"
+    )
+  }
+
+  it should "render several in the order given" in {
+    val query = select(shieldId).from(OneTestTable).settings("max_threads" -> "1", "max_block_size" -> "100")
+    sql(query) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} SETTINGS max_threads = 1, max_block_size = 100"
+    )
+  }
+
+  it should "come after LIMIT" in {
+    val query = select(shieldId).from(OneTestTable).limit(Option(Limit(10))).settings("max_threads" -> "1")
+    sql(query) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} LIMIT 0, 10 SETTINGS max_threads = 1"
+    )
+  }
+
+  // The clause has to land inside the query it belongs to, not after the union of both.
+  it should "come before UNION ALL" in {
+    val query = select(shieldId)
+      .from(OneTestTable)
+      .settings("max_threads" -> "1")
+      .unionAll(select(shieldId).from(OneTestTable))
+    sql(query) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} SETTINGS max_threads = 1 " +
+        s"UNION ALL SELECT shield_id FROM ${OneTestTable.quoted}"
+    )
+  }
+
+  it should "come before FORMAT" in {
+    val query = select(shieldId).from(OneTestTable).settings("max_threads" -> "1")
+    toSql(query.internalQuery) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} SETTINGS max_threads = 1 FORMAT JSON"
+    )
+  }
+
+  "PASTE JOIN" should "render without join keys" in {
+    val query = select(itemId).from(TwoTestTable).join(JoinQuery.PasteJoin, ThreeTestTable)
+    sql(query) should matchSQL(
+      s"SELECT item_id FROM ${TwoTestTable.quoted} AS L1 PASTE JOIN (SELECT * FROM ${ThreeTestTable.quoted}) AS R1"
+    )
+  }
+
+  it should "refuse USING, which it concatenates by position instead of" in {
+    val query = select(itemId).from(TwoTestTable).join(JoinQuery.PasteJoin, ThreeTestTable) using itemId
+    an[IllegalArgumentException] should be thrownBy sql(query)
+  }
+
+  it should "refuse ON" in {
+    val query = select(itemId).from(TwoTestTable).join(JoinQuery.PasteJoin, ThreeTestTable) on itemId
+    an[IllegalArgumentException] should be thrownBy sql(query)
+  }
+}


### PR DESCRIPTION
Phase 1 of #328. Four clauses that were unreachable from the DSL, plus the return half of `WITH TOTALS`. Clause positions follow the [documented skeleton](https://clickhouse.com/docs/sql-reference/statements/select), and every one is checked against a live server through `SqlValidationITSpec`.

## What's added

| Clause | Where it's modelled | DSL |
|---|---|---|
| `ARRAY JOIN` / `LEFT ARRAY JOIN` | `InternalQuery.arrayJoin` | `withArrayJoin` / `withLeftArrayJoin` |
| `SAMPLE k [OFFSET m]` | `TableFromQuery.sampling` | `sample(rate, offset)` |
| query-level `SETTINGS` | `InternalQuery.settings` | `settings("k" -> "v", …)` |
| `PASTE JOIN` | `JoinQuery.PasteJoin` | `join(JoinQuery.PasteJoin, …)` |
| `WITH TOTALS` result row | `QueryResult.totals` | — clause already rendered; the row was discarded |

Three modelling decisions, each forced by something concrete rather than taste:

- **`withArrayJoin`, not `arrayJoin`.** An inherited member shadows an imported one, so an `arrayJoin` method on `OperationalQuery` hid the existing `arrayJoin` *function* from every subclass of the trait — including the test specs, which stopped compiling. The `with*` prefix matches the existing `withRollup`/`withCube`/`withTotals`.
- **`SAMPLE` belongs to the table expression, not the query.** It reads a table's sampling key and is illegal on a subquery, exactly like `FINAL`. The field is `sampling` rather than `sample` so it cannot collide with the `sample(rate, offset)` method — the same reason the FINAL field is called `finalized`.
- **`SETTINGS` is an ordered `Seq`, not a `Map`.** Map iteration order is unspecified, which would make the same query emit different SQL between runs and any golden test flaky.

## Two bugs the tests caught that the compiler couldn't

Both are the failure mode #328 describes: a tokenizer arm that type-checks and reads plausibly while being wrong.

**Position.** `ARRAY JOIN` must sit between the left table's alias and the `JOIN` keyword. That alias is emitted by `tokenizeJoin`, so placing the clause between `tokenizeFrom` and `tokenizeJoin` put it *before* the alias:

```sql
-- first attempt
FROM t ARRAY JOIN column_1 AS L1 INNER JOIN (…) AS R1 USING item_id
-- correct
FROM t AS L1 ARRAY JOIN numbers AS n INNER JOIN (…) AS R1 ON …
```

Threaded through `tokenizeJoin` instead. I checked whether the server accepts `ARRAY JOIN` *after* the join clause — it does, which would have been the simpler fix — but the documented order is before it, so this follows the grammar rather than an undocumented tolerance.

**Alias form.** `ARRAY JOIN` *introduces* its aliases rather than referring to them, so it needs `tokenizeColumns`. `tokenizeColumnsAliased` emits only the alias, turning `ARRAY JOIN numbers AS n` into `ARRAY JOIN n` — which parses, and is wrong.

## Phase 0 earned its place

Field count goes 11 → 13. The arity canary from #345 fired immediately, and once I'd followed its instructions the merge round-trip and per-field conflict tests confirmed `arrayJoin` and `settings` were wired into both `:+>` and `+`. Without it both fields would have been silently dropped from every merge, with nothing failing.

## Verification

- `scalafmtCheckAll` clean; `+compile +Test/compile +It/compile` green on 2.13 and 3.3.
- **264 unit tests** (+20 clause tests, asserting emitted text *and* clause position) and **123 integration tests** (+2 for `totals`).
- 8 new `SqlValidationITSpec` entries, in a `clauseShapes` list rather than `astConstructs` — the coverage ratchet matches those names against `dsl/column` declarations, and a clause has no node there.
- `SAMPLE` is registered at `Syntax` level only: the IT tables are `Engine.Memory`, and resolving `SAMPLE` against a table with no sampling key fails with `SAMPLING_NOT_SUPPORTED` before the analyzer reaches the clause. That is what the `Syntax` level exists for.
- Every clause was confirmed against a live 25.3 server before implementation, including that `SAMPLE 0.5 FINAL` is a syntax error while `FINAL SAMPLE 0.5` is not — hence a test pinning that order.

Rebased onto `main` after #345 merged, so this is a single commit on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)