### PR TITLE
Remove the last of the deprecated API

### DIFF
--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/OperationalQuery.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/OperationalQuery.scala
@@ -254,54 +254,6 @@ trait OperationalQuery extends Query {
   def globalJoin[TargetTable <: Table](joinType: JoinQuery.JoinType, table: TargetTable): OperationalQuery =
     join(joinType = joinType, table = table, global = true)
 
-  @deprecated("Please use join(JoinQuery.AllInnerJoin)")
-  def allInnerJoin(query: OperationalQuery): OperationalQuery =
-    join(JoinQuery.AllInnerJoin, query)
-
-  @deprecated("Please use join(JoinQuery.AllLeftJoin)")
-  def allLeftJoin(query: OperationalQuery): OperationalQuery =
-    join(JoinQuery.AllLeftJoin, query)
-
-  @deprecated("Please use join(JoinQuery.AllRightJoin)")
-  def allRightJoin(query: OperationalQuery): OperationalQuery =
-    join(JoinQuery.AllRightJoin, query)
-
-  @deprecated("Please use join(JoinQuery.AnyInnerJoin)")
-  def anyInnerJoin(query: OperationalQuery): OperationalQuery =
-    join(JoinQuery.AnyInnerJoin, query)
-
-  @deprecated("Please use join(JoinQuery.AnyLeftJoin)")
-  def anyLeftJoin(query: OperationalQuery): OperationalQuery =
-    join(JoinQuery.AnyLeftJoin, query)
-
-  @deprecated("Please use join(JoinQuery.AnyRightJoin)")
-  def anyRightJoin(query: OperationalQuery): OperationalQuery =
-    join(JoinQuery.AnyRightJoin, query)
-
-  @deprecated("Please use globalJoin(JoinQuery.AllInnerJoin)")
-  def globalAllInnerJoin(query: OperationalQuery): OperationalQuery =
-    globalJoin(JoinQuery.AllInnerJoin, query)
-
-  @deprecated("Please use globalJoin(JoinQuery.AllLeftJoin)")
-  def globalAllLeftJoin(query: OperationalQuery): OperationalQuery =
-    globalJoin(JoinQuery.AllLeftJoin, query)
-
-  @deprecated("Please use globalJoin(JoinQuery.AllRightJoin)")
-  def globalAllRightJoin(query: OperationalQuery): OperationalQuery =
-    globalJoin(JoinQuery.AllRightJoin, query)
-
-  @deprecated("Please use globalJoin(JoinQuery.AnyInnerJoin)")
-  def globalAnyInnerJoin(query: OperationalQuery): OperationalQuery =
-    globalJoin(JoinQuery.AnyInnerJoin, query)
-
-  @deprecated("Please use globalJoin(JoinQuery.AnyLeftJoin)")
-  def globalAnyLeftJoin(query: OperationalQuery): OperationalQuery =
-    globalJoin(JoinQuery.AnyLeftJoin, query)
-
-  @deprecated("Please use globalJoin(JoinQuery.AnyRightJoin)")
-  def globalAnyRightJoin(query: OperationalQuery): OperationalQuery =
-    globalJoin(JoinQuery.AnyRightJoin, query)
-
   def using(
       column: Column,
       columns: Column*

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/ComparisonFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/ComparisonFunctions.scala
@@ -8,10 +8,6 @@ trait ComparisonFunctions {
   case class ComparisonColumn(left: Magnet[_], operator: String, right: Magnet[_])
       extends ExpressionColumn[Boolean](EmptyColumn)
 
-  @deprecated("Use isEqual instead")
-  def _equals(col1: ConstOrColMagnet[_], col2: ConstOrColMagnet[_]): ExpressionColumn[Boolean] =
-    ComparisonColumn(col1, "=", col2)
-
   def isEqual(col1: ConstOrColMagnet[_], col2: ConstOrColMagnet[_]): ExpressionColumn[Boolean] =
     ComparisonColumn(col1, "=", col2)
 

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/schemabuilder/Column.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/schemabuilder/Column.scala
@@ -53,9 +53,6 @@ object ColumnType {
 
   case class FixedString(length: Int) extends SimpleColumnType(s"FixedString($length)")
 
-  @deprecated("Use the native UUID type instead of String", "1-10-2018")
-  val Uuid: ColumnType = String
-
   case object UUID extends SimpleColumnType("UUID")
 
   case object Date extends SimpleColumnType("Date")


### PR DESCRIPTION
Closes #344. **No `@deprecated` member remains anywhere in the codebase.**

| Removed | Replacement |
|---|---|
| 12 `OperationalQuery` join helpers (`allInnerJoin` … `globalAnyRightJoin`) | `join(JoinQuery.X)` / `globalJoin(JoinQuery.X)` |
| `ComparisonFunctions._equals` | `isEqual` — it was a character-for-character duplicate |
| `ColumnType.Uuid` (deprecated 2018) | see below, **not** a rename |

None had a caller in the repo, so this is a pure surface removal.

## `ColumnType.Uuid` is the one to read twice

It was `val Uuid: ColumnType = String`, sitting directly above `case object UUID`, differing only in capitalisation. Verified what each emits:

```
ColumnType.Uuid -> String
ColumnType.UUID -> UUID
```

So **anyone who wrote `ColumnType.Uuid` has a `String` column in ClickHouse.** To keep that schema they want `ColumnType.String`; switching to `ColumnType.UUID` changes the declared column type and will not match an existing table. The old deprecation message — *"Use the native UUID type instead of String"* — was advice to migrate the schema, not an instruction to swap the constant, and a mechanical find-and-replace would silently change DDL.

That's the release-note line that matters here; the other thirteen are ordinary renames.

Removing it also clears half the name collision flagged in #344, between this and `TypeCastFunctions.Uuid` — the unrelated AST node behind `toUUID`.

## Verification

- `scalafmtCheckAll` clean; `+compile +Test/compile +It/compile` green on 2.13 and 3.3, with no deprecation warnings left in the build.
- 323 unit tests and 139 integration tests pass, unchanged.

I deliberately did not add a test forbidding `@deprecated`. Deprecating is a legitimate tool; the problem #344 records was these lingering for seven years, not their existence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)