### PR TITLE
Pin the time behaviour, and fix date parsing for zones with an underscore

### DIFF
--- a/client/src/test/scala/com/crobox/clickhouse/time/MultiIntervalTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/time/MultiIntervalTest.scala
@@ -178,14 +178,7 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
       (startExpected.plusSeconds(5) to startExpected.plusSeconds(10)) :: Nil)
   }
 
-  // ---------------------------------------------------------------------------------------------------------------
-  // Zone-sensitive alignment.
-  //
-  // Everything above runs in UTC, where the `tzOffset` arithmetic in MultiInterval's Day and Week branches is a
-  // no-op -- so none of it was exercised. These pin the current behaviour in real zones, on both sides of UTC and
-  // across both DST transitions, because that behaviour is what a change of date library is most likely to alter
-  // quietly.
-  // ---------------------------------------------------------------------------------------------------------------
+  // The cases above are all UTC, where MultiInterval's tzOffset arithmetic is a no-op.
 
   private val Amsterdam = DateTimeZone.forID("Europe/Amsterdam")
   private val NewYork   = DateTimeZone.forID("America/New_York")
@@ -211,7 +204,6 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
     interval.getEnd should be(new DateTime(2014, 5, 10, 0, 0, 0, Amsterdam))
   }
 
-  // The clocks go forward at 02:00, so this calendar day is 23 hours long, not 24.
   it should "keep a spring-forward day one calendar day, not 24 hours" in {
     val interval = firstSubInterval(new DateTime(2014, 3, 30, 12, 0, 0, Amsterdam), MultiDuration(1, TimeUnit.Day))
     interval.getStart should be(new DateTime(2014, 3, 30, 0, 0, 0, Amsterdam))
@@ -219,7 +211,6 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
     interval.toDuration.getStandardHours should be(23)
   }
 
-  // And back at 03:00, making this one 25.
   it should "keep a fall-back day one calendar day, not 24 hours" in {
     val interval = firstSubInterval(new DateTime(2014, 10, 26, 12, 0, 0, Amsterdam), MultiDuration(1, TimeUnit.Day))
     interval.getStart should be(new DateTime(2014, 10, 26, 0, 0, 0, Amsterdam))
@@ -252,10 +243,8 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
     interval.toDuration.getStandardHours should be((7 * 24) - 1)
   }
 
-  // Deliberately pinned, because it is the one inconsistency here: sub-day buckets are aligned on the epoch rather
-  // than on local midnight, so east of UTC a 6-hour bucket starts at 02:00, 08:00, 14:00, 20:00 local -- not at
-  // midnight. Day and Week above do align locally. A port that "fixed" this silently would change every grouped
-  // result for non-UTC consumers.
+  // Pinned on purpose: unlike Day and Week above, sub-day buckets do not align to local midnight. Looks like a bug,
+  // is not, and changing it would move every grouped result for non-UTC consumers.
   "Sub-day alignment" should "bucket on the epoch rather than on local midnight" in {
     val interval = firstSubInterval(new DateTime(2014, 5, 8, 12, 0, 0, Amsterdam), MultiDuration(6, TimeUnit.Hour))
     interval.getStart should be(new DateTime(2014, 5, 8, 8, 0, 0, Amsterdam))

--- a/client/src/test/scala/com/crobox/clickhouse/time/MultiIntervalTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/time/MultiIntervalTest.scala
@@ -1,6 +1,6 @@
 package com.crobox.clickhouse.time
 
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, DateTimeZone}
 import org.joda.time.DateTimeZone.UTC
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -176,6 +176,96 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
     interval.getEnd should be(startExpected.plusSeconds(10))
     interval.subIntervals should contain theSameElementsInOrderAs ((startExpected to startExpected.plusSeconds(5)) ::
       (startExpected.plusSeconds(5) to startExpected.plusSeconds(10)) :: Nil)
+  }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Zone-sensitive alignment.
+  //
+  // Everything above runs in UTC, where the `tzOffset` arithmetic in MultiInterval's Day and Week branches is a
+  // no-op -- so none of it was exercised. These pin the current behaviour in real zones, on both sides of UTC and
+  // across both DST transitions, because that behaviour is what a change of date library is most likely to alter
+  // quietly.
+  // ---------------------------------------------------------------------------------------------------------------
+
+  private val Amsterdam = DateTimeZone.forID("Europe/Amsterdam")
+  private val NewYork   = DateTimeZone.forID("America/New_York")
+
+  private def firstSubInterval(start: DateTime, duration: Duration) =
+    MultiInterval(start, start.plusDays(2), duration).subIntervals.head
+
+  "Day alignment" should "start at local midnight, east of UTC" in {
+    val interval = firstSubInterval(new DateTime(2014, 5, 8, 16, 26, 0, Amsterdam), MultiDuration(1, TimeUnit.Day))
+    interval.getStart should be(new DateTime(2014, 5, 8, 0, 0, 0, Amsterdam))
+    interval.getEnd should be(new DateTime(2014, 5, 9, 0, 0, 0, Amsterdam))
+  }
+
+  it should "start at local midnight, west of UTC" in {
+    val interval = firstSubInterval(new DateTime(2014, 5, 8, 16, 26, 0, NewYork), MultiDuration(1, TimeUnit.Day))
+    interval.getStart should be(new DateTime(2014, 5, 8, 0, 0, 0, NewYork))
+    interval.getEnd should be(new DateTime(2014, 5, 9, 0, 0, 0, NewYork))
+  }
+
+  it should "align a multi-day bucket to local midnight" in {
+    val interval = firstSubInterval(new DateTime(2014, 5, 8, 16, 26, 0, Amsterdam), MultiDuration(2, TimeUnit.Day))
+    interval.getStart should be(new DateTime(2014, 5, 8, 0, 0, 0, Amsterdam))
+    interval.getEnd should be(new DateTime(2014, 5, 10, 0, 0, 0, Amsterdam))
+  }
+
+  // The clocks go forward at 02:00, so this calendar day is 23 hours long, not 24.
+  it should "keep a spring-forward day one calendar day, not 24 hours" in {
+    val interval = firstSubInterval(new DateTime(2014, 3, 30, 12, 0, 0, Amsterdam), MultiDuration(1, TimeUnit.Day))
+    interval.getStart should be(new DateTime(2014, 3, 30, 0, 0, 0, Amsterdam))
+    interval.getEnd should be(new DateTime(2014, 3, 31, 0, 0, 0, Amsterdam))
+    interval.toDuration.getStandardHours should be(23)
+  }
+
+  // And back at 03:00, making this one 25.
+  it should "keep a fall-back day one calendar day, not 24 hours" in {
+    val interval = firstSubInterval(new DateTime(2014, 10, 26, 12, 0, 0, Amsterdam), MultiDuration(1, TimeUnit.Day))
+    interval.getStart should be(new DateTime(2014, 10, 26, 0, 0, 0, Amsterdam))
+    interval.getEnd should be(new DateTime(2014, 10, 27, 0, 0, 0, Amsterdam))
+    interval.toDuration.getStandardHours should be(25)
+  }
+
+  "Week alignment" should "start on Monday at local midnight, east of UTC" in {
+    val interval = firstSubInterval(new DateTime(2014, 5, 8, 16, 26, 0, Amsterdam), MultiDuration(1, TimeUnit.Week))
+    interval.getStart should be(new DateTime(2014, 5, 5, 0, 0, 0, Amsterdam))
+    interval.getEnd should be(new DateTime(2014, 5, 12, 0, 0, 0, Amsterdam))
+  }
+
+  it should "start on Monday at local midnight, west of UTC" in {
+    val interval = firstSubInterval(new DateTime(2014, 5, 8, 16, 26, 0, NewYork), MultiDuration(1, TimeUnit.Week))
+    interval.getStart should be(new DateTime(2014, 5, 5, 0, 0, 0, NewYork))
+    interval.getEnd should be(new DateTime(2014, 5, 12, 0, 0, 0, NewYork))
+  }
+
+  it should "align a multi-week bucket to a Monday" in {
+    val interval = firstSubInterval(new DateTime(2014, 5, 8, 16, 26, 0, Amsterdam), MultiDuration(2, TimeUnit.Week))
+    interval.getStart should be(new DateTime(2014, 4, 28, 0, 0, 0, Amsterdam))
+    interval.getEnd should be(new DateTime(2014, 5, 12, 0, 0, 0, Amsterdam))
+  }
+
+  it should "span a DST transition inside the week" in {
+    val interval = firstSubInterval(new DateTime(2014, 3, 30, 12, 0, 0, Amsterdam), MultiDuration(1, TimeUnit.Week))
+    interval.getStart should be(new DateTime(2014, 3, 24, 0, 0, 0, Amsterdam))
+    interval.getEnd should be(new DateTime(2014, 3, 31, 0, 0, 0, Amsterdam))
+    interval.toDuration.getStandardHours should be((7 * 24) - 1)
+  }
+
+  // Deliberately pinned, because it is the one inconsistency here: sub-day buckets are aligned on the epoch rather
+  // than on local midnight, so east of UTC a 6-hour bucket starts at 02:00, 08:00, 14:00, 20:00 local -- not at
+  // midnight. Day and Week above do align locally. A port that "fixed" this silently would change every grouped
+  // result for non-UTC consumers.
+  "Sub-day alignment" should "bucket on the epoch rather than on local midnight" in {
+    val interval = firstSubInterval(new DateTime(2014, 5, 8, 12, 0, 0, Amsterdam), MultiDuration(6, TimeUnit.Hour))
+    interval.getStart should be(new DateTime(2014, 5, 8, 8, 0, 0, Amsterdam))
+    interval.getEnd should be(new DateTime(2014, 5, 8, 14, 0, 0, Amsterdam))
+  }
+
+  it should "bucket minutes on the epoch, west of UTC" in {
+    val interval = firstSubInterval(new DateTime(2014, 5, 8, 16, 26, 12, NewYork), MultiDuration(15, TimeUnit.Minute))
+    interval.getStart should be(new DateTime(2014, 5, 8, 16, 15, 0, NewYork))
+    interval.getEnd should be(new DateTime(2014, 5, 8, 16, 30, 0, NewYork))
   }
 
 }

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/marshalling/ClickhouseJsonSupport.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/marshalling/ClickhouseJsonSupport.scala
@@ -17,8 +17,14 @@ trait ClickhouseJsonSupport {
 
     override def write(obj: IntervalStart): JsValue = JsNumber(obj.getMillis)
 
-    val month: Regex                 = """(\d+)_(.*)""".r
-    val date: Regex                  = """(.+)_(.*)""".r
+    val month: Regex = """(\d+)_(.*)""".r
+
+    // Lazy first group, deliberately. Greedy, this split on the *last* underscore, so any timezone whose id contains
+    // one -- America/New_York, America/Los_Angeles, Asia/Ho_Chi_Minh -- was cut in half: `1970-12-17_America/New_York`
+    // parsed as date `1970-12-17_America/New` in zone `York`, and the resulting IllegalArgumentException is not caught
+    // in this branch, so date-granularity grouping failed outright for those zones. A date never contains an
+    // underscore, so splitting on the first is right. `month` was never affected: `\d+` cannot over-consume.
+    val date: Regex                  = """(.+?)_(.*)""".r
     val nanoTimestamp: Regex         = """^(\d{16})$""".r
     val msTimestamp: Regex           = """^(\d{13})$""".r
     val timestamp: Regex             = """^(\d{10})$""".r

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/marshalling/ClickhouseJsonSupport.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/marshalling/ClickhouseJsonSupport.scala
@@ -19,11 +19,7 @@ trait ClickhouseJsonSupport {
 
     val month: Regex = """(\d+)_(.*)""".r
 
-    // Lazy first group, deliberately. Greedy, this split on the *last* underscore, so any timezone whose id contains
-    // one -- America/New_York, America/Los_Angeles, Asia/Ho_Chi_Minh -- was cut in half: `1970-12-17_America/New_York`
-    // parsed as date `1970-12-17_America/New` in zone `York`, and the resulting IllegalArgumentException is not caught
-    // in this branch, so date-granularity grouping failed outright for those zones. A date never contains an
-    // underscore, so splitting on the first is right. `month` was never affected: `\d+` cannot over-consume.
+    // Lazy: a zone id can contain an underscore (America/New_York), a date cannot, so split on the first.
     val date: Regex                  = """(.+?)_(.*)""".r
     val nanoTimestamp: Regex         = """^(\d{16})$""".r
     val msTimestamp: Regex           = """^(\d{13})$""".r

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/marshalling/ClickhouseIntervalStartFormatTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/marshalling/ClickhouseIntervalStartFormatTest.scala
@@ -44,4 +44,65 @@ class ClickhouseIntervalStartFormatTest extends DslTestSpec {
     // JsString("1618876800000000").convertTo[IntervalStart] should be ("53270-03-01T00:00:00.000Z")
     JsString("1618876800000000").convertTo[IntervalStart].getMillis should be(1618876800000L)
   }
+
+  // A zone id with an underscore in it. The date regex used to be greedy and split on the last underscore, cutting
+  // the id in half and throwing out of the reader rather than returning a date.
+  it should "read date only for a timezone whose id contains an underscore" in {
+    ClickhouseIntervalStartFormat.read(JsString("1970-12-17_America/New_York")) should be(
+      new DateTime("1970-12-17T00:00:00.000-05:00", DateTimeZone.UTC)
+    )
+  }
+
+  it should "read date only for a timezone with two underscores" in {
+    ClickhouseIntervalStartFormat.read(JsString("1970-12-17_America/Argentina/Rio_Gallegos")) should be(
+      new DateTime("1970-12-17T00:00:00.000-03:00", DateTimeZone.UTC)
+    )
+  }
+
+  // The month branch was never affected -- `\d+` cannot swallow the zone -- but pin it so a future rewrite of either
+  // regex has to keep both working.
+  it should "read month relative for a timezone whose id contains an underscore" in {
+    ClickhouseIntervalStartFormat.read(
+      JsString(s"${ClickhouseIntervalStartFormat.RelativeMonthsSinceUnixStart + 3}_America/New_York")
+    ) should be(new DateTime("1970-04-01T00:00:00.000-05:00", DateTimeZone.UTC))
+  }
+
+  it should "read a month before the unix epoch" in {
+    ClickhouseIntervalStartFormat.read(
+      JsString(s"${ClickhouseIntervalStartFormat.RelativeMonthsSinceUnixStart - 2}_$zone")
+    ) should be(new DateTime("1969-11-01T00:00:00.000+02:00", DateTimeZone.UTC))
+  }
+
+  // Quarter and year grouping come back through the date branch, per the comment on it.
+  it should "read a quarter boundary as a date" in {
+    ClickhouseIntervalStartFormat.read(JsString(s"1970-04-01_$zone")) should be(
+      new DateTime("1970-04-01T00:00:00.000+02:00", DateTimeZone.UTC)
+    )
+  }
+
+  it should "read a year boundary as a date" in {
+    ClickhouseIntervalStartFormat.read(JsString(s"1971-01-01_$zone")) should be(
+      new DateTime("1971-01-01T00:00:00.000+02:00", DateTimeZone.UTC)
+    )
+  }
+
+  // Ten digits: seconds rather than millis. This branch had no test at all.
+  it should "read a ten-digit value as seconds" in {
+    ClickhouseIntervalStartFormat.read(JsString("1618876800")) should be(
+      new DateTime(1618876800000L, DateTimeZone.UTC)
+    )
+  }
+
+  it should "read a sixteen-digit value as microseconds" in {
+    ClickhouseIntervalStartFormat.read(JsString("1618876800000000")).getMillis should be(1618876800000L)
+  }
+
+  it should "write millis" in {
+    val date = new DateTime(1618876800000L, DateTimeZone.UTC)
+    ClickhouseIntervalStartFormat.write(date) should be(JsNumber(1618876800000L))
+  }
+
+  it should "refuse a value it cannot parse rather than returning an epoch" in {
+    a[Exception] should be thrownBy ClickhouseIntervalStartFormat.read(JsString("not-a-date"))
+  }
 }

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/marshalling/ClickhouseIntervalStartFormatTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/marshalling/ClickhouseIntervalStartFormatTest.scala
@@ -45,8 +45,6 @@ class ClickhouseIntervalStartFormatTest extends DslTestSpec {
     JsString("1618876800000000").convertTo[IntervalStart].getMillis should be(1618876800000L)
   }
 
-  // A zone id with an underscore in it. The date regex used to be greedy and split on the last underscore, cutting
-  // the id in half and throwing out of the reader rather than returning a date.
   it should "read date only for a timezone whose id contains an underscore" in {
     ClickhouseIntervalStartFormat.read(JsString("1970-12-17_America/New_York")) should be(
       new DateTime("1970-12-17T00:00:00.000-05:00", DateTimeZone.UTC)
@@ -59,8 +57,6 @@ class ClickhouseIntervalStartFormatTest extends DslTestSpec {
     )
   }
 
-  // The month branch was never affected -- `\d+` cannot swallow the zone -- but pin it so a future rewrite of either
-  // regex has to keep both working.
   it should "read month relative for a timezone whose id contains an underscore" in {
     ClickhouseIntervalStartFormat.read(
       JsString(s"${ClickhouseIntervalStartFormat.RelativeMonthsSinceUnixStart + 3}_America/New_York")
@@ -73,7 +69,6 @@ class ClickhouseIntervalStartFormatTest extends DslTestSpec {
     ) should be(new DateTime("1969-11-01T00:00:00.000+02:00", DateTimeZone.UTC))
   }
 
-  // Quarter and year grouping come back through the date branch, per the comment on it.
   it should "read a quarter boundary as a date" in {
     ClickhouseIntervalStartFormat.read(JsString(s"1970-04-01_$zone")) should be(
       new DateTime("1970-04-01T00:00:00.000+02:00", DateTimeZone.UTC)
@@ -86,7 +81,6 @@ class ClickhouseIntervalStartFormatTest extends DslTestSpec {
     )
   }
 
-  // Ten digits: seconds rather than millis. This branch had no test at all.
   it should "read a ten-digit value as seconds" in {
     ClickhouseIntervalStartFormat.read(JsString("1618876800")) should be(
       new DateTime(1618876800000L, DateTimeZone.UTC)


### PR DESCRIPTION
Groundwork for #326 (joda-time → java.time), plus one real bug the groundwork uncovered.

## Why not just migrate

#326 touches 32 files, but the imports are the easy part. `java.time` splits joda's `Period` into a date-based `Period` and a time-based `Duration`, **normalises weeks into days** (`Period.ofWeeks(1).toString == "P7D"`, so `TimeUnit.apply` can no longer tell a week from 7 days), and offers different primitives for the epoch-offset arithmetic `MultiInterval` does by hand. Every one of those can change results without failing to compile.

And `MultiIntervalTest` had **four cases, all in UTC** — where the `tzOffset` arithmetic in the Day and Week branches is a no-op. The most timezone-sensitive code in the library had no timezone coverage.

## What is now pinned

Eleven cases in real zones, both sides of UTC, across both DST transitions:

- **Day and Week buckets start at *local* midnight**, Week on a Monday — verified in `Europe/Amsterdam` and `America/New_York`.
- **A spring-forward day is 23 hours and a fall-back day 25**, because these are calendar days rather than fixed durations.
- **Sub-day buckets align on the epoch, not on local midnight.** East of UTC a 6-hour bucket starts at 02:00/08:00/14:00/20:00 local, so 12:00 in Amsterdam gives a bucket starting 08:00.

That last one is the inconsistency in the current design — Day and Week align locally, sub-day buckets don't — and it's pinned *deliberately*. A port that tidied it would silently change every grouped result for non-UTC consumers. Worth a conscious decision later, not an accidental one.

## The bug

`ClickhouseIntervalStartFormat`'s `date` regex was `"""(.+)_(.*)"""` — greedy, so it split on the **last** underscore:

| Input | dateOnly | timezoneId | |
|---|---|---|---|
| `1970-12-17_Europe/Bucharest` | `1970-12-17` | `Europe/Bucharest` | ✅ |
| `1970-12-17_America/New_York` | `1970-12-17_America/New` | `York` | ❌ throws |
| `1970-12-17_America/Los_Angeles` | `1970-12-17_America/Los` | `Angeles` | ❌ throws |

The resulting `IllegalArgumentException` is **not caught** in that branch, so date-granularity grouping — day, week, and the quarter/year paths that come back as dates — failed outright for any timezone whose id contains an underscore. That's `America/New_York`, `America/Los_Angeles`, `America/Sao_Paulo`, `America/Mexico_City`, `Asia/Ho_Chi_Minh`, and more.

Fixed by making the first group lazy. A date never contains an underscore, so the first one is the right split point. `month` was never affected (`\d+` can't over-consume), but there's now a test holding both — I verified the two new tests fail against the old regex and pass against the new one.

## Also covered

Branches that previously had no test at all: a ten-digit seconds value, quarter and year boundaries through the date branch, a month before the epoch, the `write` side, and that an unparseable value raises rather than quietly yielding the epoch.

## Verification

- `scalafmtCheckAll` clean; `+compile +Test/compile +It/compile` green on 2.13 and 3.3.
- **308 dsl unit tests**, 138 integration tests, and the client suite green apart from the two known environmental failures (`should support SSL certs` needs a local keystore; `should select cluster hosts` needs a clustered server).
- No behaviour change beyond the regex fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)