### PR TITLE
Add the WITH clause, in all three of ClickHouse's forms

### DIFF
--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/QueryIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/QueryIT.scala
@@ -41,6 +41,31 @@ class QueryIT extends DslITSpec {
     queryExecutor.execute[Totals](query).futureValue.totals should be(None)
   }
 
+  // #142's shape: a scalar subquery named in WITH, then used in the projection.
+  it should "compute a share against a total named in a WITH clause" in {
+    case class Share(itemId: String, share: Double)
+    implicit val shareFormat: RootJsonFormat[Share] =
+      jsonFormat[String, Double, Share](Share.apply, "item_id", "share")
+
+    val total = WithScalarQuery(select(toInt32(count())).from(TwoTestTable), "total")
+    val query = select(itemId, (toInt32(count()) / ref[Int]("total")) as "share")
+      .from(TwoTestTable)
+      .groupBy(itemId)
+      .withCte(total)
+
+    val shares = queryExecutor.execute[Share](query).futureValue.rows
+    shares.map(_.share).sum shouldBe 1.0 +- 0.0001
+  }
+
+  it should "select from a CTE declared in a WITH clause" in {
+    case class Row(itemId: String)
+    implicit val rowFormat: RootJsonFormat[Row] = jsonFormat[String, Row](Row.apply, "item_id")
+
+    val recent = WithTable("recent", select(itemId).from(TwoTestTable))
+    val rows   = queryExecutor.execute[Row](select(itemId).from(recent).withCte(recent)).futureValue.rows
+    rows.map(_.itemId) should contain theSameElementsAs table2Entries.map(_.itemId.toString)
+  }
+
   it should "map as result" in {
 
     case class Result(columnResult: String, empty: Int)

--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
@@ -181,6 +181,29 @@ class SqlValidationITSpec extends DslITSpec {
     Construct("paste join", select(itemId).from(TwoTestTable).join(JoinQuery.PasteJoin, ThreeTestTable)),
     // Syntax only: the IT tables are Engine.Memory, and resolving SAMPLE against a table with no sampling key fails
     // with SAMPLING_NOT_SUPPORTED before the analyzer gets to the clause itself.
+    Construct(
+      "with, naming an expression",
+      select(ref[Int]("one")).from(OneTestTable).withCte(WithExpression(const(1), "one"))
+    ),
+    Construct(
+      "with, naming a scalar subquery",
+      select(itemId, ref[Long]("total"))
+        .from(TwoTestTable)
+        .withCte(WithScalarQuery(select(count()).from(TwoTestTable), "total"))
+    ),
+    Construct(
+      "with, declaring a CTE and selecting from it", {
+        val recent = WithTable("recent", select(itemId).from(TwoTestTable))
+        select(itemId).from(recent).withCte(recent)
+      }
+    ),
+    Construct(
+      "with, scoped to a union branch",
+      select(ref[Int]("one"))
+        .from(OneTestTable)
+        .withCte(WithExpression(const(1), "one"))
+        .unionAll(select(ref[Int]("two")).from(OneTestTable).withCte(WithExpression(const(2), "two")))
+    ),
     Construct("sample", select(shieldId).from(OneTestTable).sample(0.1), Syntax),
     Construct("sample with an offset", select(shieldId).from(OneTestTable).sample(0.1, Option(0.5)), Syntax)
   )

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/OperationalQuery.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/OperationalQuery.scala
@@ -94,6 +94,13 @@ trait OperationalQuery extends Query {
     )
 
   /**
+   * `WITH`, covering all three of the forms ClickHouse puts behind the keyword -- see [[WithEntry]]. A name introduced
+   * here is referenced with `ref`, and is scoped to this query rather than to any subquery inside it.
+   */
+  def withCte(entries: WithEntry*): OperationalQuery =
+    OperationalQuery(internalQuery.copy(withEntries = internalQuery.withEntries ++ entries))
+
+  /**
    * `ARRAY JOIN`, unfolding each array column into one row per element. Rows with an empty array are dropped.
    *
    * Named `withArrayJoin` rather than `arrayJoin`, matching [[withRollup]] and [[withTotals]]: an inherited member

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/Query.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/Query.scala
@@ -51,7 +51,10 @@ sealed case class InternalQuery(
     unionAll: Seq[OperationalQuery] = Seq.empty,
     // Ordered rather than a Map: map iteration order is unspecified, which would make the emitted SQL vary between
     // runs for the same query.
-    settings: Seq[(String, String)] = Seq.empty
+    settings: Seq[(String, String)] = Seq.empty,
+    // Last despite rendering first: several call sites construct InternalQuery positionally, and clause order is the
+    // tokenizer's business rather than this list's.
+    withEntries: Seq[WithEntry] = Seq.empty
 ) {
 
   def isValid: Boolean = {
@@ -89,7 +92,8 @@ sealed case class InternalQuery(
       limit = limit.orElse(other.limit),
       limitBy = limitBy.orElse(other.limitBy),
       unionAll = if (unionAll.nonEmpty) unionAll else other.unionAll,
-      settings = if (settings.nonEmpty) settings else other.settings
+      settings = if (settings.nonEmpty) settings else other.settings,
+      withEntries = if (withEntries.nonEmpty) withEntries else other.withEntries
     )
 
   /**
@@ -133,6 +137,7 @@ sealed case class InternalQuery(
     noConflict("limitBy", limitBy, other.limitBy)
     noSeqConflict("unionAll", unionAll, other.unionAll)
     noSeqConflict("settings", settings, other.settings)
+    noSeqConflict("withEntries", withEntries, other.withEntries)
 
     :+>(other)
   }

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/WithEntry.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/WithEntry.scala
@@ -1,0 +1,48 @@
+package com.crobox.clickhouse.dsl
+
+/**
+ * One entry in a `WITH` clause.
+ *
+ * ClickHouse puts three different things behind the same keyword, and the first two read in opposite orders:
+ *   - [[WithExpression]] -- `WITH <expression> AS <name>`, naming a plain expression
+ *   - [[WithScalarQuery]] -- `WITH (<subquery>) AS <name>`, naming the single value a subquery returns
+ *   - [[WithTable]] -- `WITH <name> AS (<subquery>)`, a CTE you can select FROM
+ *
+ * A name introduced here is referenced with `ref`, which already exists for exactly this: `ref[Long]("total")`.
+ *
+ * Entries are scoped to the `SELECT` that declares them, so a subquery or a `UNION ALL` branch carries its own.
+ */
+sealed trait WithEntry {
+  def name: String
+}
+
+/** `WITH <expression> AS <name>`, as in `WITH 1 AS one`. */
+case class WithExpression(expression: Column, name: String) extends WithEntry
+
+/**
+ * `WITH (<subquery>) AS <name>`, where the subquery returns a single value -- the form requested in #142:
+ * {{{WITH (SELECT sum(bytes) FROM system.parts WHERE active) AS total_disk_usage}}}
+ */
+case class WithScalarQuery(query: OperationalQuery, name: String) extends WithEntry
+
+/**
+ * `WITH <name> AS (<subquery>)`, a CTE.
+ *
+ * Also a [[Table]], so the same value both declares the CTE and selects from it:
+ * {{{
+ * val recent = WithTable("recent", select(itemId).from(TwoTestTable))
+ * select(itemId).from(recent).withCte(recent)
+ * }}}
+ *
+ * `columns` is empty because a CTE's shape is whatever its query projects rather than a declared schema; name its
+ * columns with `ref` or reuse the columns of the tables it selects from.
+ */
+case class WithTable(name: String, query: OperationalQuery) extends WithEntry with Table {
+
+  /** A CTE is referenced by a bare identifier -- there is no database to qualify it with. */
+  override def database: String = ""
+
+  override lazy val quoted: String = ClickhouseStatement.quoteIdentifier(name)
+
+  override val columns: Seq[NativeColumn[_]] = Seq.empty
+}

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -145,12 +145,14 @@ trait ClickhouseTokenizerModule
             limit,
             limitBy,
             union,
-            settings
+            settings,
+            withEntries
           ) =>
         // The left table's alias is emitted by tokenizeJoin, and ARRAY JOIN has to land between that alias and the
         // JOIN keyword, so it is threaded through rather than placed here. Without a join there is no alias to follow.
         val arrayJoinSql = tokenizeArrayJoin(arrayJoin)
         Seq(
+          tokenizeWith(withEntries),
           tokenizeSelect(select),
           tokenizeFrom(from),
           if (join.isDefined) "" else arrayJoinSql,
@@ -166,6 +168,21 @@ trait ClickhouseTokenizerModule
           tokenizeUnionAll(union)
         ).filter(_.nonEmpty).mkString(" ")
     }
+
+  private def tokenizeWith(entries: Seq[WithEntry])(implicit ctx: TokenizeContext): String =
+    if (entries.isEmpty) ""
+    else
+      entries
+        .map {
+          // The two expression forms read `<value> AS <name>`; the CTE form reads the other way round.
+          case WithExpression(expression, name) =>
+            s"${tokenizeColumn(expression)} AS ${ClickhouseStatement.quoteIdentifier(name)}"
+          case WithScalarQuery(query, name) =>
+            s"(${toRawSql(query.internalQuery)}) AS ${ClickhouseStatement.quoteIdentifier(name)}"
+          case WithTable(name, query) =>
+            s"${ClickhouseStatement.quoteIdentifier(name)} AS (${toRawSql(query.internalQuery)})"
+        }
+        .mkString("WITH ", Tokens.Delimiter, "")
 
   private def tokenizeArrayJoin(arrayJoin: Option[ArrayJoinQuery])(implicit ctx: TokenizeContext): String =
     arrayJoin match {

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/InternalQueryFieldsTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/InternalQueryFieldsTest.scala
@@ -23,7 +23,7 @@ class InternalQueryFieldsTest extends DslTestSpec {
    *   3. `InternalQuery.+` -- otherwise two queries that conflict on it merge without complaint
    *   4. this constant, plus setting the field in [[populated]] and adding it to [[singleFieldQueries]]
    */
-  private val FieldCount = 13
+  private val FieldCount = 14
 
   private val condition = col3 isEq "a"
 
@@ -41,24 +41,26 @@ class InternalQueryFieldsTest extends DslTestSpec {
     limit = Option(Limit(10, 5)),
     limitBy = Option(LimitBy(1, 0, Seq(itemId))),
     unionAll = Seq(select(itemId).from(OneTestTable)),
-    settings = Seq("max_threads" -> "1")
+    settings = Seq("max_threads" -> "1"),
+    withEntries = Seq(WithExpression(const(1), "one"))
   )
 
   /** One query per field, carrying only that field, so a missing conflict check shows up as a merge that succeeds. */
   private val singleFieldQueries: Seq[(String, InternalQuery)] = Seq(
-    "select"    -> InternalQuery(select = populated.select),
-    "from"      -> InternalQuery(from = populated.from),
-    "prewhere"  -> InternalQuery(prewhere = populated.prewhere),
-    "where"     -> InternalQuery(where = populated.where),
-    "groupBy"   -> InternalQuery(groupBy = populated.groupBy),
-    "having"    -> InternalQuery(having = populated.having),
-    "join"      -> InternalQuery(join = populated.join),
-    "arrayJoin" -> InternalQuery(arrayJoin = populated.arrayJoin),
-    "orderBy"   -> InternalQuery(orderBy = populated.orderBy),
-    "limit"     -> InternalQuery(limit = populated.limit),
-    "limitBy"   -> InternalQuery(limitBy = populated.limitBy),
-    "unionAll"  -> InternalQuery(unionAll = populated.unionAll),
-    "settings"  -> InternalQuery(settings = populated.settings)
+    "select"      -> InternalQuery(select = populated.select),
+    "from"        -> InternalQuery(from = populated.from),
+    "prewhere"    -> InternalQuery(prewhere = populated.prewhere),
+    "where"       -> InternalQuery(where = populated.where),
+    "groupBy"     -> InternalQuery(groupBy = populated.groupBy),
+    "having"      -> InternalQuery(having = populated.having),
+    "join"        -> InternalQuery(join = populated.join),
+    "arrayJoin"   -> InternalQuery(arrayJoin = populated.arrayJoin),
+    "orderBy"     -> InternalQuery(orderBy = populated.orderBy),
+    "limit"       -> InternalQuery(limit = populated.limit),
+    "limitBy"     -> InternalQuery(limitBy = populated.limitBy),
+    "unionAll"    -> InternalQuery(unionAll = populated.unionAll),
+    "settings"    -> InternalQuery(settings = populated.settings),
+    "withEntries" -> InternalQuery(withEntries = populated.withEntries)
   )
 
   /** Names the fields that differ, because an InternalQuery's `toString` is far too long to diff by eye. */

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/WithClauseTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/WithClauseTest.scala
@@ -1,0 +1,106 @@
+package com.crobox.clickhouse.dsl
+
+import com.crobox.clickhouse.DslTestSpec
+
+/**
+ * `WITH` rendering, for all three of the forms ClickHouse puts behind the keyword. The two expression forms read
+ * `<value> AS <name>` and the CTE form reads `<name> AS (<query>)`, so getting one confused for the other produces
+ * something that still looks like a WITH clause.
+ */
+class WithClauseTest extends DslTestSpec {
+
+  private def sql(query: OperationalQuery): String = toSql(query.internalQuery, None)
+
+  "WITH" should "name a plain expression" in {
+    val query = select(ref[Int]("one")).from(OneTestTable).withCte(WithExpression(const(1), "one"))
+    sql(query) should matchSQL(s"WITH 1 AS one SELECT one FROM ${OneTestTable.quoted}")
+  }
+
+  it should "come before SELECT" in {
+    val query = select(shieldId).from(OneTestTable).where(shieldId isEq "a").withCte(WithExpression(const(1), "one"))
+    sql(query) should matchSQL(
+      s"WITH 1 AS one SELECT shield_id FROM ${OneTestTable.quoted} WHERE shield_id = 'a'"
+    )
+  }
+
+  // The shape #142 asked for.
+  it should "name the value a scalar subquery returns" in {
+    val total = WithScalarQuery(select(count()).from(TwoTestTable), "total")
+    val query = select(itemId, ref[Long]("total")).from(TwoTestTable).withCte(total)
+    sql(query) should matchSQL(
+      s"WITH (SELECT count() FROM ${TwoTestTable.quoted}) AS total " +
+        s"SELECT item_id, total FROM ${TwoTestTable.quoted}"
+    )
+  }
+
+  it should "declare a CTE with the name first, unlike the expression forms" in {
+    val recent = WithTable("recent", select(itemId).from(TwoTestTable))
+    sql(select(itemId).from(recent).withCte(recent)) should matchSQL(
+      s"WITH recent AS (SELECT item_id FROM ${TwoTestTable.quoted}) SELECT item_id FROM recent"
+    )
+  }
+
+  it should "reference a CTE as a bare identifier, with no database to qualify it" in {
+    WithTable("recent", select(itemId).from(TwoTestTable)).quoted shouldBe "recent"
+  }
+
+  it should "render several entries in the order given" in {
+    val query = select(ref[Int]("one"))
+      .from(OneTestTable)
+      .withCte(WithExpression(const(1), "one"), WithExpression(const(2), "two"))
+    sql(query) should matchSQL(s"WITH 1 AS one, 2 AS two SELECT one FROM ${OneTestTable.quoted}")
+  }
+
+  it should "accumulate across calls rather than replacing" in {
+    val query = select(ref[Int]("one"))
+      .from(OneTestTable)
+      .withCte(WithExpression(const(1), "one"))
+      .withCte(WithExpression(const(2), "two"))
+    sql(query) should matchSQL(s"WITH 1 AS one, 2 AS two SELECT one FROM ${OneTestTable.quoted}")
+  }
+
+  it should "mix the forms in one clause" in {
+    val query = select(itemId)
+      .from(TwoTestTable)
+      .withCte(
+        WithExpression(const(1), "one"),
+        WithScalarQuery(select(count()).from(TwoTestTable), "total"),
+        WithTable("recent", select(itemId).from(ThreeTestTable))
+      )
+    sql(query) should matchSQL(
+      s"WITH 1 AS one, (SELECT count() FROM ${TwoTestTable.quoted}) AS total, " +
+        s"recent AS (SELECT item_id FROM ${ThreeTestTable.quoted}) SELECT item_id FROM ${TwoTestTable.quoted}"
+    )
+  }
+
+  // quoteIdentifier quotes on syntax, not on reserved words -- `WITH 1 AS select` is accepted by the server as-is.
+  it should "quote a name that could not be parsed bare" in {
+    val query = select(shieldId).from(OneTestTable).withCte(WithExpression(const(1), "my name"))
+    sql(query) should matchSQL(s"WITH 1 AS `my name` SELECT shield_id FROM ${OneTestTable.quoted}")
+  }
+
+  it should "render nothing when there are no entries" in {
+    sql(select(shieldId).from(OneTestTable).withCte()) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted}"
+    )
+  }
+
+  // Entries are scoped to the SELECT that declares them, so an inner query keeps its own rather than hoisting.
+  it should "stay inside the subquery that declared it" in {
+    val inner = select(shieldId).from(OneTestTable).withCte(WithExpression(const(1), "one"))
+    sql(select(shieldId).from(inner)) should matchSQL(
+      s"SELECT shield_id FROM (WITH 1 AS one SELECT shield_id FROM ${OneTestTable.quoted})"
+    )
+  }
+
+  it should "stay inside its own UNION ALL branch" in {
+    val query = select(shieldId)
+      .from(OneTestTable)
+      .withCte(WithExpression(const(1), "one"))
+      .unionAll(select(shieldId).from(OneTestTable).withCte(WithExpression(const(2), "two")))
+    sql(query) should matchSQL(
+      s"WITH 1 AS one SELECT shield_id FROM ${OneTestTable.quoted} " +
+        s"UNION ALL WITH 2 AS two SELECT shield_id FROM ${OneTestTable.quoted}"
+    )
+  }
+}


### PR DESCRIPTION
Phase 2 of #328, and **closes #142**.

**Stacked on #346** — base is `feat/query-clauses-phase-1`, so review that first; this diff shrinks once it merges.

## Three forms, not one

ClickHouse puts three different things behind `WITH`, and the expression forms read in the opposite order from the CTE form:

| Case | Renders | |
|---|---|---|
| `WithExpression(expr, name)` | `WITH <expr> AS <name>` | |
| `WithScalarQuery(query, name)` | `WITH (<subquery>) AS <name>` | **the form #142 asked for** |
| `WithTable(name, query)` | `WITH <name> AS (<subquery>)` | a CTE |

Three cases of a sealed `WithEntry` rather than one case with a flag, because mistaking one for another still emits something that looks like a valid WITH clause — precisely the failure mode #328 is about. #142's example is a *scalar subquery* (`WITH (SELECT sum(bytes) …) AS total_disk_usage`), which is why that form gets its own case rather than being folded into the CTE one.

## Referencing, and selecting from, a CTE

Names introduced here are referenced with the **existing** `ref` — no new machinery:

```scala
select(itemId, ref[Long]("total")).from(t).withCte(WithScalarQuery(select(count()).from(t), "total"))
```

`WithTable` is additionally a `Table`, so one value both declares the CTE and serves as the FROM source:

```scala
val recent = WithTable("recent", select(itemId).from(TwoTestTable))
select(itemId).from(recent).withCte(recent)
```

Its `quoted` is overridden to a bare identifier — a CTE has no database to qualify it with — and `columns` is empty, because a CTE's shape is whatever its query projects rather than a declared schema.

## Two decisions worth a look

- **`withEntries` is the last field of `InternalQuery` despite rendering first.** `SelectQuery` and several tests construct `InternalQuery` positionally, so putting it first silently shifted every one of those arguments. Field order is not clause order; the tokenizer decides that.
- **Scoping is pinned by tests.** Entries belong to the `SELECT` that declares them, which falls out of `toRawSql` already recursing — but it's the kind of property that breaks quietly, so there are tests for a subquery and for a `UNION ALL` branch each keeping their own WITH.

## Verification

- `scalafmtCheckAll` clean; `+compile +Test/compile +It/compile` green on 2.13 and 3.3.
- **276 unit tests** (+12) and **125 integration tests** (+2).
- 4 new `SqlValidationITSpec` entries covering all three forms plus the union-scoping case, so each is parsed and analysed by the server.
- Two end-to-end tests in `QueryIT`: #142's shape (a share computed against a `WITH`-named total, asserting the shares sum to 1.0) and selecting from a declared CTE.
- Both syntaxes were confirmed against a live 25.3 server before implementation. I also checked that `WITH 1 AS select` is accepted unquoted, so `quoteIdentifier` quoting on syntax rather than on reserved words is not a gap here — the quoting test uses a name that genuinely cannot be parsed bare.

Field count goes 13 → 14, and the Phase 0 arity canary caught it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)