### PR TITLE
Add EXPLAIN, as a statement wrapper rather than a clause

### DIFF
--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/ExplainIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/ExplainIT.scala
@@ -1,0 +1,69 @@
+package com.crobox.clickhouse.dsl
+
+import com.crobox.clickhouse.DslITSpec
+
+/**
+ * Every `EXPLAIN` kind against a real server. A tokenizer arm is a string template, so the only real check that a
+ * kind's keyword and option placement are right is the server accepting them.
+ */
+class ExplainIT extends DslITSpec {
+
+  // Valid on purpose: the analysing kinds reject a query whose projection is neither grouped nor aggregated, which is
+  // itself a decent advertisement for EXPLAIN.
+  private val query = select(itemId).from(TwoTestTable).where(col3 isEq "x").groupBy(itemId)
+
+  // Asserted on the declared columns rather than on rows: ESTIMATE reports parts and marks, which a Memory table has
+  // none of, so it legitimately returns a header and no rows here.
+  it should "be accepted by the server for every kind" in
+    ExplainKind.All.foreach { kind =>
+      withClue(s"EXPLAIN ${kind.keyword}: ") {
+        queryExecutor.explainRows(kind, query).futureValue.meta.map(_.columnTypes) should not be empty
+      }
+    }
+
+  it should "report the plan as text" in {
+    val lines = queryExecutor.explain(ExplainKind.Plan, query).futureValue
+    lines should not be empty
+    // Asserting the whole tree would pin this to a server version; the outermost step is stable.
+    lines.head should include("Expression")
+  }
+
+  it should "report the parsed statement for AST, which cannot carry a FORMAT of its own" in {
+    val lines = queryExecutor.explain(ExplainKind.Ast, query).futureValue
+    lines.head should include("SelectWithUnionQuery")
+  }
+
+  it should "rewrite the query back to SQL for SYNTAX" in {
+    val sql = queryExecutor.explain(ExplainKind.Syntax, query).futureValue.mkString(" ")
+    sql should include("SELECT")
+    sql should include("item_id")
+  }
+
+  it should "expose ESTIMATE's columns, which are not a single explain column" in {
+    val meta = queryExecutor.explainRows(ExplainKind.Estimate, query).futureValue.meta
+    meta.map(_.columnTypes.map(_.name)).getOrElse(Seq.empty) should
+    contain allOf ("database", "table", "parts", "rows", "marks")
+  }
+
+  it should "report nothing through the text accessor for ESTIMATE" in {
+    queryExecutor.explain(ExplainKind.Estimate, query).futureValue shouldBe empty
+  }
+
+  it should "pass options through to the server" in {
+    queryExecutor.explain(ExplainKind.Plan, query, Seq("indexes" -> "1")).futureValue should not be empty
+  }
+
+  it should "surface an option the server rejects rather than dropping it" in {
+    queryExecutor.explain(ExplainKind.Plan, query, Seq("not_a_setting" -> "1")).failed.futureValue should not be null
+  }
+
+  it should "explain a query carrying the clauses added for #328" in {
+    val clauses = select(shieldId)
+      .from(OneTestTable)
+      .withArrayJoin(numbers as "n")
+      .where(shieldId isEq "a")
+      .limit(Option(Limit(5)))
+      .settings("max_threads" -> "1")
+    queryExecutor.explain(ExplainKind.Syntax, clauses).futureValue should not be empty
+  }
+}

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/ExplainKind.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/ExplainKind.scala
@@ -1,0 +1,35 @@
+package com.crobox.clickhouse.dsl
+
+/**
+ * What an `EXPLAIN` should report.
+ *
+ * `EXPLAIN` is a statement that wraps a query rather than a clause inside one, which is why it is not a field on
+ * [[InternalQuery]]: `toRawSql` recurses for subqueries, so a field would let a subquery render `EXPLAIN` inside its
+ * own parentheses, and merging two queries would propagate it.
+ *
+ * https://clickhouse.com/docs/sql-reference/statements/explain
+ */
+sealed abstract class ExplainKind(val keyword: String)
+
+object ExplainKind {
+
+  /** The parsed statement, before any name resolution. Parses anything that is syntactically a query. */
+  case object Ast extends ExplainKind("AST")
+
+  /** The query rewritten back to SQL after analysis. */
+  case object Syntax extends ExplainKind("SYNTAX")
+
+  /** The analyzer's resolved tree: names, arity and argument types. Needs the analyzer, so 24.3 onwards. */
+  case object QueryTree extends ExplainKind("QUERY TREE")
+
+  /** The query plan. What a bare `EXPLAIN` returns. */
+  case object Plan extends ExplainKind("PLAN")
+
+  /** The execution pipeline. */
+  case object Pipeline extends ExplainKind("PIPELINE")
+
+  /** Estimated parts, rows and marks per table. The one kind whose result is not a single `explain` column. */
+  case object Estimate extends ExplainKind("ESTIMATE")
+
+  val All: Seq[ExplainKind] = Seq(Ast, Syntax, QueryTree, Plan, Pipeline, Estimate)
+}

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/execution/ClickhouseQueryExecutor.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/execution/ClickhouseQueryExecutor.scala
@@ -2,7 +2,7 @@ package com.crobox.clickhouse.dsl.execution
 
 import com.crobox.clickhouse.ClickhouseClient
 import com.crobox.clickhouse.dsl.language.{ClickhouseTokenizerModule, TokenizeContext, TokenizerModule}
-import com.crobox.clickhouse.dsl.{Query, Table}
+import com.crobox.clickhouse.dsl.{ExplainKind, Query, Table}
 import com.crobox.clickhouse.internal.QuerySettings
 import spray.json.{JsonReader, _}
 
@@ -42,6 +42,35 @@ trait ClickhouseQueryExecutor extends QueryExecutor {
   //      client.queryWithProgress(toSql(query.internalQuery)(ctx = TokenizeContext()))
   //    queryResult.mapMaterializedValue(_.map(_.parseJson.convertTo[QueryResult[V]]))
   //  }
+
+  /** Every EXPLAIN kind but ESTIMATE reports a single column under this name. */
+  private val ExplainColumn = "explain"
+
+  override def explain(
+      kind: ExplainKind,
+      query: Query,
+      options: Seq[(String, String)] = Seq.empty
+  )(implicit
+      executionContext: ExecutionContext,
+      settings: QuerySettings = QuerySettings()
+  ): Future[Seq[String]] =
+    explainRows(kind, query, options).map(_.rows.flatMap(_.getByName[String](ExplainColumn)))
+
+  override def explainRows(
+      kind: ExplainKind,
+      query: Query,
+      options: Seq[(String, String)] = Seq.empty
+  )(implicit
+      executionContext: ExecutionContext,
+      settings: QuerySettings = QuerySettings()
+  ): Future[QueryResult[Row]] = {
+    val explainSql = toExplainSql(kind, query.internalQuery, options)(ctx = TokenizeContext())
+    // Selected from as a subquery rather than given a trailing FORMAT. EXPLAIN AST reports the whole parsed statement,
+    // so a `FORMAT` after it becomes part of what it explains and the result comes back in the default format instead;
+    // wrapping sidesteps that and reads identically for every kind.
+    val sql = s"SELECT * FROM ($explainSql) FORMAT ${CompactRowParser.Format}"
+    client.query(sql)(settings).map(CompactRowParser.parse)
+  }
 
   override def executeRows(
       query: Query

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/execution/QueryExecutor.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/execution/QueryExecutor.scala
@@ -1,7 +1,7 @@
 package com.crobox.clickhouse.dsl.execution
 
 import com.crobox.clickhouse.dsl.language.TokenizerModule
-import com.crobox.clickhouse.dsl.{Query, Table}
+import com.crobox.clickhouse.dsl.{ExplainKind, Query, Table}
 import com.crobox.clickhouse.internal.QuerySettings
 import spray.json._
 
@@ -31,6 +31,26 @@ trait QueryExecutor { self: TokenizerModule =>
    */
   def executeRows(
       query: Query
+  )(implicit executionContext: ExecutionContext, settings: QuerySettings = QuerySettings()): Future[QueryResult[Row]]
+
+  /**
+   * `EXPLAIN`, as the lines of text it reports. Empty for [[ExplainKind.Estimate]], whose result is a set of columns
+   * rather than a single `explain` one -- use [[explainRows]] for that.
+   */
+  def explain(
+      kind: ExplainKind,
+      query: Query,
+      options: Seq[(String, String)] = Seq.empty
+  )(implicit executionContext: ExecutionContext, settings: QuerySettings = QuerySettings()): Future[Seq[String]]
+
+  /**
+   * `EXPLAIN` read by column, for kinds whose result is not a single `explain` column. Mirrors [[executeRows]]: the
+   * column set depends on the kind, so there is nothing to declare up front.
+   */
+  def explainRows(
+      kind: ExplainKind,
+      query: Query,
+      options: Seq[(String, String)] = Seq.empty
   )(implicit executionContext: ExecutionContext, settings: QuerySettings = QuerySettings()): Future[QueryResult[Row]]
 
   def insert[V: JsonWriter](table: Table, values: Seq[V])(implicit

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -123,6 +123,19 @@ trait ClickhouseTokenizerModule
     sql
   }
 
+  override def toExplainSql(
+      kind: ExplainKind,
+      query: InternalQuery,
+      options: Seq[(String, String)] = Seq.empty
+  )(implicit ctx: TokenizeContext): String = {
+    // Same `key = value` form as query-level SETTINGS, but positioned before the query rather than after it.
+    val optionsSql =
+      if (options.isEmpty) "" else options.map { case (k, v) => s"$k = $v" }.mkString(" ", Tokens.Delimiter, "")
+    val sql = s"EXPLAIN ${kind.keyword}$optionsSql ${toRawSql(query)}"
+    logger.debug(s"Generated sql [$sql]")
+    sql
+  }
+
   private def removeSurroundingBrackets(value: String): String =
     if (value.startsWith("(") && value.endsWith(")") && value.count(_ == '(') == 1 && value.count(_ == ')') == 1) {
       value.substring(1, value.length - 1)

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/TokenizerModule.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/TokenizerModule.scala
@@ -1,8 +1,25 @@
 package com.crobox.clickhouse.dsl.language
 
-import com.crobox.clickhouse.dsl.InternalQuery
+import com.crobox.clickhouse.dsl.{ExplainKind, InternalQuery}
 
 trait TokenizerModule {
 
   def toSql(query: InternalQuery, formatting: Option[String] = Some("JSON"))(implicit ctx: TokenizeContext): String
+
+  /**
+   * `EXPLAIN <kind> [options] <query>`, with no `FORMAT` of its own.
+   *
+   * A separate entry point rather than a clause on [[InternalQuery]], because EXPLAIN wraps a whole statement: as a
+   * field it would render inside subquery parentheses and survive a query merge.
+   *
+   * No formatting parameter, because a trailing `FORMAT` does not mean the same thing for every kind --
+   * [[ExplainKind.Ast]] reports the entire parsed statement, so it folds the `FORMAT` into what it explains rather than
+   * using it. Callers that need to parse the result should select from this as a subquery, which is what
+   * `QueryExecutor.explainRows` does.
+   */
+  def toExplainSql(
+      kind: ExplainKind,
+      query: InternalQuery,
+      options: Seq[(String, String)] = Seq.empty
+  )(implicit ctx: TokenizeContext): String
 }

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/ExplainTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/ExplainTest.scala
@@ -1,0 +1,75 @@
+package com.crobox.clickhouse.dsl
+
+import com.crobox.clickhouse.DslTestSpec
+
+/**
+ * `EXPLAIN` rendering. It wraps a statement rather than sitting inside one, so what matters here is that the wrapped
+ * query is unchanged and that the prefix cannot leak into a subquery.
+ */
+class ExplainTest extends DslTestSpec {
+
+  private val query = select(shieldId).from(OneTestTable).where(shieldId isEq "a")
+
+  "EXPLAIN" should "prefix the query with the kind's keyword" in {
+    toExplainSql(ExplainKind.Plan, query.internalQuery) should matchSQL(
+      s"EXPLAIN PLAN SELECT shield_id FROM ${OneTestTable.quoted} WHERE shield_id = 'a'"
+    )
+  }
+
+  // That each of these is actually accepted is checked against a live server in ExplainIT.
+  it should "spell every kind the way ClickHouse does" in {
+    ExplainKind.All.map(_.keyword) should contain theSameElementsInOrderAs
+    Seq("AST", "SYNTAX", "QUERY TREE", "PLAN", "PIPELINE", "ESTIMATE")
+  }
+
+  it should "put the kind's keyword straight after EXPLAIN" in
+    ExplainKind.All.foreach { kind =>
+      toExplainSql(kind, select(const(1)).internalQuery) should
+      startWith(s"EXPLAIN ${kind.keyword} ")
+    }
+
+  it should "render options before the query, not after it" in {
+    val sql = toExplainSql(ExplainKind.Plan, query.internalQuery, Seq("indexes" -> "1"))
+    sql should matchSQL(
+      s"EXPLAIN PLAN indexes = 1 SELECT shield_id FROM ${OneTestTable.quoted} WHERE shield_id = 'a'"
+    )
+  }
+
+  it should "separate several options" in {
+    val sql = toExplainSql(ExplainKind.Plan, query.internalQuery, Seq("header" -> "1", "indexes" -> "1"))
+    sql should matchSQL(
+      s"EXPLAIN PLAN header = 1, indexes = 1 SELECT shield_id FROM ${OneTestTable.quoted} WHERE shield_id = 'a'"
+    )
+  }
+
+  // No FORMAT of its own: EXPLAIN AST reports the whole parsed statement, so a trailing FORMAT would become part of
+  // what it explains. QueryExecutor.explainRows selects from this as a subquery instead.
+  it should "not append a FORMAT" in {
+    toExplainSql(ExplainKind.Ast, select(const(1)).internalQuery) should not include "FORMAT"
+  }
+
+  // The reason EXPLAIN is not a field on InternalQuery: as one it would render inside these parentheses.
+  it should "not leak into a subquery" in {
+    val outer = select(shieldId).from(select(shieldId).from(OneTestTable))
+    val sql   = toExplainSql(ExplainKind.Plan, outer.internalQuery)
+    sql should matchSQL(
+      s"EXPLAIN PLAN SELECT shield_id FROM (SELECT shield_id FROM ${OneTestTable.quoted})"
+    )
+    sql.sliding("EXPLAIN".length).count(_ == "EXPLAIN") shouldBe 1
+  }
+
+  it should "leave a clause-heavy query untouched" in {
+    val full = select(itemId, col2)
+      .from(TwoTestTable)
+      .where(col3 isEq "x")
+      .groupBy(itemId)
+      .having(col2 isEq 1)
+      .orderBy(itemId)
+      .limit(Option(Limit(5)))
+      .settings("max_threads" -> "1")
+    toExplainSql(ExplainKind.Syntax, full.internalQuery) should matchSQL(
+      s"EXPLAIN SYNTAX SELECT item_id, column_2 FROM ${TwoTestTable.quoted} WHERE column_3 = 'x' " +
+        "GROUP BY item_id HAVING column_2 = 1 ORDER BY item_id ASC LIMIT 0, 5 SETTINGS max_threads = 1"
+    )
+  }
+}


### PR DESCRIPTION
Phase 4 of #328. All six kinds — `AST`, `SYNTAX`, `QUERY TREE`, `PLAN`, `PIPELINE`, `ESTIMATE` — plus the `key = value` options each accepts.

Independent of #347 (the WITH clause), which is still open: this adds no `InternalQuery` field, so the two don't overlap.

## Not an InternalQuery field, on purpose

`EXPLAIN` wraps a whole statement and is absent from the `SELECT` grammar. `toRawSql` recurses for subqueries, so as a field it would render inside a subquery's own parentheses, and `:+>` would carry it through a query merge. It gets its own tokenizer entry point instead, and there's a test asserting the keyword cannot appear twice in one rendering.

## The FORMAT detour

A trailing `FORMAT` does not mean the same thing for every kind. `EXPLAIN AST` reports the *entire parsed statement*, so `EXPLAIN AST SELECT 1 FORMAT JSON` folds the FORMAT into what it explains and returns the default format instead. Its own output gives it away:

```
SelectWithUnionQuery (children 2)
 ExpressionList (children 1)
  ...
 Identifier JSON        <-- the FORMAT became part of the explained statement
```

Every other kind honours it. Rather than special-case AST, `toExplainSql` emits **no** `FORMAT` and `explainRows` selects from the statement as a subquery:

```sql
SELECT * FROM (EXPLAIN AST SELECT …) FORMAT JSONCompactEachRowWithNamesAndTypes
```

Verified to read identically for all six kinds, and to preserve ESTIMATE's column set.

## API mirrors execute/executeRows

| Method | Returns | For |
|---|---|---|
| `explain(kind, query, options)` | `Future[Seq[String]]` | the text lines — five of six kinds report a single `explain` column |
| `explainRows(kind, query, options)` | `Future[QueryResult[Row]]` | `ESTIMATE`, which reports `database`/`table`/`parts`/`rows`/`marks` |

`explainRows` reuses the by-column reading added in #341 — the column set depends on the kind, so there is nothing to declare up front, which is exactly what that machinery is for.

## SqlValidationITSpec left alone

It hand-builds `EXPLAIN AST …` / `EXPLAIN QUERY TREE …` strings and is the obvious consumer of a typed version. Converting it would make the validation harness depend on the feature it validates, so it stays on strings — noted rather than done.

## Verification

- `scalafmtCheckAll` clean; `+compile +Test/compile +It/compile` green on 2.13 and 3.3.
- **272 unit tests** and **132 integration tests**.
- `ExplainIT` exercises all six kinds against a live server, plus AST's parsed-statement output, SYNTAX's SQL rewrite, ESTIMATE's columns, option pass-through, and that a bad option surfaces as a failure rather than being dropped. One case explains a query carrying the Phase 1 clauses, so the two features are checked together.
- It asserts on **declared columns rather than rows**: `ESTIMATE` reports parts and marks, and the IT tables are `Engine.Memory`, so it correctly returns a header and no rows there. Worth knowing before someone reads an empty result as a bug.

Two of my own test queries were wrong before the server corrected them — one projected a column that was neither grouped nor aggregated, which only the analysing kinds reject. A decent advertisement for the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)