### PR TITLE
Migrate joda-time to java.time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,8 +40,7 @@ lazy val client: Project = (project in file("client"))
       "org.apache.pekko"           %% "pekko-stream"  % PekkoVersion,
       "org.apache.pekko"           %% "pekko-http"    % PekkoHttpVersion,
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.6",
-      "com.typesafe"                % "config"        % "1.4.9",
-      "joda-time"                   % "joda-time"     % "2.14.3"
+      "com.typesafe"                % "config"        % "1.4.9"
     ) ++ Seq("org.apache.pekko" %% "pekko-testkit" % PekkoVersion % Test) ++ Build.testDependencies.map(_ % Test)
   )
 

--- a/client/src/main/scala/com/crobox/clickhouse/partitioning/PartitionDateFormatter.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/partitioning/PartitionDateFormatter.scala
@@ -1,18 +1,22 @@
 package com.crobox.clickhouse.partitioning
 
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, LocalDate, ZoneId, ZonedDateTime}
 import java.util.Date
 
-import org.joda.time.{DateTime, LocalDate}
-import org.joda.time.format.DateTimeFormat
-
 object PartitionDateFormatter {
-  private val formatter = DateTimeFormat.forPattern("yyyy-MM-dd")
+  private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 
-  def dateFormat(ts: Long): String = formatter.print(ts)
+  /** A bare instant carries no zone, so the system default decides the date, as it did before. */
+  def dateFormat(ts: Long): String =
+    formatter.format(Instant.ofEpochMilli(ts).atZone(ZoneId.systemDefault()))
 
-  def dateFormat(dt: LocalDate): String = formatter.print(dt)
+  def dateFormat(dt: LocalDate): String = formatter.format(dt)
 
-  def dateFormat(dt: DateTime): String = dateFormat(dt.getMillis)
+  /**
+   * Uses the value's own zone. Previously this went through the epoch millis and so used the system default instead.
+   */
+  def dateFormat(dt: ZonedDateTime): String = formatter.format(dt)
 
   def dateFormat(dt: Date): String = dateFormat(dt.getTime)
 }

--- a/client/src/main/scala/com/crobox/clickhouse/time/Duration.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/time/Duration.scala
@@ -1,6 +1,6 @@
 package com.crobox.clickhouse.time
 
-import org.joda.time.Period
+import java.time.ZonedDateTime
 
 sealed trait Duration {
   val unit: TimeUnit
@@ -25,7 +25,10 @@ object Duration {
 }
 
 case class MultiDuration(value: Int, override val unit: MultiTimeUnit) extends Duration {
-  val asPeriod: Period = unit.asPeriod.multipliedBy(value)
+
+  def addTo(moment: ZonedDateTime): ZonedDateTime = moment.plus(value.toLong * unit.amount, unit.chronoUnit)
+
+  def millis: Long = unit.standardMillis * value
 }
 
 object MultiDuration {

--- a/client/src/main/scala/com/crobox/clickhouse/time/MultiInterval.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/time/MultiInterval.scala
@@ -2,8 +2,9 @@ package com.crobox.clickhouse.time
 
 import com.crobox.clickhouse.time.MultiInterval._
 import com.crobox.clickhouse.time.TimeUnit._
-import org.joda.time.base.BaseInterval
-import org.joda.time.{DateTime, DateTimeConstants, DateTimeZone, Interval}
+
+import java.time.temporal.{ChronoUnit, TemporalAdjusters}
+import java.time.{DayOfWeek, Instant, ZonedDateTime}
 
 /**
  * A multi interval is a interval that contains subintervals, this is then used to select data by constaint, and
@@ -16,87 +17,93 @@ import org.joda.time.{DateTime, DateTimeConstants, DateTimeZone, Interval}
  * @param duration
  *   The length/duration of the subintervals
  */
-case class MultiInterval(rawStart: DateTime, rawEnd: DateTime, duration: Duration)
-    extends BaseInterval(startFromDate(rawStart, duration), intervalsBetween(rawStart, rawEnd, duration).last.getEnd) {
+case class MultiInterval(rawStart: ZonedDateTime, rawEnd: ZonedDateTime, duration: Duration) {
 
-  private lazy val innerIntervals = intervalsBetween(rawStart, rawEnd, duration)
+  private val innerIntervals: IndexedSeq[TimeInterval] = intervalsBetween(rawStart, rawEnd, duration)
 
-  def subIntervals: Seq[Interval] =
-    innerIntervals
+  val start: ZonedDateTime = startFromDate(rawStart, duration)
+
+  val end: ZonedDateTime = innerIntervals.last.end
+
+  def subIntervals: Seq[TimeInterval] = innerIntervals
 }
 
 object MultiInterval {
 
-  private def startFromDate(start: DateTime, duration: Duration) =
+  private def atEpochMilli(reference: ZonedDateTime, millis: Long): ZonedDateTime =
+    Instant.ofEpochMilli(millis).atZone(reference.getZone)
+
+  private def startOfDay(moment: ZonedDateTime): ZonedDateTime =
+    moment.toLocalDate.atStartOfDay(moment.getZone)
+
+  private def offsetMillis(moment: ZonedDateTime): Long =
+    moment.getOffset.getTotalSeconds.toLong * 1000L
+
+  private def startFromDate(start: ZonedDateTime, duration: Duration): ZonedDateTime =
     duration match {
       case MultiDuration(value, Second) =>
-        val ref = start.withMillisOfSecond(0)
+        val ref = start.truncatedTo(ChronoUnit.SECONDS)
 
-        val secs    = ref.getMillis / 1000
+        val secs    = ref.toInstant.toEpochMilli / 1000
         val detSecs = secs - (secs % value)
 
-        ref.withMillis(detSecs * 1000)
+        atEpochMilli(ref, detSecs * 1000)
       case MultiDuration(value, Minute) =>
-        val ref = start
-          .withSecondOfMinute(0)
-          .withMillisOfSecond(0)
+        val ref = start.truncatedTo(ChronoUnit.MINUTES)
 
-        val mins   = ref.getMillis / Minute.standardMillis
+        val mins   = ref.toInstant.toEpochMilli / Minute.standardMillis
         val detMin = mins - (mins % value)
 
-        ref.withMillis(detMin * Minute.standardMillis)
+        atEpochMilli(ref, detMin * Minute.standardMillis)
       case MultiDuration(value, Hour) =>
-        val ref = start
-          .withMinuteOfHour(0)
-          .withSecondOfMinute(0)
-          .withMillisOfSecond(0)
+        val ref = start.truncatedTo(ChronoUnit.HOURS)
 
-        val hours    = ref.getMillis / Hour.standardMillis
+        val hours    = ref.toInstant.toEpochMilli / Hour.standardMillis
         val detHours = hours - (hours % value)
 
-        ref.withMillis(detHours * Hour.standardMillis)
+        atEpochMilli(ref, detHours * Hour.standardMillis)
       case MultiDuration(value, Day) =>
-        val ref      = start.withTimeAtStartOfDay()
-        val tzOffset = ref.getZone.getOffset(ref.withZone(DateTimeZone.UTC))
+        val ref      = startOfDay(start)
+        val tzOffset = offsetMillis(ref)
 
-        val days    = (ref.getMillis + tzOffset) / Day.standardMillis
+        val days    = (ref.toInstant.toEpochMilli + tzOffset) / Day.standardMillis
         val detDays = days - (days % value)
 
-        ref.withMillis((detDays * Day.standardMillis) - tzOffset)
+        atEpochMilli(ref, (detDays * Day.standardMillis) - tzOffset)
       case MultiDuration(value, Week) =>
-        val ref      = start.withTimeAtStartOfDay.withDayOfWeek(DateTimeConstants.MONDAY)
-        val tzOffset = ref.getZone.getOffset(ref.withZone(DateTimeZone.UTC))
+        val ref      = startOfDay(start).`with`(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+        val tzOffset = offsetMillis(ref)
 
         // Week 1 (since epoch) starts at the 5th of January 1970, hence we subtract the 4 days of week 0
-        val msWeek1 = ref.getMillis - (Day.standardMillis * 4) + tzOffset
+        val msWeek1 = ref.toInstant.toEpochMilli - (Day.standardMillis * 4) + tzOffset
 
         val weeks    = msWeek1 / Week.standardMillis
         val detWeeks = weeks - (weeks % value)
 
-        ref.withMillis((detWeeks * Week.standardMillis) + (Day.standardMillis * 4) - tzOffset)
+        atEpochMilli(ref, (detWeeks * Week.standardMillis) + (Day.standardMillis * 4) - tzOffset)
       case MultiDuration(value, Month) =>
-        val ref = start.withTimeAtStartOfDay.withDayOfMonth(1)
+        val ref = startOfDay(start.withDayOfMonth(1))
 
-        val months       = (ref.getYear * 12) + ref.getMonthOfYear
+        val months       = (ref.getYear * 12) + ref.getMonthValue
         val detRelMonths = (months - 1) - (months % value)
 
         val detMonthOfYearZeroBased = detRelMonths % 12
         val detYear                 = (detRelMonths - detMonthOfYearZeroBased) / 12
 
-        ref.withYear(detYear).withMonthOfYear(detMonthOfYearZeroBased + 1)
+        ref.withYear(detYear).withMonth(detMonthOfYearZeroBased + 1)
       case MultiDuration(value, Quarter) =>
-        val ref = start.withTimeAtStartOfDay.withDayOfMonth(1)
+        val ref = startOfDay(start.withDayOfMonth(1))
 
-        val quarter        = (ref.getYear * 4) + (ref.getMonthOfYear - 1) / 3
+        val quarter        = (ref.getYear * 4) + (ref.getMonthValue - 1) / 3
         val detRelQuarters = quarter - (quarter % value)
 
         val detQuarterOfYearZeroBased = detRelQuarters % 4
         val detYear                   = (detRelQuarters - detQuarterOfYearZeroBased) / 4
 
-        ref.withYear(detYear).withMonthOfYear(detQuarterOfYearZeroBased * 3 + 1)
+        ref.withYear(detYear).withMonth(detQuarterOfYearZeroBased * 3 + 1)
 
       case MultiDuration(value, Year) =>
-        val ref = start.withTimeAtStartOfDay.withDayOfYear(1)
+        val ref = startOfDay(start.withDayOfYear(1))
 
         val detYear = ref.getYear - (ref.getYear % value)
 
@@ -106,7 +113,7 @@ object MultiInterval {
       case d => throw new IllegalArgumentException(s"Invalid duration: $d")
     }
 
-  private def endFromDate(date: DateTime, duration: Duration) =
+  private def endFromDate(date: ZonedDateTime, duration: Duration): ZonedDateTime =
     duration match {
       case TotalDuration =>
         date
@@ -114,38 +121,27 @@ object MultiInterval {
         nextStartFromDate(startFromDate(date, duration), duration)
     }
 
-  private def nextStartFromDate(startDate: DateTime, duration: Duration) =
+  private def nextStartFromDate(startDate: ZonedDateTime, duration: Duration): ZonedDateTime =
     duration match {
-      case MultiDuration(value, Second) =>
-        startDate.plusSeconds(value)
-      case MultiDuration(value, Minute) =>
-        startDate.plusMinutes(value)
-      case MultiDuration(value, Hour) =>
-        startDate.plusHours(value)
-      case MultiDuration(value, Day) =>
-        startDate.plusDays(value)
-      case MultiDuration(value, Week) =>
-        startDate.plusWeeks(value)
-      case MultiDuration(value, Month) =>
-        startDate.plusMonths(value)
-      case MultiDuration(value, Quarter) =>
-        startDate.plusMonths(value * 3)
-      case MultiDuration(value, Year) =>
-        startDate.plusYears(value)
-      case d => throw new IllegalArgumentException(s"Invalid duration: $d")
+      case d: MultiDuration => d.addTo(startDate)
+      case d                => throw new IllegalArgumentException(s"Invalid duration: $d")
     }
 
-  private def intervalsBetween(start: DateTime, end: DateTime, duration: Duration) = {
+  private def intervalsBetween(
+      start: ZonedDateTime,
+      end: ZonedDateTime,
+      duration: Duration
+  ): IndexedSeq[TimeInterval] = {
     val result = duration.unit match {
       case Total =>
-        IndexedSeq(new Interval(start, end))
+        IndexedSeq(TimeInterval(start, end))
       case _ =>
         Iterator
-          .iterate(new Interval(startFromDate(start, duration), endFromDate(start, duration))) { interval =>
-            val intervalStart = nextStartFromDate(interval.getStart, duration)
-            new Interval(intervalStart, endFromDate(intervalStart, duration))
+          .iterate(TimeInterval(startFromDate(start, duration), endFromDate(start, duration))) { interval =>
+            val intervalStart = nextStartFromDate(interval.start, duration)
+            TimeInterval(intervalStart, endFromDate(intervalStart, duration))
           }
-          .takeWhile(_.getStart.isBefore(end))
+          .takeWhile(_.start.isBefore(end))
           .toIndexedSeq
     }
     if (result.isEmpty) {

--- a/client/src/main/scala/com/crobox/clickhouse/time/TimeUnit.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/time/TimeUnit.scala
@@ -1,6 +1,6 @@
 package com.crobox.clickhouse.time
 
-import org.joda.time.Period
+import java.time.temporal.ChronoUnit
 
 sealed trait TimeUnit {
   val labels: Array[String]
@@ -15,9 +15,20 @@ sealed trait TimeUnit {
     }
 }
 
-abstract class MultiTimeUnit(override val labels: Array[String], override val mainLabel: String) extends TimeUnit {
-  val asPeriod: Period
-  lazy protected[time] val standardMillis: Long = asPeriod.toStandardDuration.getMillis
+/**
+ * @param amount
+ *   how many `chronoUnit`s one of this unit spans, so a quarter is three months.
+ */
+abstract class MultiTimeUnit(
+    override val labels: Array[String],
+    override val mainLabel: String,
+    val amount: Int,
+    val chronoUnit: ChronoUnit
+) extends TimeUnit {
+
+  // Exact for second through week. Month and above have no fixed length and never reach here: MultiInterval aligns
+  // them by calendar field instead.
+  lazy protected[time] val standardMillis: Long = chronoUnit.getDuration.toMillis * amount
 }
 
 /**
@@ -28,37 +39,21 @@ object TimeUnit {
   private lazy val allUnits =
     Seq(Second, Minute, Hour, Day, Week, Month, Quarter, Year, Total)
 
-  case object Second extends MultiTimeUnit(Array("s", "second", "seconds"), "second") {
-    override val asPeriod: Period = Period.seconds(1)
-  }
+  case object Second extends MultiTimeUnit(Array("s", "second", "seconds"), "second", 1, ChronoUnit.SECONDS)
 
-  case object Minute extends MultiTimeUnit(Array("m", "minute", "minutes"), "minute") {
-    override val asPeriod: Period = Period.minutes(1)
-  }
+  case object Minute extends MultiTimeUnit(Array("m", "minute", "minutes"), "minute", 1, ChronoUnit.MINUTES)
 
-  case object Hour extends MultiTimeUnit(Array("h", "hour", "hours"), "hour") {
-    override val asPeriod: Period = Period.hours(1)
-  }
+  case object Hour extends MultiTimeUnit(Array("h", "hour", "hours"), "hour", 1, ChronoUnit.HOURS)
 
-  case object Day extends MultiTimeUnit(Array("d", "day", "days"), "day") {
-    override val asPeriod: Period = Period.days(1)
-  }
+  case object Day extends MultiTimeUnit(Array("d", "day", "days"), "day", 1, ChronoUnit.DAYS)
 
-  case object Week extends MultiTimeUnit(Array("w", "week", "weeks"), "week") {
-    override val asPeriod: Period = Period.weeks(1)
-  }
+  case object Week extends MultiTimeUnit(Array("w", "week", "weeks"), "week", 1, ChronoUnit.WEEKS)
 
-  case object Month extends MultiTimeUnit(Array("M", "month", "months"), "month") {
-    override val asPeriod: Period = Period.months(1)
-  }
+  case object Month extends MultiTimeUnit(Array("M", "month", "months"), "month", 1, ChronoUnit.MONTHS)
 
-  case object Quarter extends MultiTimeUnit(Array("q", "quarter"), "quarter") {
-    override val asPeriod: Period = Period.months(3)
-  }
+  case object Quarter extends MultiTimeUnit(Array("q", "quarter"), "quarter", 3, ChronoUnit.MONTHS)
 
-  case object Year extends MultiTimeUnit(Array("y", "year"), "year") {
-    override val asPeriod: Period = Period.years(1)
-  }
+  case object Year extends MultiTimeUnit(Array("y", "year"), "year", 1, ChronoUnit.YEARS)
 
   case object Total extends TimeUnit {
     override val labels: Array[String] = Array("t", "total")
@@ -69,16 +64,8 @@ object TimeUnit {
     .find(_.labels.contains(label))
     .getOrElse(throw new IllegalArgumentException(s"Invalid label $label for time unit."))
 
-  def apply(period: Period): Option[TimeUnit] = period.toString match {
-    case "PT1S" => Some(TimeUnit.Second)
-    case "PT1M" => Some(TimeUnit.Minute)
-    case "PT1H" => Some(TimeUnit.Hour)
-    case "P1D"  => Some(TimeUnit.Day)
-    case "P1W"  => Some(TimeUnit.Week)
-    case "P1M"  => Some(TimeUnit.Month)
-    case "P3M"  => Some(TimeUnit.Quarter)
-    case "P1Y"  => Some(TimeUnit.Year)
-    case _      => None
-  }
-
+  def apply(amount: Int, chronoUnit: ChronoUnit): Option[TimeUnit] =
+    allUnits.collectFirst {
+      case unit: MultiTimeUnit if unit.amount == amount && unit.chronoUnit == chronoUnit => unit
+    }
 }

--- a/client/src/main/scala/com/crobox/clickhouse/time/TimeUnit.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/time/TimeUnit.scala
@@ -26,9 +26,17 @@ abstract class MultiTimeUnit(
     val chronoUnit: ChronoUnit
 ) extends TimeUnit {
 
-  // Exact for second through week. Month and above have no fixed length and never reach here: MultiInterval aligns
-  // them by calendar field instead.
-  lazy protected[time] val standardMillis: Long = chronoUnit.getDuration.toMillis * amount
+  /** False for month and longer, whose length depends on the calendar. */
+  def hasFixedLength: Boolean = true
+
+  // Refuses month and longer rather than returning java.time's ~30.44-day estimate for them, which is what joda's
+  // Period.toStandardDuration did. MultiInterval never asks: it aligns those units by calendar field.
+  lazy protected[time] val standardMillis: Long =
+    if (hasFixedLength) chronoUnit.getDuration.toMillis * amount
+    else
+      throw new UnsupportedOperationException(
+        s"Cannot convert a $mainLabel to milliseconds, because months and longer vary in length"
+      )
 }
 
 /**
@@ -49,11 +57,17 @@ object TimeUnit {
 
   case object Week extends MultiTimeUnit(Array("w", "week", "weeks"), "week", 1, ChronoUnit.WEEKS)
 
-  case object Month extends MultiTimeUnit(Array("M", "month", "months"), "month", 1, ChronoUnit.MONTHS)
+  case object Month extends MultiTimeUnit(Array("M", "month", "months"), "month", 1, ChronoUnit.MONTHS) {
+    override def hasFixedLength: Boolean = false
+  }
 
-  case object Quarter extends MultiTimeUnit(Array("q", "quarter"), "quarter", 3, ChronoUnit.MONTHS)
+  case object Quarter extends MultiTimeUnit(Array("q", "quarter"), "quarter", 3, ChronoUnit.MONTHS) {
+    override def hasFixedLength: Boolean = false
+  }
 
-  case object Year extends MultiTimeUnit(Array("y", "year"), "year", 1, ChronoUnit.YEARS)
+  case object Year extends MultiTimeUnit(Array("y", "year"), "year", 1, ChronoUnit.YEARS) {
+    override def hasFixedLength: Boolean = false
+  }
 
   case object Total extends TimeUnit {
     override val labels: Array[String] = Array("t", "total")

--- a/client/src/main/scala/com/crobox/clickhouse/time/package.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/time/package.scala
@@ -1,16 +1,23 @@
 package com.crobox.clickhouse
 
-import org.joda.time.{DateTime, Interval}
+import java.time.{Duration => JavaDuration, ZonedDateTime}
 
 package object time {
-  type IntervalStart = DateTime
+  type IntervalStart = ZonedDateTime
 
   implicit class FixedDurationExtension(multiDuration: MultiDuration) {
-    def millis(): Long = multiDuration.asPeriod.toStandardDuration.getMillis
+    def millis(): Long = multiDuration.millis
   }
 
-  implicit class IntervalExtras(obj: DateTime) {
+  implicit class IntervalExtras(obj: ZonedDateTime) {
+    def to(endInterval: ZonedDateTime): TimeInterval = TimeInterval(obj, endInterval)
+  }
+}
 
-    def to(endInterval: DateTime) = new Interval(obj, endInterval)
+package time {
+
+  /** Replaces joda's `Interval`, which `MultiInterval` used to extend. */
+  case class TimeInterval(start: ZonedDateTime, end: ZonedDateTime) {
+    def duration: JavaDuration = JavaDuration.between(start, end)
   }
 }

--- a/client/src/test/scala/com/crobox/clickhouse/partitioning/PartitionDateFormatterTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/partitioning/PartitionDateFormatterTest.scala
@@ -2,7 +2,7 @@ package com.crobox.clickhouse.partitioning
 
 import java.util.Date
 
-import org.joda.time.DateTime
+import java.time.{ZoneId, ZonedDateTime}
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
@@ -14,8 +14,16 @@ class PartitionDateFormatterTest extends AnyFlatSpecLike with Matchers {
   it should "parse timestamp to partition date" in {
     PartitionDateFormatter.dateFormat(inputTimestamp) should be(expectedResult)
   }
-  it should "parse joda date time to partition date" in {
-    PartitionDateFormatter.dateFormat(new DateTime(inputTimestamp)) should be(expectedResult)
+  it should "parse a zoned date time to partition date" in {
+    val zoned = ZonedDateTime.ofInstant(java.time.Instant.ofEpochMilli(inputTimestamp), ZoneId.systemDefault())
+    PartitionDateFormatter.dateFormat(zoned) should be(expectedResult)
+  }
+
+  it should "use the value's own zone rather than the system default" in {
+    val instant = java.time.Instant.ofEpochMilli(inputTimestamp)
+    PartitionDateFormatter.dateFormat(instant.atZone(ZoneId.of("UTC"))) should be("2017-12-31")
+    // 08:42 UTC, so a zone ten hours behind is still on the previous day.
+    PartitionDateFormatter.dateFormat(instant.atZone(ZoneId.of("Pacific/Honolulu"))) should be("2017-12-30")
   }
   it should "parse java date to partition date" in {
     PartitionDateFormatter.dateFormat(new Date(inputTimestamp)) should be(expectedResult)

--- a/client/src/test/scala/com/crobox/clickhouse/time/MultiIntervalTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/time/MultiIntervalTest.scala
@@ -177,6 +177,21 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
       (startExpected.plusSeconds(5) to startExpected.plusSeconds(10)) :: Nil)
   }
 
+  "Duration in milliseconds" should "be exact for units with a fixed length" in {
+    MultiDuration(1, TimeUnit.Second).millis shouldBe 1000L
+    MultiDuration(2, TimeUnit.Hour).millis shouldBe 7200000L
+    MultiDuration(1, TimeUnit.Day).millis shouldBe 86400000L
+    MultiDuration(1, TimeUnit.Week).millis shouldBe 604800000L
+  }
+
+  // joda's Period.toStandardDuration refused these; returning java.time's ~30.44-day estimate instead would be a
+  // silently wrong number.
+  it should "refuse units whose length depends on the calendar" in {
+    an[UnsupportedOperationException] should be thrownBy MultiDuration(1, TimeUnit.Month).millis
+    an[UnsupportedOperationException] should be thrownBy MultiDuration(1, TimeUnit.Quarter).millis
+    an[UnsupportedOperationException] should be thrownBy MultiDuration(1, TimeUnit.Year).millis
+  }
+
   // The cases above are all UTC, where MultiInterval's tzOffset arithmetic is a no-op.
 
   private val Amsterdam = ZoneId.of("Europe/Amsterdam")

--- a/client/src/test/scala/com/crobox/clickhouse/time/MultiIntervalTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/time/MultiIntervalTest.scala
@@ -1,7 +1,6 @@
 package com.crobox.clickhouse.time
 
-import org.joda.time.{DateTime, DateTimeZone}
-import org.joda.time.DateTimeZone.UTC
+import java.time.{ZoneId, ZoneOffset, ZonedDateTime}
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -9,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPropertyChecks {
 
   def toDateTime(year: Int, month: Int, day: Int, hour: Int, minutes: Int, seconds: Int, millis: Int) =
-    new DateTime(year, month, day, hour, minutes, seconds, millis, UTC)
+    ZonedDateTime.of(year, month, day, hour, minutes, seconds, millis * 1000000, ZoneOffset.UTC)
 
   "Duration parsing" should "parse expression correctly" in {
     val duration = MultiDuration(1, TimeUnit.Hour)
@@ -20,7 +19,7 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
     Duration.parse("1d") should be(MultiDuration(1, TimeUnit.Day))
   }
 
-  private val dateTime: DateTime = toDateTime(2014, 5, 8, 16, 26, 12, 123)
+  private val dateTime: ZonedDateTime = toDateTime(2014, 5, 8, 16, 26, 12, 123)
 
   "Sub intervals" should "build sub intervals and start end for all time units" in
     forAll(
@@ -28,7 +27,7 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
         ("Time Unit", "End interval function", "Expected intervals"),
         (
           MultiDuration(1, TimeUnit.Second),
-          (time: DateTime) => time.plusSeconds(1),
+          (time: ZonedDateTime) => time.plusSeconds(1),
           IndexedSeq(
             toDateTime(2014, 5, 8, 16, 26, 12, 0) to
               toDateTime(2014, 5, 8, 16, 26, 13, 0),
@@ -38,7 +37,7 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
         ),
         (
           MultiDuration(1, TimeUnit.Minute),
-          (time: DateTime) => time.plusMinutes(1),
+          (time: ZonedDateTime) => time.plusMinutes(1),
           IndexedSeq(
             toDateTime(2014, 5, 8, 16, 26, 0, 0) to
               toDateTime(2014, 5, 8, 16, 27, 0, 0),
@@ -48,7 +47,7 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
         ),
         (
           MultiDuration(1, TimeUnit.Hour),
-          (time: DateTime) => time.plusHours(1),
+          (time: ZonedDateTime) => time.plusHours(1),
           IndexedSeq(
             toDateTime(2014, 5, 8, 16, 0, 0, 0) to
               toDateTime(2014, 5, 8, 17, 0, 0, 0),
@@ -58,7 +57,7 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
         ),
         (
           MultiDuration(6, TimeUnit.Hour),
-          (time: DateTime) => time.plusHours(1),
+          (time: ZonedDateTime) => time.plusHours(1),
           IndexedSeq(
             toDateTime(2014, 5, 8, 12, 0, 0, 0) to
               toDateTime(2014, 5, 8, 18, 0, 0, 0)
@@ -66,7 +65,7 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
         ),
         (
           MultiDuration(6, TimeUnit.Hour),
-          (time: DateTime) => time.plusHours(6),
+          (time: ZonedDateTime) => time.plusHours(6),
           IndexedSeq(
             toDateTime(2014, 5, 8, 12, 0, 0, 0) to
               toDateTime(2014, 5, 8, 18, 0, 0, 0),
@@ -76,7 +75,7 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
         ),
         (
           MultiDuration(1, TimeUnit.Day),
-          (time: DateTime) => time.plusDays(1),
+          (time: ZonedDateTime) => time.plusDays(1),
           IndexedSeq(
             toDateTime(2014, 5, 8, 0, 0, 0, 0) to
               toDateTime(2014, 5, 9, 0, 0, 0, 0),
@@ -86,7 +85,7 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
         ),
         (
           MultiDuration(1, TimeUnit.Week),
-          (time: DateTime) => time.plusWeeks(1),
+          (time: ZonedDateTime) => time.plusWeeks(1),
           IndexedSeq(
             toDateTime(2014, 5, 5, 0, 0, 0, 0) to
               toDateTime(2014, 5, 12, 0, 0, 0, 0),
@@ -96,7 +95,7 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
         ),
         (
           MultiDuration(3, TimeUnit.Week),
-          (time: DateTime) => time.plusWeeks(1),
+          (time: ZonedDateTime) => time.plusWeeks(1),
           IndexedSeq(
             toDateTime(2014, 5, 5, 0, 0, 0, 0) to
               toDateTime(2014, 5, 26, 0, 0, 0, 0)
@@ -104,7 +103,7 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
         ),
         (
           MultiDuration(1, TimeUnit.Month),
-          (time: DateTime) => time.plusMonths(1),
+          (time: ZonedDateTime) => time.plusMonths(1),
           IndexedSeq(
             toDateTime(2014, 5, 1, 0, 0, 0, 0) to
               toDateTime(2014, 6, 1, 0, 0, 0, 0),
@@ -114,7 +113,7 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
         ),
         (
           MultiDuration(2, TimeUnit.Month),
-          (time: DateTime) => time.plusMonths(1),
+          (time: ZonedDateTime) => time.plusMonths(1),
           IndexedSeq(
             toDateTime(2014, 4, 1, 0, 0, 0, 0) to
               toDateTime(2014, 6, 1, 0, 0, 0, 0),
@@ -124,7 +123,7 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
         ),
         (
           MultiDuration(TimeUnit.Quarter),
-          (time: DateTime) => time.plusMonths(3),
+          (time: ZonedDateTime) => time.plusMonths(3),
           IndexedSeq(
             toDateTime(2014, 4, 1, 0, 0, 0, 0) to
               toDateTime(2014, 7, 1, 0, 0, 0, 0),
@@ -134,7 +133,7 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
         ),
         (
           MultiDuration(TimeUnit.Quarter),
-          (time: DateTime) => time.plusMonths(1),
+          (time: ZonedDateTime) => time.plusMonths(1),
           IndexedSeq(
             toDateTime(2014, 4, 1, 0, 0, 0, 0) to
               toDateTime(2014, 7, 1, 0, 0, 0, 0)
@@ -142,119 +141,129 @@ class MultiIntervalTest extends AnyFlatSpecLike with Matchers with TableDrivenPr
         ),
         (
           MultiDuration(TimeUnit.Year),
-          (time: DateTime) => time.plusMonths(3),
+          (time: ZonedDateTime) => time.plusMonths(3),
           IndexedSeq(
             toDateTime(2014, 1, 1, 0, 0, 0, 0) to
               toDateTime(2015, 1, 1, 0, 0, 0, 0)
           )
         ),
-        (TotalDuration, (time: DateTime) => time.plusMonths(3), IndexedSeq(dateTime to dateTime.plusMonths(3)))
+        (TotalDuration, (time: ZonedDateTime) => time.plusMonths(3), IndexedSeq(dateTime to dateTime.plusMonths(3)))
       )
     ) { (duration, intervalEnd, intervals) =>
       val interval = MultiInterval(dateTime, intervalEnd(dateTime), duration)
-      interval.getStart should be(intervals.head.getStart)
-      interval.getEnd should be(intervals.last.getEnd)
+      interval.start should be(intervals.head.start)
+      interval.end should be(intervals.last.end)
       interval.subIntervals should contain theSameElementsInOrderAs intervals
 
     }
 
   it should "build correctly full time interval" in {
-    val start    = DateTime.now().withTimeAtStartOfDay()
+    val start    = ZonedDateTime.now().toLocalDate.atStartOfDay(ZoneId.systemDefault())
     val end      = start.plusDays(1)
     val interval = MultiInterval(start, end, TotalDuration)
-    interval.getStart should be(start)
+    interval.start should be(start)
     interval.subIntervals should contain theSameElementsInOrderAs IndexedSeq(start to end)
-    interval.getEnd should be(end)
+    interval.end should be(end)
   }
 
   it should "include sub interval for which start date is equal to expected interval end date" in {
     val startDate     = toDateTime(2012, 1, 1, 1, 1, 9, 999)
     val endDate       = toDateTime(2012, 1, 1, 1, 1, 14, 999)
     val interval      = MultiInterval(startDate, endDate, MultiDuration(5, TimeUnit.Second))
-    val startExpected = startDate.withMillisOfSecond(0).withSecondOfMinute(5)
-    interval.getStart should be(startExpected)
-    interval.getEnd should be(startExpected.plusSeconds(10))
+    val startExpected = startDate.withNano(0).withSecond(5)
+    interval.start should be(startExpected)
+    interval.end should be(startExpected.plusSeconds(10))
     interval.subIntervals should contain theSameElementsInOrderAs ((startExpected to startExpected.plusSeconds(5)) ::
       (startExpected.plusSeconds(5) to startExpected.plusSeconds(10)) :: Nil)
   }
 
   // The cases above are all UTC, where MultiInterval's tzOffset arithmetic is a no-op.
 
-  private val Amsterdam = DateTimeZone.forID("Europe/Amsterdam")
-  private val NewYork   = DateTimeZone.forID("America/New_York")
+  private val Amsterdam = ZoneId.of("Europe/Amsterdam")
+  private val NewYork   = ZoneId.of("America/New_York")
 
-  private def firstSubInterval(start: DateTime, duration: Duration) =
+  private def firstSubInterval(start: ZonedDateTime, duration: Duration) =
     MultiInterval(start, start.plusDays(2), duration).subIntervals.head
 
   "Day alignment" should "start at local midnight, east of UTC" in {
-    val interval = firstSubInterval(new DateTime(2014, 5, 8, 16, 26, 0, Amsterdam), MultiDuration(1, TimeUnit.Day))
-    interval.getStart should be(new DateTime(2014, 5, 8, 0, 0, 0, Amsterdam))
-    interval.getEnd should be(new DateTime(2014, 5, 9, 0, 0, 0, Amsterdam))
+    val interval =
+      firstSubInterval(ZonedDateTime.of(2014, 5, 8, 16, 26, 0, 0, Amsterdam), MultiDuration(1, TimeUnit.Day))
+    interval.start should be(ZonedDateTime.of(2014, 5, 8, 0, 0, 0, 0, Amsterdam))
+    interval.end should be(ZonedDateTime.of(2014, 5, 9, 0, 0, 0, 0, Amsterdam))
   }
 
   it should "start at local midnight, west of UTC" in {
-    val interval = firstSubInterval(new DateTime(2014, 5, 8, 16, 26, 0, NewYork), MultiDuration(1, TimeUnit.Day))
-    interval.getStart should be(new DateTime(2014, 5, 8, 0, 0, 0, NewYork))
-    interval.getEnd should be(new DateTime(2014, 5, 9, 0, 0, 0, NewYork))
+    val interval = firstSubInterval(ZonedDateTime.of(2014, 5, 8, 16, 26, 0, 0, NewYork), MultiDuration(1, TimeUnit.Day))
+    interval.start should be(ZonedDateTime.of(2014, 5, 8, 0, 0, 0, 0, NewYork))
+    interval.end should be(ZonedDateTime.of(2014, 5, 9, 0, 0, 0, 0, NewYork))
   }
 
   it should "align a multi-day bucket to local midnight" in {
-    val interval = firstSubInterval(new DateTime(2014, 5, 8, 16, 26, 0, Amsterdam), MultiDuration(2, TimeUnit.Day))
-    interval.getStart should be(new DateTime(2014, 5, 8, 0, 0, 0, Amsterdam))
-    interval.getEnd should be(new DateTime(2014, 5, 10, 0, 0, 0, Amsterdam))
+    val interval =
+      firstSubInterval(ZonedDateTime.of(2014, 5, 8, 16, 26, 0, 0, Amsterdam), MultiDuration(2, TimeUnit.Day))
+    interval.start should be(ZonedDateTime.of(2014, 5, 8, 0, 0, 0, 0, Amsterdam))
+    interval.end should be(ZonedDateTime.of(2014, 5, 10, 0, 0, 0, 0, Amsterdam))
   }
 
   it should "keep a spring-forward day one calendar day, not 24 hours" in {
-    val interval = firstSubInterval(new DateTime(2014, 3, 30, 12, 0, 0, Amsterdam), MultiDuration(1, TimeUnit.Day))
-    interval.getStart should be(new DateTime(2014, 3, 30, 0, 0, 0, Amsterdam))
-    interval.getEnd should be(new DateTime(2014, 3, 31, 0, 0, 0, Amsterdam))
-    interval.toDuration.getStandardHours should be(23)
+    val interval =
+      firstSubInterval(ZonedDateTime.of(2014, 3, 30, 12, 0, 0, 0, Amsterdam), MultiDuration(1, TimeUnit.Day))
+    interval.start should be(ZonedDateTime.of(2014, 3, 30, 0, 0, 0, 0, Amsterdam))
+    interval.end should be(ZonedDateTime.of(2014, 3, 31, 0, 0, 0, 0, Amsterdam))
+    interval.duration.toHours should be(23)
   }
 
   it should "keep a fall-back day one calendar day, not 24 hours" in {
-    val interval = firstSubInterval(new DateTime(2014, 10, 26, 12, 0, 0, Amsterdam), MultiDuration(1, TimeUnit.Day))
-    interval.getStart should be(new DateTime(2014, 10, 26, 0, 0, 0, Amsterdam))
-    interval.getEnd should be(new DateTime(2014, 10, 27, 0, 0, 0, Amsterdam))
-    interval.toDuration.getStandardHours should be(25)
+    val interval =
+      firstSubInterval(ZonedDateTime.of(2014, 10, 26, 12, 0, 0, 0, Amsterdam), MultiDuration(1, TimeUnit.Day))
+    interval.start should be(ZonedDateTime.of(2014, 10, 26, 0, 0, 0, 0, Amsterdam))
+    interval.end should be(ZonedDateTime.of(2014, 10, 27, 0, 0, 0, 0, Amsterdam))
+    interval.duration.toHours should be(25)
   }
 
   "Week alignment" should "start on Monday at local midnight, east of UTC" in {
-    val interval = firstSubInterval(new DateTime(2014, 5, 8, 16, 26, 0, Amsterdam), MultiDuration(1, TimeUnit.Week))
-    interval.getStart should be(new DateTime(2014, 5, 5, 0, 0, 0, Amsterdam))
-    interval.getEnd should be(new DateTime(2014, 5, 12, 0, 0, 0, Amsterdam))
+    val interval =
+      firstSubInterval(ZonedDateTime.of(2014, 5, 8, 16, 26, 0, 0, Amsterdam), MultiDuration(1, TimeUnit.Week))
+    interval.start should be(ZonedDateTime.of(2014, 5, 5, 0, 0, 0, 0, Amsterdam))
+    interval.end should be(ZonedDateTime.of(2014, 5, 12, 0, 0, 0, 0, Amsterdam))
   }
 
   it should "start on Monday at local midnight, west of UTC" in {
-    val interval = firstSubInterval(new DateTime(2014, 5, 8, 16, 26, 0, NewYork), MultiDuration(1, TimeUnit.Week))
-    interval.getStart should be(new DateTime(2014, 5, 5, 0, 0, 0, NewYork))
-    interval.getEnd should be(new DateTime(2014, 5, 12, 0, 0, 0, NewYork))
+    val interval =
+      firstSubInterval(ZonedDateTime.of(2014, 5, 8, 16, 26, 0, 0, NewYork), MultiDuration(1, TimeUnit.Week))
+    interval.start should be(ZonedDateTime.of(2014, 5, 5, 0, 0, 0, 0, NewYork))
+    interval.end should be(ZonedDateTime.of(2014, 5, 12, 0, 0, 0, 0, NewYork))
   }
 
   it should "align a multi-week bucket to a Monday" in {
-    val interval = firstSubInterval(new DateTime(2014, 5, 8, 16, 26, 0, Amsterdam), MultiDuration(2, TimeUnit.Week))
-    interval.getStart should be(new DateTime(2014, 4, 28, 0, 0, 0, Amsterdam))
-    interval.getEnd should be(new DateTime(2014, 5, 12, 0, 0, 0, Amsterdam))
+    val interval =
+      firstSubInterval(ZonedDateTime.of(2014, 5, 8, 16, 26, 0, 0, Amsterdam), MultiDuration(2, TimeUnit.Week))
+    interval.start should be(ZonedDateTime.of(2014, 4, 28, 0, 0, 0, 0, Amsterdam))
+    interval.end should be(ZonedDateTime.of(2014, 5, 12, 0, 0, 0, 0, Amsterdam))
   }
 
   it should "span a DST transition inside the week" in {
-    val interval = firstSubInterval(new DateTime(2014, 3, 30, 12, 0, 0, Amsterdam), MultiDuration(1, TimeUnit.Week))
-    interval.getStart should be(new DateTime(2014, 3, 24, 0, 0, 0, Amsterdam))
-    interval.getEnd should be(new DateTime(2014, 3, 31, 0, 0, 0, Amsterdam))
-    interval.toDuration.getStandardHours should be((7 * 24) - 1)
+    val interval =
+      firstSubInterval(ZonedDateTime.of(2014, 3, 30, 12, 0, 0, 0, Amsterdam), MultiDuration(1, TimeUnit.Week))
+    interval.start should be(ZonedDateTime.of(2014, 3, 24, 0, 0, 0, 0, Amsterdam))
+    interval.end should be(ZonedDateTime.of(2014, 3, 31, 0, 0, 0, 0, Amsterdam))
+    interval.duration.toHours should be((7 * 24) - 1)
   }
 
   // Pinned on purpose: unlike Day and Week above, sub-day buckets do not align to local midnight. Looks like a bug,
   // is not, and changing it would move every grouped result for non-UTC consumers.
   "Sub-day alignment" should "bucket on the epoch rather than on local midnight" in {
-    val interval = firstSubInterval(new DateTime(2014, 5, 8, 12, 0, 0, Amsterdam), MultiDuration(6, TimeUnit.Hour))
-    interval.getStart should be(new DateTime(2014, 5, 8, 8, 0, 0, Amsterdam))
-    interval.getEnd should be(new DateTime(2014, 5, 8, 14, 0, 0, Amsterdam))
+    val interval =
+      firstSubInterval(ZonedDateTime.of(2014, 5, 8, 12, 0, 0, 0, Amsterdam), MultiDuration(6, TimeUnit.Hour))
+    interval.start should be(ZonedDateTime.of(2014, 5, 8, 8, 0, 0, 0, Amsterdam))
+    interval.end should be(ZonedDateTime.of(2014, 5, 8, 14, 0, 0, 0, Amsterdam))
   }
 
   it should "bucket minutes on the epoch, west of UTC" in {
-    val interval = firstSubInterval(new DateTime(2014, 5, 8, 16, 26, 12, NewYork), MultiDuration(15, TimeUnit.Minute))
-    interval.getStart should be(new DateTime(2014, 5, 8, 16, 15, 0, NewYork))
-    interval.getEnd should be(new DateTime(2014, 5, 8, 16, 30, 0, NewYork))
+    val interval =
+      firstSubInterval(ZonedDateTime.of(2014, 5, 8, 16, 26, 12, 0, NewYork), MultiDuration(15, TimeUnit.Minute))
+    interval.start should be(ZonedDateTime.of(2014, 5, 8, 16, 15, 0, 0, NewYork))
+    interval.end should be(ZonedDateTime.of(2014, 5, 8, 16, 30, 0, 0, NewYork))
   }
 
 }

--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/ClickhouseTimeSeriesIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/ClickhouseTimeSeriesIT.scala
@@ -4,7 +4,8 @@ import com.crobox.clickhouse.{ClickhouseClient, DslITSpec}
 import com.crobox.clickhouse.dsl.execution.QueryResult
 import com.crobox.clickhouse.dsl.marshalling.ClickhouseJsonSupport._
 import com.crobox.clickhouse.time.{IntervalStart, MultiDuration, MultiInterval, TimeUnit, TotalDuration}
-import org.joda.time.{DateTime, DateTimeZone, Days}
+import java.time.temporal.ChronoUnit
+import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
 import org.scalactic.TripleEqualsSupport
 import org.scalatest.prop.TableDrivenPropertyChecks
 import spray.json.RootJsonFormat
@@ -22,12 +23,13 @@ class ClickhouseTimeSeriesIT extends DslITSpec with TableDrivenPropertyChecks {
   }
 
   implicit val clickhouseClient: ClickhouseClient = clickClient
-  val startInterval = DateTime.parse("2019-03-01").withTimeAtStartOfDay().withZone(DateTimeZone.UTC)
-  val secondsId     = UUID.randomUUID()
-  val dayId         = UUID.randomUUID()
-  val minutesId     = UUID.randomUUID()
+  val startInterval                               = LocalDate.parse("2019-03-01").atStartOfDay(ZoneOffset.UTC)
+  val secondsId                                   = UUID.randomUUID()
+  val dayId                                       = UUID.randomUUID()
+  val minutesId                                   = UUID.randomUUID()
   private val numberOfGeneratedEntries: Int       = 60 * 60 * 5
-  private val numberOfGeneratedEntriesForDay: Int = Days.daysBetween(startInterval, startInterval.plusYears(5)).getDays
+  private val numberOfGeneratedEntriesForDay: Int =
+    ChronoUnit.DAYS.between(startInterval, startInterval.plusYears(5)).toInt
 
   val secondAndMinuteEntries: Seq[Table1Entry] = (0 until numberOfGeneratedEntries).flatMap(diff =>
     Table1Entry(secondsId, startInterval.plusSeconds(diff)) ::
@@ -42,7 +44,7 @@ class ClickhouseTimeSeriesIT extends DslITSpec with TableDrivenPropertyChecks {
   val lastDayIntervalDate    = startInterval.plusDays(numberOfGeneratedEntriesForDay)
 
   "Grouping on total" should "return full result" in {
-    val modifiedStartInterval = startInterval.minus(12416)
+    val modifiedStartInterval = startInterval.minus(java.time.Duration.ofMillis(12416))
     val multiInterval         = MultiInterval(modifiedStartInterval, lastSecondEntryDate, TotalDuration)
     val results: Future[QueryResult[CustomResult]] = getEntries(multiInterval, secondsId)
     val rows                                       = results.futureValue.rows
@@ -55,7 +57,7 @@ class ClickhouseTimeSeriesIT extends DslITSpec with TableDrivenPropertyChecks {
     forAll(Table("Second", 1, 2, 3, 5, 10, 15, 20, 30)) { duration =>
       val multiInterval = MultiInterval(startInterval, lastSecondEntryDate, MultiDuration(duration, TimeUnit.Second))
       val results: Future[QueryResult[CustomResult]] = getEntries(multiInterval, secondsId)
-      val expectedIntervalStarts = multiInterval.subIntervals.map(_.getStart.withZone(DateTimeZone.UTC))
+      val expectedIntervalStarts = multiInterval.subIntervals.map(_.start.withZoneSameInstant(ZoneOffset.UTC))
       val rows                   = results.futureValue.rows
       validateFullRows(rows, duration)
       rows.map(_.time) should contain theSameElementsInOrderAs expectedIntervalStarts
@@ -67,7 +69,7 @@ class ClickhouseTimeSeriesIT extends DslITSpec with TableDrivenPropertyChecks {
       val multiInterval = MultiInterval(startInterval, lastSecondEntryDate, MultiDuration(duration, TimeUnit.Minute))
       forAll(Table("Timezone", multiInterval, shiftedTz(multiInterval))) { multiInterval =>
         val results: Future[QueryResult[CustomResult]] = getEntries(multiInterval, secondsId)
-        val expectedIntervalStarts = multiInterval.subIntervals.map(_.getStart.withZone(DateTimeZone.UTC))
+        val expectedIntervalStarts = multiInterval.subIntervals.map(_.start.withZoneSameInstant(ZoneOffset.UTC))
         val rows                   = results.futureValue.rows
         validateFullRows(rows, expectedEntriesPerMinutes * duration)
         rows.map(_.time) should contain theSameElementsInOrderAs expectedIntervalStarts
@@ -80,7 +82,7 @@ class ClickhouseTimeSeriesIT extends DslITSpec with TableDrivenPropertyChecks {
       val multiInterval = MultiInterval(startInterval, lastMinuteIntervalDate, MultiDuration(duration, TimeUnit.Hour))
       forAll(Table("Timezone", multiInterval, shiftedTz(multiInterval))) { multiInterval =>
         val results: Future[QueryResult[CustomResult]] = getEntries(multiInterval, minutesId)
-        val expectedIntervalStarts      = multiInterval.subIntervals.map(_.getStart.withZone(DateTimeZone.UTC))
+        val expectedIntervalStarts      = multiInterval.subIntervals.map(_.start.withZoneSameInstant(ZoneOffset.UTC))
         val rows                        = results.futureValue.rows
         val expectedCountInFullInterval = expectedEntriesPerHour * duration
         validateFullRows(rows, expectedCountInFullInterval)
@@ -94,7 +96,7 @@ class ClickhouseTimeSeriesIT extends DslITSpec with TableDrivenPropertyChecks {
       val multiInterval = MultiInterval(startInterval, lastMinuteIntervalDate, MultiDuration(duration, TimeUnit.Day))
       forAll(Table("Timezone", multiInterval, shiftedTz(multiInterval))) { multiInterval =>
         val results: Future[QueryResult[CustomResult]] = getEntries(multiInterval, minutesId)
-        val expectedIntervalStarts      = multiInterval.subIntervals.map(_.getStart.withZone(DateTimeZone.UTC))
+        val expectedIntervalStarts      = multiInterval.subIntervals.map(_.start.withZoneSameInstant(ZoneOffset.UTC))
         val rows                        = results.futureValue.rows
         val expectedCountInFullInterval = expectedEntriesPerDay * duration
         validateFullRows(rows, expectedCountInFullInterval)
@@ -107,7 +109,7 @@ class ClickhouseTimeSeriesIT extends DslITSpec with TableDrivenPropertyChecks {
       val multiInterval = MultiInterval(startInterval, lastDayIntervalDate, MultiDuration(duration, TimeUnit.Week))
       forAll(Table("Timezone", multiInterval, shiftedTz(multiInterval))) { multiInterval =>
         val results: Future[QueryResult[CustomResult]] = getEntries(multiInterval, dayId)
-        val expectedIntervalStarts      = multiInterval.subIntervals.map(_.getStart.withZone(DateTimeZone.UTC))
+        val expectedIntervalStarts      = multiInterval.subIntervals.map(_.start.withZoneSameInstant(ZoneOffset.UTC))
         val rows                        = results.futureValue.rows
         val expectedCountInFullInterval = 7 * duration
         validateFullRows(rows, expectedCountInFullInterval)
@@ -120,7 +122,7 @@ class ClickhouseTimeSeriesIT extends DslITSpec with TableDrivenPropertyChecks {
       val multiInterval = MultiInterval(startInterval, lastDayIntervalDate, MultiDuration(duration, TimeUnit.Month))
       forAll(Table("Timezone", multiInterval, shiftedTz(multiInterval))) { multiInterval =>
         val results: Future[QueryResult[CustomResult]] = getEntries(multiInterval, dayId)
-        var expectedIntervalStarts      = multiInterval.subIntervals.map(_.getStart.withZone(DateTimeZone.UTC))
+        var expectedIntervalStarts      = multiInterval.subIntervals.map(_.start.withZoneSameInstant(ZoneOffset.UTC))
         val rows                        = results.futureValue.rows
         val expectedCountInFullInterval = duration * 30 +- duration * 3
         validateFullRows(rows, expectedCountInFullInterval)
@@ -141,7 +143,7 @@ class ClickhouseTimeSeriesIT extends DslITSpec with TableDrivenPropertyChecks {
 
       forAll(Table("Timezone", multiInterval, shiftedTz(multiInterval))) { multiInterval =>
         val results: Future[QueryResult[CustomResult]] = getEntries(multiInterval, dayId)
-        val expectedIntervalStarts      = multiInterval.subIntervals.map(_.getStart.withZone(DateTimeZone.UTC))
+        val expectedIntervalStarts      = multiInterval.subIntervals.map(_.start.withZoneSameInstant(ZoneOffset.UTC))
         val rows                        = results.futureValue.rows
         val expectedCountInFullInterval = duration * 90 +- duration * 3
         validateFullRows(rows, expectedCountInFullInterval)
@@ -154,7 +156,7 @@ class ClickhouseTimeSeriesIT extends DslITSpec with TableDrivenPropertyChecks {
       val multiInterval = MultiInterval(startInterval, lastDayIntervalDate, MultiDuration(duration, TimeUnit.Year))
       forAll(Table("Timezone", multiInterval, shiftedTz(multiInterval))) { multiInterval =>
         val results: Future[QueryResult[CustomResult]] = getEntries(multiInterval, dayId)
-        val expectedIntervalStarts      = multiInterval.subIntervals.map(_.getStart.withZone(DateTimeZone.UTC))
+        val expectedIntervalStarts      = multiInterval.subIntervals.map(_.start.withZoneSameInstant(ZoneOffset.UTC))
         val rows                        = results.futureValue.rows
         val expectedCountInFullInterval = duration * 365 +- duration * 4
         validateFullRows(rows, expectedCountInFullInterval)
@@ -184,8 +186,8 @@ class ClickhouseTimeSeriesIT extends DslITSpec with TableDrivenPropertyChecks {
 
   private def shiftedTz(intv: MultiInterval): MultiInterval =
     MultiInterval(
-      intv.rawStart.withZone(DateTimeZone.forOffsetHours(Random.nextInt(24) - 12)),
-      intv.rawEnd.withZone(DateTimeZone.forOffsetHours(Random.nextInt(24) - 12)),
+      intv.rawStart.withZoneSameInstant(ZoneOffset.ofHours(Random.nextInt(24) - 12)),
+      intv.rawEnd.withZoneSameInstant(ZoneOffset.ofHours(Random.nextInt(24) - 12)),
       intv.duration
     )
 }

--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/ClickhouseTimeSeriesIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/ClickhouseTimeSeriesIT.scala
@@ -5,7 +5,7 @@ import com.crobox.clickhouse.dsl.execution.QueryResult
 import com.crobox.clickhouse.dsl.marshalling.ClickhouseJsonSupport._
 import com.crobox.clickhouse.time.{IntervalStart, MultiDuration, MultiInterval, TimeUnit, TotalDuration}
 import java.time.temporal.ChronoUnit
-import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
+import java.time.{LocalDate, ZoneOffset}
 import org.scalactic.TripleEqualsSupport
 import org.scalatest.prop.TableDrivenPropertyChecks
 import spray.json.RootJsonFormat

--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/RowQueryIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/RowQueryIT.scala
@@ -3,7 +3,7 @@ package com.crobox.clickhouse.dsl
 import com.crobox.clickhouse.DslITSpec
 import com.crobox.clickhouse.dsl.execution.ColumnLookupException
 import com.crobox.clickhouse.internal.QuerySettings
-import org.joda.time.DateTime
+import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
 
 import java.util.UUID
 
@@ -18,8 +18,8 @@ class RowQueryIT extends DslITSpec {
   private val idB = UUID.randomUUID()
 
   override val table1Entries: Seq[Table1Entry] = Seq(
-    Table1Entry(idA, DateTime.now(), Seq(1, 2, 3)),
-    Table1Entry(idB, DateTime.now(), Seq(4, 5))
+    Table1Entry(idA, ZonedDateTime.now(), Seq(1, 2, 3)),
+    Table1Entry(idB, ZonedDateTime.now(), Seq(4, 5))
   )
 
   override val table2Entries: Seq[Table2Entry] = Seq(

--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/RowQueryIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/RowQueryIT.scala
@@ -3,7 +3,7 @@ package com.crobox.clickhouse.dsl
 import com.crobox.clickhouse.DslITSpec
 import com.crobox.clickhouse.dsl.execution.ColumnLookupException
 import com.crobox.clickhouse.internal.QuerySettings
-import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
+import java.time.ZonedDateTime
 
 import java.util.UUID
 

--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/column/DateTimeFunctionsIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/column/DateTimeFunctionsIT.scala
@@ -3,25 +3,28 @@ package com.crobox.clickhouse.dsl.column
 import com.crobox.clickhouse.DslITSpec
 import com.crobox.clickhouse.TestUtils.DDTStringify
 import com.crobox.clickhouse.dsl._
-import org.joda.time._
+import java.time.temporal.ChronoUnit
+import java.time.{LocalDate, ZoneOffset, ZonedDateTime}
 
 class DateTimeFunctionsIT extends DslITSpec {
   it should "succeed for DateTimeFunctions" in {
-    val now         = new DateTime().withZone(DateTimeZone.UTC)
-    val epoch       = new DateTime(0).withZone(DateTimeZone.UTC)
-    val August_8_19 = new DateTime().withZone(DateTimeZone.UTC).withYear(2019).withMonthOfYear(8).withDayOfMonth(8)
+    val now         = ZonedDateTime.now(ZoneOffset.UTC)
+    val epoch       = java.time.Instant.EPOCH.atZone(ZoneOffset.UTC)
+    val August_8_19 = ZonedDateTime.now(ZoneOffset.UTC).withYear(2019).withMonth(8).withDayOfMonth(8)
 
-    def dynNow = new DateTime().withZone(DateTimeZone.UTC)
+    def dynNow = ZonedDateTime.now(ZoneOffset.UTC)
 
     r(toYear(now)) shouldBe now.getYear.toString
     r(toYYYYMM(now)) shouldBe now.printAsYYYYMM
-    r(toMonth(now)) shouldBe now.getMonthOfYear.toString
+    r(toMonth(now)) shouldBe now.getMonthValue.toString
     r(toDayOfMonth(now)) shouldBe now.getDayOfMonth.toString
-    r(toDayOfWeek(now)) shouldBe now.getDayOfWeek.toString
-    r(toHour(now)) shouldBe now.getHourOfDay.toString
-    r(toMinute(now)) shouldBe now.getMinuteOfHour.toString
-    r(toSecond(now)) shouldBe now.getSecondOfMinute.toString
-    r(toMonday(now)) shouldBe now.withDayOfWeek(1).printAsDate
+    r(toDayOfWeek(now)) shouldBe now.getDayOfWeek.getValue.toString
+    r(toHour(now)) shouldBe now.getHour.toString
+    r(toMinute(now)) shouldBe now.getMinute.toString
+    r(toSecond(now)) shouldBe now.getSecond.toString
+    r(toMonday(now)) shouldBe now
+      .`with`(java.time.temporal.TemporalAdjusters.previousOrSame(java.time.DayOfWeek.MONDAY))
+      .printAsDate
     r(addSeconds(now, 2)) shouldBe now.plusSeconds(2).printAsDateTime
     r(addMinutes(now, 2)) shouldBe now.plusMinutes(2).printAsDateTime
     r(addHours(now, 2)) shouldBe now.plusHours(2).printAsDateTime
@@ -36,21 +39,21 @@ class DateTimeFunctionsIT extends DslITSpec {
     r(toStartOfFiveMinute(now)) shouldBe now.toStartOfMin(5).printAsDateTime
     r(toStartOfFifteenMinutes(now)) shouldBe now.toStartOfMin(15).printAsDateTime
     r(toStartOfHour(now)) shouldBe now.toStartOfHr.printAsDateTime
-    r(toStartOfDay(now)) shouldBe now.withTimeAtStartOfDay().printAsDateTime
+    r(toStartOfDay(now)) shouldBe now.toLocalDate.atStartOfDay(ZoneOffset.UTC).printAsDateTime
     r(toTime(now)).substring(11) shouldBe now.printAsDateTime.substring(11)
     r(toRelativeYearNum(now)) shouldBe now.getYear.toString
-    r(toRelativeQuarterNum(now)) shouldBe ((now.getYear * 4) + (now.getMonthOfYear - 1) / 3).toString
-    r(toRelativeMonthNum(now)) shouldBe ((now.getYear * 12) + now.getMonthOfYear).toString
-    r(toRelativeWeekNum(now)) should (equal(Weeks.weeksBetween(epoch, now).getWeeks.toString) or equal(
-      (Weeks.weeksBetween(epoch, now).getWeeks + 1).toString
+    r(toRelativeQuarterNum(now)) shouldBe ((now.getYear * 4) + (now.getMonthValue - 1) / 3).toString
+    r(toRelativeMonthNum(now)) shouldBe ((now.getYear * 12) + now.getMonthValue).toString
+    r(toRelativeWeekNum(now)) should (equal(ChronoUnit.WEEKS.between(epoch, now).toString) or equal(
+      (ChronoUnit.WEEKS.between(epoch, now) + 1).toString
     ))
-    r(toRelativeDayNum(now)) shouldBe Days.daysBetween(epoch, now).getDays.toString
-    r(toRelativeHourNum(now)) shouldBe Hours.hoursBetween(epoch, now).getHours.toString
-    r(toRelativeMinuteNum(now)) shouldBe Minutes.minutesBetween(epoch, now).getMinutes.toString
-    r(toRelativeSecondNum(now)) shouldBe Seconds.secondsBetween(epoch, now).getSeconds.toString
+    r(toRelativeDayNum(now)) shouldBe ChronoUnit.DAYS.between(epoch, now).toString
+    r(toRelativeHourNum(now)) shouldBe ChronoUnit.HOURS.between(epoch, now).toString
+    r(toRelativeMinuteNum(now)) shouldBe ChronoUnit.MINUTES.between(epoch, now).toString
+    r(toRelativeSecondNum(now)) shouldBe ChronoUnit.SECONDS.between(epoch, now).toString
     r(chNow()) should (equal(dynNow.printAsDateTime) or equal(dynNow.minusSeconds(1).printAsDateTime))
     r(chYesterday()) shouldBe dynNow.minusDays(1).printAsDate
-    r(chToday()) shouldBe dynNow.withTimeAtStartOfDay().printAsDate
+    r(chToday()) shouldBe dynNow.toLocalDate.atStartOfDay(ZoneOffset.UTC).printAsDate
     r(timeSlot(now)) shouldBe now.toStartOfMin(30).printAsDateTime
     r(
       timeSlots(now, toUInt32(1800))

--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/schemabuilder/CreateTableIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/schemabuilder/CreateTableIT.scala
@@ -2,7 +2,7 @@ package com.crobox.clickhouse.dsl.schemabuilder
 
 import com.crobox.clickhouse.DslITSpec
 import com.crobox.clickhouse.dsl._
-import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
+import java.time.ZonedDateTime
 
 class CreateTableIT extends DslITSpec {
 

--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/schemabuilder/CreateTableIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/schemabuilder/CreateTableIT.scala
@@ -2,7 +2,7 @@ package com.crobox.clickhouse.dsl.schemabuilder
 
 import com.crobox.clickhouse.DslITSpec
 import com.crobox.clickhouse.dsl._
-import org.joda.time.DateTime
+import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
 
 class CreateTableIT extends DslITSpec {
 
@@ -11,7 +11,7 @@ class CreateTableIT extends DslITSpec {
   //
 
   it should "create table with TTL" in {
-    val eventTime = NativeColumn[DateTime]("event_time", ColumnType.DateTime)
+    val eventTime = NativeColumn[ZonedDateTime]("event_time", ColumnType.DateTime)
     val userId    = NativeColumn[Long]("user_id", ColumnType.UInt64)
     val comment   = NativeColumn[String]("comment", ColumnType.String)
     val db        = database

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/ArithmeticFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/ArithmeticFunctions.scala
@@ -1,7 +1,7 @@
 package com.crobox.clickhouse.dsl.column
 
 import com.crobox.clickhouse.dsl.{EmptyColumn, ExpressionColumn, TableColumn}
-import org.joda.time.{DateTime, LocalDate}
+import java.time.{LocalDate, ZonedDateTime}
 import scala.language.implicitConversions
 
 trait ArithmeticFunctions { self: Magnets =>
@@ -100,12 +100,12 @@ trait ArithmeticFunctions { self: Magnets =>
   implicit object LocalDateBigDecimalBinding extends AritRetType[LocalDate, BigDecimal, LocalDate]
   implicit object LocalDateBigIntBinding     extends AritRetType[LocalDate, BigInt, LocalDate]
 
-  implicit object DateTimeIntBinding        extends AritRetType[DateTime, Int, DateTime]
-  implicit object DateTimeLongBinding       extends AritRetType[DateTime, Long, DateTime]
-  implicit object DateTimeDoubleBinding     extends AritRetType[DateTime, Double, DateTime]
-  implicit object DateTimeFloatBinding      extends AritRetType[DateTime, Float, DateTime]
-  implicit object DateTimeBigDecimalBinding extends AritRetType[DateTime, BigDecimal, DateTime]
-  implicit object DateTimeBigIntBinding     extends AritRetType[DateTime, BigInt, DateTime]
+  implicit object DateTimeIntBinding        extends AritRetType[ZonedDateTime, Int, ZonedDateTime]
+  implicit object DateTimeLongBinding       extends AritRetType[ZonedDateTime, Long, ZonedDateTime]
+  implicit object DateTimeDoubleBinding     extends AritRetType[ZonedDateTime, Double, ZonedDateTime]
+  implicit object DateTimeFloatBinding      extends AritRetType[ZonedDateTime, Float, ZonedDateTime]
+  implicit object DateTimeBigDecimalBinding extends AritRetType[ZonedDateTime, BigDecimal, ZonedDateTime]
+  implicit object DateTimeBigIntBinding     extends AritRetType[ZonedDateTime, BigInt, ZonedDateTime]
 
   def abs[T](targetColumn: NumericCol[T]): Abs[T] = Abs[T](targetColumn)
 

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/ArrayFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/ArrayFunctions.scala
@@ -1,7 +1,7 @@
 package com.crobox.clickhouse.dsl.column
 
 import com.crobox.clickhouse.dsl._
-import org.joda.time.{DateTime, LocalDate}
+import java.time.{LocalDate, ZonedDateTime}
 
 trait ArrayFunctions { this: Magnets =>
   sealed trait ArrayFunction
@@ -21,7 +21,7 @@ trait ArrayFunctions { this: Magnets =>
   case class EmptyArrayFloat32()     extends ArrayFunctionConst[Float]
   case class EmptyArrayFloat64()     extends ArrayFunctionConst[Double]
   case class EmptyArrayDate()        extends ArrayFunctionConst[LocalDate]
-  case class EmptyArrayDateTime()    extends ArrayFunctionConst[DateTime]
+  case class EmptyArrayDateTime()    extends ArrayFunctionConst[ZonedDateTime]
   case class EmptyArrayString()      extends ArrayFunctionConst[String]
   case class Range(n: NumericCol[_]) extends ArrayFunctionConst[Long]
 

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/DateTimeFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/DateTimeFunctions.scala
@@ -1,7 +1,7 @@
 package com.crobox.clickhouse.dsl.column
 
 import com.crobox.clickhouse.dsl._
-import org.joda.time.{DateTime, LocalDate}
+import java.time.{LocalDate, ZonedDateTime}
 
 trait DateTimeFunctions { self: Magnets =>
   sealed trait DateTimeFunction
@@ -20,9 +20,9 @@ trait DateTimeFunctions { self: Magnets =>
   case class Minute(d: DateOrDateTime[_])     extends DateTimeFunctionCol[Int](d)
   case class Second(d: DateOrDateTime[_])     extends DateTimeFunctionCol[Int](d)
   case class Monday[V](d: DateOrDateTime[_])  extends DateTimeFunctionCol[V](d)
-  case class AddSeconds(d: DateOrDateTime[_], seconds: NumericCol[_])  extends DateTimeFunctionCol[DateTime](d)
-  case class AddMinutes(d: DateOrDateTime[_], minutes: NumericCol[_])  extends DateTimeFunctionCol[DateTime](d)
-  case class AddHours(d: DateOrDateTime[_], hours: NumericCol[_])      extends DateTimeFunctionCol[DateTime](d)
+  case class AddSeconds(d: DateOrDateTime[_], seconds: NumericCol[_])  extends DateTimeFunctionCol[ZonedDateTime](d)
+  case class AddMinutes(d: DateOrDateTime[_], minutes: NumericCol[_])  extends DateTimeFunctionCol[ZonedDateTime](d)
+  case class AddHours(d: DateOrDateTime[_], hours: NumericCol[_])      extends DateTimeFunctionCol[ZonedDateTime](d)
   case class AddDays[V](d: DateOrDateTime[V], days: NumericCol[_])     extends DateTimeFunctionCol[V](d)
   case class AddWeeks[V](d: DateOrDateTime[V], weeks: NumericCol[_])   extends DateTimeFunctionCol[V](d)
   case class AddMonths[V](d: DateOrDateTime[V], months: NumericCol[_]) extends DateTimeFunctionCol[V](d)
@@ -35,7 +35,7 @@ trait DateTimeFunctions { self: Magnets =>
   case class StartOfFifteenMinutes[V](d: DateOrDateTime[_])            extends DateTimeFunctionCol[V](d)
   case class StartOfHour[V](d: DateOrDateTime[_])                      extends DateTimeFunctionCol[V](d)
   case class StartOfDay[V](d: DateOrDateTime[_])                       extends DateTimeFunctionCol[V](d)
-  case class Time(d: DateOrDateTime[_])                                extends DateTimeFunctionCol[DateTime](d)
+  case class Time(d: DateOrDateTime[_])                                extends DateTimeFunctionCol[ZonedDateTime](d)
   case class RelativeYearNum[V](d: DateOrDateTime[_])                  extends DateTimeFunctionCol[V](d)
   case class RelativeQuarterNum[V](d: DateOrDateTime[_])               extends DateTimeFunctionCol[V](d)
   case class RelativeMonthNum[V](d: DateOrDateTime[_])                 extends DateTimeFunctionCol[V](d)
@@ -44,11 +44,11 @@ trait DateTimeFunctions { self: Magnets =>
   case class RelativeHourNum[V](d: DateOrDateTime[_])                  extends DateTimeFunctionCol[V](d)
   case class RelativeMinuteNum[V](d: DateOrDateTime[_])                extends DateTimeFunctionCol[V](d)
   case class RelativeSecondNum[V](d: DateOrDateTime[_])                extends DateTimeFunctionCol[V](d)
-  case class Now()                                                     extends DateTimeConst[DateTime]()
+  case class Now()                                                     extends DateTimeConst[ZonedDateTime]()
   case class Today()                                                   extends DateTimeConst[LocalDate]()
   case class Yesterday()                                               extends DateTimeConst[LocalDate]()
-  case class TimeSlot(d: DateOrDateTime[_])                            extends DateTimeFunctionCol[DateTime](d)
-  case class TimeSlots(d: DateOrDateTime[_], duration: NumericCol[_])  extends DateTimeFunctionCol[DateTime](d)
+  case class TimeSlot(d: DateOrDateTime[_])                            extends DateTimeFunctionCol[ZonedDateTime](d)
+  case class TimeSlots(d: DateOrDateTime[_], duration: NumericCol[_])  extends DateTimeFunctionCol[ZonedDateTime](d)
   case class ISOYear(d: DateOrDateTime[_])                             extends DateTimeFunctionCol[Int](d)
   case class ISOWeek(d: DateOrDateTime[_])                             extends DateTimeFunctionCol[Int](d)
   case class Week(d: DateOrDateTime[_], mode: Int)                     extends DateTimeFunctionCol[Int](d)

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/DictionaryFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/DictionaryFunctions.scala
@@ -3,7 +3,7 @@ package com.crobox.clickhouse.dsl.column
 import java.util.UUID
 
 import com.crobox.clickhouse.dsl._
-import org.joda.time.{DateTime, LocalDate}
+import java.time.{LocalDate, ZonedDateTime}
 
 trait DictionaryFunctions { self: Magnets =>
 
@@ -86,8 +86,8 @@ trait DictionaryFunctions { self: Magnets =>
       _dictName: StringColMagnet[_],
       _attrName: StringColMagnet[_],
       _id: ConstOrColMagnet[_],
-      _default: Option[Magnet[DateTime]] = None
-  ) extends DictionaryGetFuncColumn[DateTime](_dictName, _attrName, _id, _default)
+      _default: Option[Magnet[ZonedDateTime]] = None
+  ) extends DictionaryGetFuncColumn[ZonedDateTime](_dictName, _attrName, _id, _default)
   case class DictGetUUID(
       _dictName: StringColMagnet[_],
       _attrName: StringColMagnet[_],
@@ -210,7 +210,7 @@ trait DictionaryFunctions { self: Magnets =>
       dictName: StringColMagnet[_],
       attrName: StringColMagnet[_],
       id: ConstOrColMagnet[_],
-      default: Magnet[DateTime]
+      default: Magnet[ZonedDateTime]
   ) = DictGetDateTime(dictName, attrName, id, Some(default))
   def dictGetUUIDOrDefault(
       dictName: StringColMagnet[_],

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/Magnets.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/Magnets.scala
@@ -4,7 +4,7 @@ import com.crobox.clickhouse.dsl.marshalling.QueryValueFormats._
 import com.crobox.clickhouse.dsl.marshalling.{QueryValue, QueryValueFormats}
 import com.crobox.clickhouse.dsl.schemabuilder.ColumnType.SimpleColumnType
 import com.crobox.clickhouse.dsl.{Const, EmptyColumn, ExpressionColumn, OperationalQuery, Table, TableColumn}
-import org.joda.time.{DateTime, LocalDate}
+import java.time.{LocalDate, ZonedDateTime}
 
 import java.util.UUID
 import scala.language.implicitConversions
@@ -188,8 +188,8 @@ trait Magnets {
       override val column = s
     }
 
-  implicit def ddtFromDateTimeCol[T <: TableColumn[DateTime]](s: T): DateOrDateTime[DateTime] =
-    new DateOrDateTime[DateTime] {
+  implicit def ddtFromDateTimeCol[T <: TableColumn[ZonedDateTime]](s: T): DateOrDateTime[ZonedDateTime] =
+    new DateOrDateTime[ZonedDateTime] {
       override val column = s
     }
 
@@ -198,8 +198,8 @@ trait Magnets {
       override val column = toDate(s)
     }
 
-  implicit def ddtFromDateTime[T <: DateTime: QueryValue](s: T): DateOrDateTime[DateTime] =
-    new DateOrDateTime[DateTime] {
+  implicit def ddtFromDateTime[T <: ZonedDateTime: QueryValue](s: T): DateOrDateTime[ZonedDateTime] =
+    new DateOrDateTime[ZonedDateTime] {
       override val column = toDateTime(s)
     }
 

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/TypeCastFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/TypeCastFunctions.scala
@@ -3,7 +3,7 @@ package com.crobox.clickhouse.dsl.column
 import com.crobox.clickhouse.dsl.schemabuilder.ColumnType
 import com.crobox.clickhouse.dsl.schemabuilder.ColumnType.SimpleColumnType
 import com.crobox.clickhouse.dsl.{ExpressionColumn, TableColumn}
-import org.joda.time.DateTime
+import java.time.ZonedDateTime
 
 trait TypeCastFunctions {
   self: Magnets =>
@@ -109,17 +109,17 @@ trait TypeCastFunctions {
   case class DateRep(
       tableColumn: ConstOrColMagnet[_],
       orZero: Boolean = false,
-      orDefault: Option[DateTime] = None,
+      orDefault: Option[ZonedDateTime] = None,
       orNull: Boolean = false
-  ) extends TypeCastColumn[org.joda.time.LocalDate](tableColumn)
+  ) extends TypeCastColumn[java.time.LocalDate](tableColumn)
       with Reinterpretable
 
   case class DateTimeRep(
       tableColumn: ConstOrColMagnet[_],
       orZero: Boolean = false,
-      orDefault: Option[org.joda.time.DateTime] = None,
+      orDefault: Option[java.time.ZonedDateTime] = None,
       orNull: Boolean = false
-  ) extends TypeCastColumn[org.joda.time.DateTime](tableColumn)
+  ) extends TypeCastColumn[java.time.ZonedDateTime](tableColumn)
       with Reinterpretable
 
   case class StringRep(tableColumn: ConstOrColMagnet[_])
@@ -248,7 +248,7 @@ trait TypeCastFunctions {
 
   def toDate(tableColumn: ConstOrColMagnet[_]): DateRep = DateRep(tableColumn)
 
-  def toDateOrDefault(tableColumn: ConstOrColMagnet[_], value: DateTime): DateRep =
+  def toDateOrDefault(tableColumn: ConstOrColMagnet[_], value: ZonedDateTime): DateRep =
     DateRep(tableColumn, orDefault = Option(value))
 
   def toDateOrNull(tableColumn: ConstOrColMagnet[_]): DateRep = DateRep(tableColumn, orNull = true)
@@ -257,7 +257,7 @@ trait TypeCastFunctions {
 
   def toDateTime(tableColumn: ConstOrColMagnet[_]): DateTimeRep = DateTimeRep(tableColumn)
 
-  def toDateTimeOrDefault(tableColumn: ConstOrColMagnet[_], value: DateTime): DateTimeRep =
+  def toDateTimeOrDefault(tableColumn: ConstOrColMagnet[_], value: ZonedDateTime): DateTimeRep =
     DateTimeRep(tableColumn, orDefault = Option(value))
 
   def toDateTimeOrNull(tableColumn: ConstOrColMagnet[_]): DateTimeRep = DateTimeRep(tableColumn, orNull = true)

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -4,7 +4,7 @@ import com.crobox.clickhouse.dsl.JoinQuery._
 import com.crobox.clickhouse.dsl._
 import com.crobox.clickhouse.time.{MultiDuration, TimeUnit, TotalDuration}
 import com.typesafe.scalalogging.Logger
-import org.joda.time.{DateTime, DateTimeZone}
+import java.time.{ZoneId, ZonedDateTime}
 import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters._
@@ -337,7 +337,7 @@ trait ClickhouseTokenizerModule
     def toUnixTimestamp(inner: String): String = s"toUnixTimestamp($inner, '$dateZone')"
 
     interval.duration match {
-      case TotalDuration                      => s"${interval.getStartMillis}"
+      case TotalDuration                      => s"${interval.start.toInstant.toEpochMilli}"
       case MultiDuration(1, TimeUnit.Year)    => toDateTime(convert("toStartOfYear"))
       case MultiDuration(1, TimeUnit.Quarter) => toDateTime(convert("toStartOfQuarter"))
       case MultiDuration(1, TimeUnit.Month)   => toDateTime(convert("toStartOfMonth"))
@@ -369,21 +369,18 @@ trait ClickhouseTokenizerModule
   // TODO this is a fallback to find a similar timezone when the provided interval does not have a set timezone id.
   // We should be able to disable this from the config and fail fast if we cannot determine the timezone for timeseries
   // (probably default to failing)
-  private def determineZoneId(start: DateTime): String = {
-    val provider   = DateTimeZone.getProvider
-    val zones      = provider.getAvailableIDs.asScala.map(provider.getZone)
-    val zone       = start.getZone
-    val targetZone = zones
-      .find(_.getID == zone.getID)
-      .orElse(
-        zones.find(targetZone =>
-          targetZone.getID.startsWith("Etc/") &&
-            targetZone.getOffset(start.getMillis) == start.getZone.getOffset(start.getMillis)
-        )
-      )
-      .getOrElse(throw new IllegalArgumentException(s"Could not determine the zone from source $zone"))
-      .getID
-    targetZone
+  private def determineZoneId(start: ZonedDateTime): String = {
+    val zone      = start.getZone
+    val available = ZoneId.getAvailableZoneIds.asScala
+    if (available.contains(zone.getId)) zone.getId
+    else {
+      // Sorted, because eight Etc/ zones sit at offset zero and getAvailableZoneIds is unordered -- without this the
+      // emitted timezone would vary between runs for a UTC interval.
+      val instant = start.toInstant
+      available.toSeq.sorted
+        .find(id => id.startsWith("Etc/") && ZoneId.of(id).getRules.getOffset(instant) == start.getOffset)
+        .getOrElse(throw new IllegalArgumentException(s"Could not determine the zone from source $zone"))
+    }
   }
 
   //  Table joins are tokenized as select * because of https://github.com/yandex/ClickHouse/issues/635

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/marshalling/ClickhouseJsonSupport.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/marshalling/ClickhouseJsonSupport.scala
@@ -1,8 +1,8 @@
 package com.crobox.clickhouse.dsl.marshalling
 
 import com.crobox.clickhouse.time.IntervalStart
-import org.joda.time.format.{DateTimeFormatter, DateTimeFormatterBuilder, ISODateTimeFormat}
-import org.joda.time.{DateTime, DateTimeZone}
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
 import spray.json.{deserializationError, JsNumber, JsString, JsValue, JsonFormat, _}
 
 import scala.util.Try
@@ -11,11 +11,11 @@ import scala.util.matching.Regex
 trait ClickhouseJsonSupport {
 
   /**
-   * Adds support for org.joda.time.DateTime format specific to clickhouse
+   * Adds support for the date formats clickhouse returns for grouped intervals
    */
   implicit object ClickhouseIntervalStartFormat extends JsonFormat[IntervalStart] {
 
-    override def write(obj: IntervalStart): JsValue = JsNumber(obj.getMillis)
+    override def write(obj: IntervalStart): JsValue = JsNumber(obj.toInstant.toEpochMilli)
 
     val month: Regex = """(\d+)_(.*)""".r
 
@@ -26,17 +26,9 @@ trait ClickhouseJsonSupport {
     val timestamp: Regex             = """^(\d{10})$""".r
     val RelativeMonthsSinceUnixStart = 23641
 
-    val UnixStartTimeWithoutTimeZone            = "1970-01-01T00:00:00.000"
-    val formatter: DateTimeFormatter            = ISODateTimeFormat.date()
-    private val isoFormatter: DateTimeFormatter = ISODateTimeFormat.dateTimeNoMillis
-
-    val readFormatter: DateTimeFormatter = new DateTimeFormatterBuilder()
-      .append(
-        isoFormatter.getPrinter,
-        Array(isoFormatter.getParser, ISODateTimeFormat.date().withZone(DateTimeZone.UTC).getParser)
-      )
-      .toFormatter
-      .withOffsetParsed()
+    val UnixStart: LocalDate             = LocalDate.of(1970, 1, 1)
+    val formatter: DateTimeFormatter     = DateTimeFormatter.ISO_LOCAL_DATE
+    val readFormatter: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
 
     /*
      * It read the dates back as UTC, but it does contain the corresponding milliseconds relative to the timezone used in the initial request
@@ -47,43 +39,44 @@ trait ClickhouseJsonSupport {
         case JsString(value) =>
           value match {
             case month(relativeMonth, timezoneId) =>
-              new DateTime(UnixStartTimeWithoutTimeZone)
-                .withZoneRetainFields(DateTimeZone.forID(timezoneId))
-                .plusMonths(relativeMonth.toInt - RelativeMonthsSinceUnixStart)
-                .withZone(DateTimeZone.UTC)
+              UnixStart
+                .atStartOfDay(ZoneId.of(timezoneId))
+                .plusMonths((relativeMonth.toInt - RelativeMonthsSinceUnixStart).toLong)
+                .withZoneSameInstant(ZoneOffset.UTC)
             case date(dateOnly, timezoneId) =>
               // should handle quarter and year grouping as it returns a date
-              formatter
-                .parseDateTime(dateOnly)
-                .withZoneRetainFields(DateTimeZone.forID(timezoneId))
-                .withZone(DateTimeZone.UTC)
-            case nanoTimestamp(millis) => new DateTime(millis.toLong / 1000, DateTimeZone.UTC)
-            case msTimestamp(millis)   => new DateTime(millis.toLong, DateTimeZone.UTC)
-            case timestamp(secs)       => new DateTime(secs.toLong * 1000, DateTimeZone.UTC)
+              LocalDate
+                .parse(dateOnly, formatter)
+                .atStartOfDay(ZoneId.of(timezoneId))
+                .withZoneSameInstant(ZoneOffset.UTC)
+            case nanoTimestamp(millis) => atUtc(millis.toLong / 1000)
+            case msTimestamp(millis)   => atUtc(millis.toLong)
+            case timestamp(secs)       => atUtc(secs.toLong * 1000)
             case _                     =>
               // sometimes clickhouse mistakenly returns a long / int value as JsString. Therefor, first try to
               // parse it as a long...
-              val dateTime = Try {
-                new DateTime(value.toLong, DateTimeZone.UTC)
-              }.toOption
+              val dateTime = Try(atUtc(value.toLong)).toOption
 
               // continue with parsing using the formatter
               dateTime.getOrElse {
                 try
-                  formatter.parseDateTime(value)
+                  LocalDate.parse(value, formatter).atStartOfDay(ZoneId.systemDefault())
                 catch {
-                  case _: IllegalArgumentException      => error(s"Couldn't parse $value into valid date time")
+                  case _: java.time.format.DateTimeParseException =>
+                    error(s"Couldn't parse $value into valid date time")
                   case _: UnsupportedOperationException =>
                     error("Unsupported operation, programmatic misconfiguration?")
                 }
               }
           }
-        case JsNumber(millis) => new DateTime(millis.longValue, DateTimeZone.UTC)
+        case JsNumber(millis) => atUtc(millis.longValue)
         case _                => throw DeserializationException(s"Unknown date format read from clickhouse for $json")
       }
 
-    def error(v: Any): DateTime = {
-      val example = readFormatter.print(0)
+    private def atUtc(millis: Long): ZonedDateTime = Instant.ofEpochMilli(millis).atZone(ZoneOffset.UTC)
+
+    def error(v: Any): ZonedDateTime = {
+      val example = readFormatter.format(Instant.EPOCH.atZone(ZoneOffset.UTC))
       deserializationError(
         f"'$v' is not a valid date value. Dates must be in compact ISO-8601 format, e.g. '$example'"
       )

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/marshalling/ColumnDecoder.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/marshalling/ColumnDecoder.scala
@@ -1,7 +1,8 @@
 package com.crobox.clickhouse.dsl.marshalling
 
-import org.joda.time.format.DateTimeFormatterBuilder
-import org.joda.time.{DateTime, DateTimeZone, LocalDate}
+import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder, DateTimeParseException}
+import java.time.temporal.ChronoField
+import java.time.{LocalDate, LocalDateTime, ZoneOffset, ZonedDateTime}
 import spray.json._
 
 import java.util.UUID
@@ -87,33 +88,34 @@ object ColumnDecoder {
    * -- a space rather than the ISO `T`, and no offset. Everything after the date is optional, because `n` runs from 0
    * to 9: `DateTime64(0)` carries no fractional part at all and `DateTime64(9)` carries nine digits.
    *
-   * Two things this cannot do. joda carries milliseconds, so anything finer than `DateTime64(3)` is truncated rather
-   * than represented -- java.time would carry it (#326). And the absence of an offset means the server renders a
-   * `DateTime` in that column's own timezone, which the declared type carries (`DateTime('Europe/Amsterdam')`) but the
-   * value does not; these read as UTC, which is right for a default server and wrong for a column declared with an
-   * explicit zone. Reading the zone off the declared type needs the decoder to see it, which this signature does not
-   * allow.
+   * The absence of an offset means the server renders a `DateTime` in that column's own timezone, which the declared
+   * type carries (`DateTime('Europe/Amsterdam')`) but the value does not; these read as UTC, which is right for a
+   * default server and wrong for a column declared with an explicit zone. Reading the zone off the declared type needs
+   * the decoder to see it, which this signature does not allow.
    */
-  private val dateTimeParser = new DateTimeFormatterBuilder()
+  private val dateTimeParser: DateTimeFormatter = new DateTimeFormatterBuilder()
     .appendPattern("yyyy-MM-dd")
-    .appendOptional(
-      new DateTimeFormatterBuilder()
-        .appendLiteral(' ')
-        .appendPattern("HH:mm:ss")
-        .appendOptional(new DateTimeFormatterBuilder().appendLiteral('.').appendFractionOfSecond(1, 9).toParser)
-        .toParser
-    )
+    .optionalStart()
+    .appendLiteral(' ')
+    .appendPattern("HH:mm:ss")
+    .optionalStart()
+    .appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, true)
+    .optionalEnd()
+    .optionalEnd()
+    .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+    .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+    .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+    .parseDefaulting(ChronoField.NANO_OF_SECOND, 0)
     .toFormatter
-    .withZoneUTC()
 
-  implicit val dateTimeDecoder: ColumnDecoder[DateTime] = instance("DateTime") { case JsString(s) =>
-    try dateTimeParser.parseDateTime(s)
-    catch { case _: IllegalArgumentException => throw ColumnDecodingException("DateTime", JsString(s)) }
+  implicit val dateTimeDecoder: ColumnDecoder[ZonedDateTime] = instance("DateTime") { case JsString(s) =>
+    try LocalDateTime.parse(s, dateTimeParser).atZone(ZoneOffset.UTC)
+    catch { case _: DateTimeParseException => throw ColumnDecodingException("DateTime", JsString(s)) }
   }
 
   implicit val localDateDecoder: ColumnDecoder[LocalDate] = instance("Date") { case JsString(s) =>
-    try dateTimeParser.withZone(DateTimeZone.UTC).parseLocalDate(s)
-    catch { case _: IllegalArgumentException => throw ColumnDecodingException("Date", JsString(s)) }
+    try LocalDate.parse(s, dateTimeParser)
+    catch { case _: DateTimeParseException => throw ColumnDecodingException("Date", JsString(s)) }
   }
 
   /** Escape hatch for a column this layer has no instance for. */

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/marshalling/QueryValue.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/marshalling/QueryValue.scala
@@ -2,8 +2,8 @@ package com.crobox.clickhouse.dsl.marshalling
 
 import com.crobox.clickhouse.dsl.ClickhouseStatement
 import com.crobox.clickhouse.partitioning.PartitionDateFormatter
-import org.joda.time.format.DateTimeFormat
-import org.joda.time.{DateTime, LocalDate}
+import java.time.format.DateTimeFormatter
+import java.time.{LocalDate, ZonedDateTime}
 import scala.language.implicitConversions
 
 import java.util.UUID
@@ -69,9 +69,12 @@ trait QueryValueFormats {
     override def apply(v: UUID): String = quote(v.toString)
   }
 
-  implicit object DateTimeQueryValue extends QueryValue[DateTime] {
-    private val formatter                   = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss")
-    override def apply(v: DateTime): String = quote(formatter.print(v))
+  implicit object DateTimeQueryValue extends QueryValue[ZonedDateTime] {
+    private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+
+    // Second precision, as before. ZonedDateTime carries nanoseconds, so DateTime64 becomes expressible here, but
+    // widening the literal would change every DateTime value this renders -- that belongs with #329.
+    override def apply(v: ZonedDateTime): String = quote(formatter.format(v))
   }
 
   implicit object LocalDateQueryValue extends QueryValue[LocalDate] {

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/misc/DateConditions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/misc/DateConditions.scala
@@ -7,7 +7,7 @@ import com.crobox.clickhouse.dsl.numericFromLongCol
 import com.crobox.clickhouse.dsl.logicalOpsMagnetFromOptionCol
 import com.crobox.clickhouse.dsl.logicalOpsMagnetFromBooleanCol
 import com.crobox.clickhouse.dsl.{ExpressionColumn, NativeColumn}
-import org.joda.time.{DateTime, DateTimeZone, LocalDate}
+import java.time.{LocalDate, ZoneOffset, ZonedDateTime}
 import com.crobox.clickhouse.dsl.marshalling.QueryValueFormats._
 
 import scala.language.implicitConversions
@@ -21,17 +21,17 @@ trait DateConditions {
   def dateTimeCondition(
       dateColumn: NativeColumn[LocalDate],
       timestampColumn: NativeColumn[Long],
-      startDate: DateTime,
-      endDate: Option[DateTime]
+      startDate: ZonedDateTime,
+      endDate: Option[ZonedDateTime]
   ): ExpressionColumn[Boolean] =
     // this
-    dateColumn >= startDate.withZone(DateTimeZone.UTC).toLocalDate and
-      noneIfStartOfDay(startDate).map(dt => timestampColumn >= dt.getMillis) and endDate.map(ed =>
+    dateColumn >= startDate.withZoneSameInstant(ZoneOffset.UTC).toLocalDate and
+      noneIfStartOfDay(startDate).map(dt => timestampColumn >= dt.toInstant.toEpochMilli) and endDate.map(ed =>
         noneIfStartOfDay(ed)
           // Must be smaller equals because of current day overlap
-          .map(dt => dateColumn <= dt.toLocalDate and timestampColumn < dt.getMillis)
+          .map(dt => dateColumn <= dt.toLocalDate and timestampColumn < dt.toInstant.toEpochMilli)
           // Must be smaller then since endDate is not inclusive
-          .getOrElse(dateColumn < ed.withZone(DateTimeZone.UTC).toLocalDate)
+          .getOrElse(dateColumn < ed.withZoneSameInstant(ZoneOffset.UTC).toLocalDate)
       )
 
   /**
@@ -41,21 +41,21 @@ trait DateConditions {
   def dateTimeCondition(
       dateColumn: NativeColumn[LocalDate],
       timestampColumn: NativeColumn[Long],
-      startDate: Option[DateTime],
-      endDate: Option[DateTime]
+      startDate: Option[ZonedDateTime],
+      endDate: Option[ZonedDateTime]
   ): Option[ExpressionColumn[Boolean]] = {
 
     val startCondition: Option[ExpressionColumn[Boolean]] = startDate.map(sd =>
-      dateColumn >= sd.withZone(DateTimeZone.UTC).toLocalDate and
-        noneIfStartOfDay(sd).map(dt => timestampColumn >= dt.getMillis)
+      dateColumn >= sd.withZoneSameInstant(ZoneOffset.UTC).toLocalDate and
+        noneIfStartOfDay(sd).map(dt => timestampColumn >= dt.toInstant.toEpochMilli)
     )
 
     val endCondition: Option[ExpressionColumn[Boolean]] = endDate.map(ed =>
       noneIfStartOfDay(ed)
         // Must be smaller equals because of current day overlap
-        .map(dt => dateColumn <= dt.toLocalDate and timestampColumn < dt.getMillis)
+        .map(dt => dateColumn <= dt.toLocalDate and timestampColumn < dt.toInstant.toEpochMilli)
         // Must be smaller then since endDate is not inclusive
-        .getOrElse(dateColumn < ed.withZone(DateTimeZone.UTC).toLocalDate)
+        .getOrElse(dateColumn < ed.withZoneSameInstant(ZoneOffset.UTC).toLocalDate)
     )
 
     startCondition match {
@@ -64,9 +64,9 @@ trait DateConditions {
     }
   }
 
-  def noneIfStartOfDay(dateTime: DateTime): Option[DateTime] = {
-    val utcDateTime = dateTime.withZone(DateTimeZone.UTC)
-    if (utcDateTime.withTimeAtStartOfDay().isEqual(utcDateTime)) {
+  def noneIfStartOfDay(dateTime: ZonedDateTime): Option[ZonedDateTime] = {
+    val utcDateTime = dateTime.withZoneSameInstant(ZoneOffset.UTC)
+    if (utcDateTime.toLocalDate.atStartOfDay(ZoneOffset.UTC).isEqual(utcDateTime)) {
       None
     } else {
       Some(utcDateTime)

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/schemabuilder/Engine.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/schemabuilder/Engine.scala
@@ -2,7 +2,7 @@ package com.crobox.clickhouse.dsl.schemabuilder
 
 import com.crobox.clickhouse.dsl.marshalling.QueryValueFormats.StringQueryValue
 import com.crobox.clickhouse.dsl.{Column, NativeColumn}
-import org.joda.time.LocalDate
+import java.time.LocalDate
 
 /**
  * @author

--- a/dsl/src/test/scala/com/crobox/clickhouse/TestSchema.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/TestSchema.scala
@@ -3,7 +3,7 @@ package com.crobox.clickhouse
 import com.crobox.clickhouse.dsl.marshalling.ClickhouseJsonSupport._
 import com.crobox.clickhouse.dsl.schemabuilder.ColumnType
 import com.crobox.clickhouse.dsl.{NativeColumn, Table}
-import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
+import java.time.ZonedDateTime
 import spray.json._
 
 import java.util.UUID

--- a/dsl/src/test/scala/com/crobox/clickhouse/TestSchema.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/TestSchema.scala
@@ -3,7 +3,7 @@ package com.crobox.clickhouse
 import com.crobox.clickhouse.dsl.marshalling.ClickhouseJsonSupport._
 import com.crobox.clickhouse.dsl.schemabuilder.ColumnType
 import com.crobox.clickhouse.dsl.{NativeColumn, Table}
-import org.joda.time.DateTime
+import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
 import spray.json._
 
 import java.util.UUID
@@ -62,7 +62,7 @@ trait TestSchema {
   val timestampColumn = NativeColumn[Long]("ts", ColumnType.UInt64)
   val nativeUUID      = NativeColumn[UUID]("uuid", ColumnType.UUID)
 
-  case class Table1Entry(shieldId: UUID, date: DateTime = DateTime.now(), numbers: Seq[Int] = Seq())
+  case class Table1Entry(shieldId: UUID, date: ZonedDateTime = ZonedDateTime.now(), numbers: Seq[Int] = Seq())
 
   case class Table2Entry(
       itemId: UUID,

--- a/dsl/src/test/scala/com/crobox/clickhouse/TestUtils.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/TestUtils.scala
@@ -1,36 +1,30 @@
 package com.crobox.clickhouse
 
-import org.joda.time.DateTime
-import org.joda.time.format.DateTimeFormat
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 
 object TestUtils {
 
-  implicit class DDTStringify(ddt: DateTime) {
-    def printAsDate: String = DateTimeFormat.forPattern("yyyy-MM-dd").print(ddt)
+  implicit class DDTStringify(ddt: ZonedDateTime) {
+    def printAsDate: String = DateTimeFormatter.ofPattern("yyyy-MM-dd").format(ddt)
 
-    def printAsDateTime: String = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss").print(ddt)
+    def printAsDateTime: String = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(ddt)
 
-    def printAsYYYYMM: String = DateTimeFormat.forPattern("yyyyMM").print(ddt)
+    def printAsYYYYMM: String = DateTimeFormatter.ofPattern("yyyyMM").format(ddt)
 
-    def toStartOfQuarter: DateTime = {
-      val remainder = (ddt.getMonthOfYear - 1) % 3
+    def toStartOfQuarter: ZonedDateTime = {
+      val remainder = (ddt.getMonthValue - 1) % 3
 
-      ddt.withDayOfMonth(1).minusMonths(remainder)
+      ddt.withDayOfMonth(1).minusMonths(remainder.toLong)
     }
 
-    def toStartOfMin(min: Int): DateTime = {
-      val remainder = ddt.getMinuteOfHour % min
+    def toStartOfMin(min: Int): ZonedDateTime = {
+      val remainder = ddt.getMinute % min
 
-      ddt
-        .withSecondOfMinute(0)
-        .withMillisOfSecond(0)
-        .minusMinutes(remainder)
+      ddt.truncatedTo(ChronoUnit.MINUTES).minusMinutes(remainder.toLong)
     }
 
-    def toStartOfHr: DateTime =
-      ddt
-        .withMinuteOfHour(0)
-        .withSecondOfMinute(0)
-        .withMillisOfSecond(0)
+    def toStartOfHr: ZonedDateTime = ddt.truncatedTo(ChronoUnit.HOURS)
   }
 }

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/QueryTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/QueryTest.scala
@@ -3,7 +3,7 @@ package com.crobox.clickhouse.dsl
 import com.crobox.clickhouse._
 import com.crobox.clickhouse.dsl.JoinQuery.InnerJoin
 import com.crobox.clickhouse.dsl.schemabuilder.ColumnType
-import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
+import java.time.{LocalDate, ZonedDateTime}
 
 import java.util.UUID
 import scala.util.{Failure, Success}

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/QueryTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/QueryTest.scala
@@ -3,7 +3,7 @@ package com.crobox.clickhouse.dsl
 import com.crobox.clickhouse._
 import com.crobox.clickhouse.dsl.JoinQuery.InnerJoin
 import com.crobox.clickhouse.dsl.schemabuilder.ColumnType
-import org.joda.time.{DateTime, LocalDate}
+import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
 
 import java.util.UUID
 import scala.util.{Failure, Success}
@@ -92,7 +92,7 @@ class QueryTest extends DslTestSpec {
   }
 
   it should "parse datefunction" in {
-    val query = select(toYear(NativeColumn[DateTime]("dateTime"))) from OneTestTable
+    val query = select(toYear(NativeColumn[ZonedDateTime]("dateTime"))) from OneTestTable
     toSql(query.internalQuery).nonEmpty shouldBe true
   }
 

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerTest.scala
@@ -3,7 +3,7 @@ package com.crobox.clickhouse.dsl.language
 import com.crobox.clickhouse.DslTestSpec
 import com.crobox.clickhouse.dsl._
 import com.crobox.clickhouse.time.{MultiDuration, MultiInterval, TimeUnit}
-import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
+import java.time.ZonedDateTime
 
 import java.util.UUID
 

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerTest.scala
@@ -3,7 +3,7 @@ package com.crobox.clickhouse.dsl.language
 import com.crobox.clickhouse.DslTestSpec
 import com.crobox.clickhouse.dsl._
 import com.crobox.clickhouse.time.{MultiDuration, MultiInterval, TimeUnit}
-import org.joda.time.{DateTime, DateTimeZone}
+import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
 
 import java.util.UUID
 
@@ -236,8 +236,8 @@ class ClickhouseTokenizerTest extends DslTestSpec {
       TimeSeries(
         timestampColumn,
         MultiInterval(
-          DateTime.now(DateTimeZone.forOffsetHours(2)),
-          DateTime.now(DateTimeZone.forOffsetHours(2)),
+          ZonedDateTime.now(java.time.ZoneOffset.ofHours(2)),
+          ZonedDateTime.now(java.time.ZoneOffset.ofHours(2)),
           MultiDuration(TimeUnit.Month)
         )
       )

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/marshalling/ClickhouseIntervalStartFormatTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/marshalling/ClickhouseIntervalStartFormatTest.scala
@@ -3,7 +3,7 @@ package com.crobox.clickhouse.dsl.marshalling
 import com.crobox.clickhouse.DslTestSpec
 import com.crobox.clickhouse.dsl.marshalling.ClickhouseJsonSupport.ClickhouseIntervalStartFormat
 import com.crobox.clickhouse.time.IntervalStart
-import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
+import java.time.{Instant, ZoneId, ZoneOffset, ZonedDateTime}
 import spray.json.{JsNumber, JsString}
 
 class ClickhouseIntervalStartFormatTest extends DslTestSpec {

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/marshalling/ClickhouseIntervalStartFormatTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/marshalling/ClickhouseIntervalStartFormatTest.scala
@@ -3,96 +3,97 @@ package com.crobox.clickhouse.dsl.marshalling
 import com.crobox.clickhouse.DslTestSpec
 import com.crobox.clickhouse.dsl.marshalling.ClickhouseJsonSupport.ClickhouseIntervalStartFormat
 import com.crobox.clickhouse.time.IntervalStart
-import org.joda.time.{DateTime, DateTimeZone}
+import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
 import spray.json.{JsNumber, JsString}
 
 class ClickhouseIntervalStartFormatTest extends DslTestSpec {
 
-  val zone = DateTimeZone.forID("Europe/Bucharest")
+  val zone = ZoneId.of("Europe/Bucharest")
 
   it should "read using month relative" in {
     ClickhouseIntervalStartFormat.read(
       JsString(s"${ClickhouseIntervalStartFormat.RelativeMonthsSinceUnixStart + 3}_$zone")
-    ) should be(new DateTime("1970-04-01T00:00:00.000+02:00", DateTimeZone.UTC))
+    ) should be(ZonedDateTime.parse("1970-04-01T00:00:00.000+02:00").withZoneSameInstant(ZoneOffset.UTC))
   }
 
   it should "read using 0 as JsString" in {
     ClickhouseIntervalStartFormat.read(JsString("0")) should be(
-      new DateTime("1970-01-01T00:00:00.000+00:00", DateTimeZone.UTC)
+      ZonedDateTime.parse("1970-01-01T00:00:00.000+00:00").withZoneSameInstant(ZoneOffset.UTC)
     )
   }
 
   it should "read using 0 as JsNumber" in {
     ClickhouseIntervalStartFormat.read(JsNumber(0)) should be(
-      new DateTime("1970-01-01T00:00:00.000+00:00", DateTimeZone.UTC)
+      ZonedDateTime.parse("1970-01-01T00:00:00.000+00:00").withZoneSameInstant(ZoneOffset.UTC)
     )
   }
 
   it should "read date only" in {
     ClickhouseIntervalStartFormat.read(JsString(s"1970-12-17_$zone")) should be(
-      new DateTime("1970-12-17T00:00:00.000+02:00", DateTimeZone.UTC)
+      ZonedDateTime.parse("1970-12-17T00:00:00.000+02:00").withZoneSameInstant(ZoneOffset.UTC)
     )
   }
 
   it should "read timestamp" in {
-    val date = DateTime.now(DateTimeZone.UTC)
-    ClickhouseIntervalStartFormat.read(JsString(s"${date.getMillis}")) should be(date)
-    ClickhouseIntervalStartFormat.read(JsNumber(date.getMillis)) should be(date)
+    // Truncated because the wire format carries milliseconds while ZonedDateTime.now carries nanoseconds.
+    val date = ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(java.time.temporal.ChronoUnit.MILLIS)
+    ClickhouseIntervalStartFormat.read(JsString(s"${date.toInstant.toEpochMilli}")) should be(date)
+    ClickhouseIntervalStartFormat.read(JsNumber(date.toInstant.toEpochMilli)) should be(date)
   }
 
   it should "convert to correct year" in {
     // JsString("1618876800000000").convertTo[IntervalStart] should be ("53270-03-01T00:00:00.000Z")
-    JsString("1618876800000000").convertTo[IntervalStart].getMillis should be(1618876800000L)
+    JsString("1618876800000000").convertTo[IntervalStart].toInstant.toEpochMilli should be(1618876800000L)
   }
 
   it should "read date only for a timezone whose id contains an underscore" in {
     ClickhouseIntervalStartFormat.read(JsString("1970-12-17_America/New_York")) should be(
-      new DateTime("1970-12-17T00:00:00.000-05:00", DateTimeZone.UTC)
+      ZonedDateTime.parse("1970-12-17T00:00:00.000-05:00").withZoneSameInstant(ZoneOffset.UTC)
     )
   }
 
   it should "read date only for a timezone with two underscores" in {
     ClickhouseIntervalStartFormat.read(JsString("1970-12-17_America/Argentina/Rio_Gallegos")) should be(
-      new DateTime("1970-12-17T00:00:00.000-03:00", DateTimeZone.UTC)
+      ZonedDateTime.parse("1970-12-17T00:00:00.000-03:00").withZoneSameInstant(ZoneOffset.UTC)
     )
   }
 
   it should "read month relative for a timezone whose id contains an underscore" in {
     ClickhouseIntervalStartFormat.read(
       JsString(s"${ClickhouseIntervalStartFormat.RelativeMonthsSinceUnixStart + 3}_America/New_York")
-    ) should be(new DateTime("1970-04-01T00:00:00.000-05:00", DateTimeZone.UTC))
+    ) should be(ZonedDateTime.parse("1970-04-01T00:00:00.000-05:00").withZoneSameInstant(ZoneOffset.UTC))
   }
 
   it should "read a month before the unix epoch" in {
     ClickhouseIntervalStartFormat.read(
       JsString(s"${ClickhouseIntervalStartFormat.RelativeMonthsSinceUnixStart - 2}_$zone")
-    ) should be(new DateTime("1969-11-01T00:00:00.000+02:00", DateTimeZone.UTC))
+    ) should be(ZonedDateTime.parse("1969-11-01T00:00:00.000+02:00").withZoneSameInstant(ZoneOffset.UTC))
   }
 
   it should "read a quarter boundary as a date" in {
     ClickhouseIntervalStartFormat.read(JsString(s"1970-04-01_$zone")) should be(
-      new DateTime("1970-04-01T00:00:00.000+02:00", DateTimeZone.UTC)
+      ZonedDateTime.parse("1970-04-01T00:00:00.000+02:00").withZoneSameInstant(ZoneOffset.UTC)
     )
   }
 
   it should "read a year boundary as a date" in {
     ClickhouseIntervalStartFormat.read(JsString(s"1971-01-01_$zone")) should be(
-      new DateTime("1971-01-01T00:00:00.000+02:00", DateTimeZone.UTC)
+      ZonedDateTime.parse("1971-01-01T00:00:00.000+02:00").withZoneSameInstant(ZoneOffset.UTC)
     )
   }
 
   it should "read a ten-digit value as seconds" in {
     ClickhouseIntervalStartFormat.read(JsString("1618876800")) should be(
-      new DateTime(1618876800000L, DateTimeZone.UTC)
+      Instant.ofEpochMilli(1618876800000L).atZone(ZoneOffset.UTC)
     )
   }
 
   it should "read a sixteen-digit value as microseconds" in {
-    ClickhouseIntervalStartFormat.read(JsString("1618876800000000")).getMillis should be(1618876800000L)
+    ClickhouseIntervalStartFormat.read(JsString("1618876800000000")).toInstant.toEpochMilli should be(1618876800000L)
   }
 
   it should "write millis" in {
-    val date = new DateTime(1618876800000L, DateTimeZone.UTC)
+    val date = Instant.ofEpochMilli(1618876800000L).atZone(ZoneOffset.UTC)
     ClickhouseIntervalStartFormat.write(date) should be(JsNumber(1618876800000L))
   }
 

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/marshalling/CompactRowParserTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/marshalling/CompactRowParserTest.scala
@@ -3,7 +3,7 @@ package com.crobox.clickhouse.dsl.marshalling
 import com.crobox.clickhouse.dsl.NativeColumn
 import com.crobox.clickhouse.dsl.execution.{ColumnLookupException, CompactRowParser, ResultParsingException}
 import com.crobox.clickhouse.dsl.schemabuilder.ColumnType
-import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
+import java.time.{LocalDate, ZoneOffset, ZonedDateTime}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import spray.json._
@@ -50,10 +50,10 @@ class CompactRowParserTest extends AnyFlatSpec with Matchers {
   it should "expose the declared ClickHouse types as meta" in {
     val parsed =
       CompactRowParser.parse(
-        body("""["n", "t"]""", """["UInt64", "ZonedDateTime"]""", """["5", "2026-08-21 10:00:00"]""")
+        body("""["n", "t"]""", """["UInt64", "DateTime"]""", """["5", "2026-08-21 10:00:00"]""")
       )
     parsed.meta.map(_.columnTypes.map(c => c.name -> c.columnType)) shouldBe
-    Some(Seq("n" -> "UInt64", "t" -> "ZonedDateTime"))
+    Some(Seq("n" -> "UInt64", "t" -> "DateTime"))
   }
 
   it should "decode a 64-bit integer whether ClickHouse quoted it or not" in {
@@ -95,7 +95,7 @@ class CompactRowParserTest extends AnyFlatSpec with Matchers {
       .parse(
         body(
           """["d", "dt", "dt64"]""",
-          """["Date", "ZonedDateTime", "DateTime64(3)"]""",
+          """["Date", "DateTime", "DateTime64(3)"]""",
           """["2026-08-21", "2026-08-21 21:48:17", "2026-08-21 21:48:17.250"]"""
         )
       )

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/marshalling/CompactRowParserTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/marshalling/CompactRowParserTest.scala
@@ -3,7 +3,7 @@ package com.crobox.clickhouse.dsl.marshalling
 import com.crobox.clickhouse.dsl.NativeColumn
 import com.crobox.clickhouse.dsl.execution.{ColumnLookupException, CompactRowParser, ResultParsingException}
 import com.crobox.clickhouse.dsl.schemabuilder.ColumnType
-import org.joda.time.{DateTime, DateTimeZone, LocalDate}
+import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import spray.json._
@@ -49,9 +49,11 @@ class CompactRowParserTest extends AnyFlatSpec with Matchers {
 
   it should "expose the declared ClickHouse types as meta" in {
     val parsed =
-      CompactRowParser.parse(body("""["n", "t"]""", """["UInt64", "DateTime"]""", """["5", "2026-08-21 10:00:00"]"""))
+      CompactRowParser.parse(
+        body("""["n", "t"]""", """["UInt64", "ZonedDateTime"]""", """["5", "2026-08-21 10:00:00"]""")
+      )
     parsed.meta.map(_.columnTypes.map(c => c.name -> c.columnType)) shouldBe
-    Some(Seq("n" -> "UInt64", "t" -> "DateTime"))
+    Some(Seq("n" -> "UInt64", "t" -> "ZonedDateTime"))
   }
 
   it should "decode a 64-bit integer whether ClickHouse quoted it or not" in {
@@ -87,36 +89,46 @@ class CompactRowParserTest extends AnyFlatSpec with Matchers {
   it should "decode the date types with the spelling ClickHouse actually sends" in {
     // Verified against a live server: a space rather than the ISO T, and DateTime64 carries a fractional part.
     val d    = NativeColumn[LocalDate]("d", ColumnType.Date)
-    val dt   = NativeColumn[DateTime]("dt", ColumnType.DateTime)
-    val dt64 = NativeColumn[DateTime]("dt64", ColumnType.DateTime)
+    val dt   = NativeColumn[ZonedDateTime]("dt", ColumnType.DateTime)
+    val dt64 = NativeColumn[ZonedDateTime]("dt64", ColumnType.DateTime)
     val row  = CompactRowParser
       .parse(
         body(
           """["d", "dt", "dt64"]""",
-          """["Date", "DateTime", "DateTime64(3)"]""",
+          """["Date", "ZonedDateTime", "DateTime64(3)"]""",
           """["2026-08-21", "2026-08-21 21:48:17", "2026-08-21 21:48:17.250"]"""
         )
       )
       .rows
       .head
 
-    row.get(d) shouldBe Some(new LocalDate(2026, 8, 21))
-    row.get(dt) shouldBe Some(new DateTime(2026, 8, 21, 21, 48, 17, DateTimeZone.UTC))
-    row.get(dt64) shouldBe Some(new DateTime(2026, 8, 21, 21, 48, 17, 250, DateTimeZone.UTC))
+    row.get(d) shouldBe Some(LocalDate.of(2026, 8, 21))
+    row.get(dt) shouldBe Some(ZonedDateTime.of(2026, 8, 21, 21, 48, 17, 0, ZoneOffset.UTC))
+    row.get(dt64) shouldBe Some(ZonedDateTime.of(2026, 8, 21, 21, 48, 17, 250 * 1000000, ZoneOffset.UTC))
   }
 
   it should "decode every DateTime64 precision ClickHouse can send" in {
     // DateTime64(n) allows n up to 9: (0) has no fractional part at all, (3)/(6)/(9) have 3, 6 and 9 digits. Taken from
     // a live server rather than assumed.
-    val dt                 = NativeColumn[DateTime]("dt", ColumnType.DateTime)
+    val dt                 = NativeColumn[ZonedDateTime]("dt", ColumnType.DateTime)
     def one(value: String) =
       CompactRowParser.parse(body("""["dt"]""", """["DateTime64(9)"]""", s"""["$value"]""")).rows.head.get(dt)
 
-    val expected = new DateTime(2026, 8, 21, 22, 0, 33, 250, DateTimeZone.UTC)
-    one("2026-08-21 22:00:33") shouldBe Some(expected.withMillisOfSecond(0))
+    val expected = ZonedDateTime.of(2026, 8, 21, 22, 0, 33, 250 * 1000000, ZoneOffset.UTC)
+    one("2026-08-21 22:00:33") shouldBe Some(expected.withNano(0))
     one("2026-08-21 22:00:33.250") shouldBe Some(expected)
     one("2026-08-21 22:00:33.250000") shouldBe Some(expected)
     one("2026-08-21 22:00:33.250000000") shouldBe Some(expected)
+  }
+
+  // Under joda this truncated to milliseconds; ZonedDateTime carries the nanoseconds through.
+  it should "keep sub-millisecond precision from DateTime64" in {
+    val dt  = NativeColumn[ZonedDateTime]("dt", ColumnType.DateTime)
+    val row = CompactRowParser
+      .parse(body("""["dt"]""", """["DateTime64(9)"]""", """["2026-08-21 22:00:33.250000001"]"""))
+      .rows
+      .head
+    row.get(dt).map(_.getNano) shouldBe Some(250000001)
   }
 
   it should "hand over the raw value for a type this layer has no decoder for" in {

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/schemabuilder/CreateTableTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/schemabuilder/CreateTableTest.scala
@@ -4,7 +4,7 @@ import com.crobox.clickhouse.DslTestSpec
 import com.crobox.clickhouse.dsl._
 import com.crobox.clickhouse.dsl.schemabuilder.DefaultValue.Default
 import com.crobox.clickhouse.dsl.schemabuilder.Engine.{DistributedEngine, SummingMergeTree}
-import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
+import java.time.LocalDate
 
 /**
  * @author

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/schemabuilder/CreateTableTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/schemabuilder/CreateTableTest.scala
@@ -4,7 +4,7 @@ import com.crobox.clickhouse.DslTestSpec
 import com.crobox.clickhouse.dsl._
 import com.crobox.clickhouse.dsl.schemabuilder.DefaultValue.Default
 import com.crobox.clickhouse.dsl.schemabuilder.Engine.{DistributedEngine, SummingMergeTree}
-import org.joda.time.LocalDate
+import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
 
 /**
  * @author

--- a/dsl/src/test/scala/com/crobox/clickhouse/misc/DSLImprovementsTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/misc/DSLImprovementsTest.scala
@@ -3,7 +3,7 @@ package com.crobox.clickhouse.misc
 import com.crobox.clickhouse.DslTestSpec
 import com.crobox.clickhouse.dsl.misc.DSLImprovements.ColumnsImprovements
 import com.crobox.clickhouse.dsl.{Column, NativeColumn}
-import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
+import java.time.ZonedDateTime
 
 import java.util.UUID
 

--- a/dsl/src/test/scala/com/crobox/clickhouse/misc/DSLImprovementsTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/misc/DSLImprovementsTest.scala
@@ -3,7 +3,7 @@ package com.crobox.clickhouse.misc
 import com.crobox.clickhouse.DslTestSpec
 import com.crobox.clickhouse.dsl.misc.DSLImprovements.ColumnsImprovements
 import com.crobox.clickhouse.dsl.{Column, NativeColumn}
-import org.joda.time.DateTime
+import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
 
 import java.util.UUID
 
@@ -13,7 +13,7 @@ class DSLImprovementsTest extends DslTestSpec {
   val doubleCol: NativeColumn[Double]           = NativeColumn[Double]("double")
   val stringCol: NativeColumn[String]           = NativeColumn[String]("string")
   val boolCol: NativeColumn[Boolean]            = NativeColumn[Boolean]("bool")
-  val dateTimeCol: NativeColumn[DateTime]       = NativeColumn[DateTime]("date_time")
+  val dateTimeCol: NativeColumn[ZonedDateTime]  = NativeColumn[ZonedDateTime]("date_time")
   val intArrayCol: NativeColumn[Seq[Int]]       = NativeColumn[Seq[Int]]("int_array")
   val doubleArrayCol: NativeColumn[Seq[Double]] = NativeColumn[Seq[Double]]("double_array")
   val stringArrayCol: NativeColumn[Seq[String]] = NativeColumn[Seq[String]]("string_array")

--- a/dsl/src/test/scala/com/crobox/clickhouse/misc/DateTimeConditionTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/misc/DateTimeConditionTest.scala
@@ -3,8 +3,7 @@ package com.crobox.clickhouse.misc
 import com.crobox.clickhouse.DslTestSpec
 import com.crobox.clickhouse.dsl.misc.DateConditions.dateTimeCondition
 import com.crobox.clickhouse.dsl.{NativeColumn, SelectQuery}
-import org.joda.time.format.ISODateTimeFormat
-import org.joda.time.{DateTime, LocalDate}
+import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
 import org.scalatest.prop.TableDrivenPropertyChecks
 
 class DateTimeConditionTest extends DslTestSpec with TableDrivenPropertyChecks {
@@ -74,8 +73,14 @@ class DateTimeConditionTest extends DslTestSpec with TableDrivenPropertyChecks {
     }
   }
 
-  val ISO_8601 = ISODateTimeFormat.dateOptionalTimeParser().withZoneUTC();
-
-  def parseDateTime(value: String): DateTime =
-    ISO_8601.parseDateTime(value.replace(' ', 'T'))
+  // Accepts a bare date, a date-time, or a date-time with an offset, normalising to UTC -- what joda's
+  // dateOptionalTimeParser().withZoneUTC() did.
+  def parseDateTime(value: String): ZonedDateTime = {
+    val text = value.replace(' ', 'T')
+    scala.util
+      .Try(ZonedDateTime.parse(text))
+      .orElse(scala.util.Try(java.time.LocalDateTime.parse(text).atZone(ZoneOffset.UTC)))
+      .getOrElse(LocalDate.parse(text).atStartOfDay(ZoneOffset.UTC))
+      .withZoneSameInstant(ZoneOffset.UTC)
+  }
 }

--- a/dsl/src/test/scala/com/crobox/clickhouse/misc/DateTimeConditionTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/misc/DateTimeConditionTest.scala
@@ -3,7 +3,7 @@ package com.crobox.clickhouse.misc
 import com.crobox.clickhouse.DslTestSpec
 import com.crobox.clickhouse.dsl.misc.DateConditions.dateTimeCondition
 import com.crobox.clickhouse.dsl.{NativeColumn, SelectQuery}
-import java.time.{Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime}
+import java.time.{LocalDate, ZoneOffset, ZonedDateTime}
 import org.scalatest.prop.TableDrivenPropertyChecks
 
 class DateTimeConditionTest extends DslTestSpec with TableDrivenPropertyChecks {


### PR DESCRIPTION
Closes #326. 33 files, and **joda-time is gone from `build.sbt`**.

## Type mapping

| Before | After |
|---|---|
| `org.joda.time.DateTime` | `java.time.ZonedDateTime` (ClickHouse `DateTime` is zone-aware) |
| `org.joda.time.LocalDate` | `java.time.LocalDate` |
| `IntervalStart` | `ZonedDateTime` |
| joda `Period` on `MultiTimeUnit` | `(amount: Int, chronoUnit: ChronoUnit)` |
| joda `Interval` | `TimeInterval`, a two-field case class |
| `MultiInterval extends BaseInterval` | plain case class exposing `start` / `end` |

**Why not a `Period`:** java.time has no single type covering joda's. It splits into a date-based `Period` and a time-based `Duration`, and **normalises weeks into days** — `Period.ofWeeks(1).toString == "P7D"`, so `P1W` and `P7D` become indistinguishable, which `TimeUnit.apply(Period)` depended on. Carrying `(amount, ChronoUnit)` instead keeps `Week` and `7 × Day` distinct, and collapses the nine-case `nextStartFromDate` into a single `plus` call that is provably identical for every unit. `TimeUnit.apply(Period)` becomes `apply(amount, ChronoUnit)`; it had no caller in the repo.

## The alignment arithmetic is ported, not rewritten

`MultiInterval`'s epoch-millis division with an explicit zone offset — including the week-1-since-epoch adjustment — is carried over as it stood. java.time offers tidier primitives, but using them would have changed results, and #351 is what makes the difference visible: **all fifteen `MultiIntervalTest` cases pass unchanged**, including the eleven zone-sensitive ones. Local-midnight day and week alignment, 23- and 25-hour DST days, epoch-aligned sub-day buckets, Monday weeks — all identical.

That is the whole argument for having done #351 first. Without it this PR would be untestable in the ways that matter.

## Three deliberate behaviour changes

- **`PartitionDateFormatter.dateFormat(ZonedDateTime)` uses the value's own zone.** It previously went through the epoch millis and so used the system default, discarding the zone it had just been handed. This is data-affecting — it decides which partition a row lands in — so it's called out rather than buried. The zoneless overloads (`Long`, `Date`) still use the system default, since there is nothing else to use.
- **`determineZoneId` sorts the candidate ids.** A `ZonedDateTime` on `ZoneOffset.UTC` has id `"Z"`, which is *not* in `getAvailableZoneIds`, so it falls through to the `Etc/` search — where eight zones sit at offset zero and the set is unordered. Without sorting, the emitted timezone would vary between runs for a UTC interval. joda never hit this because its UTC zone id is `"UTC"`, which was in its own id list. The existing `Etc/GMT-2` assertion still passes.
- **`DateTime64` keeps sub-millisecond precision.** joda truncated anything finer than `DateTime64(3)`; `ColumnDecoder`'s scaladoc said so and pointed at this issue. There's now a test for `.250000001`.

## Deliberately not changed

`DateTimeQueryValue` still renders second precision. `ZonedDateTime` makes sub-second literals expressible, but widening the format would change **every** `DateTime` value the DSL emits, so that belongs with #329 rather than here.

## Verification

- `scalafmtCheckAll` clean; `+compile +Test/compile +It/compile` green on 2.13 and 3.3.
- **309 dsl unit tests** and **138 integration tests** pass; client green apart from the two known environmental failures (missing local keystore, non-clustered server).
- `grep -rn joda` over sources and `build.sbt` returns only three comments that reference it historically.

Two test-side consequences worth knowing for anyone porting downstream: `ZonedDateTime.now` carries nanoseconds where joda's carried milliseconds, so a millis round-trip no longer returns an equal value; and `getDayOfWeek` returns an enum rather than an `Int` (`.getValue` restores joda's 1–7 numbering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)