### PR TITLE
Add a per-query timeout

### DIFF
--- a/client/src/main/resources/reference.conf
+++ b/client/src/main/resources/reference.conf
@@ -46,6 +46,10 @@ crobox.clickhouse {
         password = ""
         ssl-cert-auth = false
       }
+      # Bound on a single query, applied twice: as ClickHouse's own max_execution_time, so the server stops doing the
+      # work, and as a deadline on the whole client call including retries, so a connection that never answers still
+      # frees the caller. Unset means unbounded, which is the behaviour every release before 2.0 had.
+      # timeout = 30 seconds
       # profile = "default"
       http-compression = ${?crobox.clickhouse.client.http-compression} #backwards compatibility
       http-compression = false

--- a/client/src/main/scala/com/crobox/clickhouse/ClickhouseException.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/ClickhouseException.scala
@@ -12,6 +12,17 @@ case class ClickhouseException(message: String, query: String, cause: Throwable 
   override val retryable: Boolean = true
 }
 
+/**
+ * A query that ran past its `timeout`.
+ *
+ * Not retryable: the deadline is a bound on the whole call, so spending another attempt on it would exceed the very
+ * budget the caller asked for.
+ */
+case class QueryTimeoutException(timeout: scala.concurrent.duration.FiniteDuration, query: String)
+    extends ClickhouseExecutionException(s"Query exceeded its timeout of $timeout, query $query") {
+  override val retryable: Boolean = false
+}
+
 case class ClickhouseChunkedException(message: String) extends ClickhouseExecutionException(message) {
   override val retryable: Boolean = true
 }

--- a/client/src/main/scala/com/crobox/clickhouse/internal/ClickHouseExecutor.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/internal/ClickHouseExecutor.scala
@@ -1,5 +1,6 @@
 package com.crobox.clickhouse.internal
 
+import org.apache.pekko
 import org.apache.pekko.actor.{ActorSystem, Terminated}
 import org.apache.pekko.http.scaladsl.{Http, HttpsConnectionContext}
 import org.apache.pekko.http.scaladsl.model._
@@ -9,10 +10,11 @@ import org.apache.pekko.stream.scaladsl.{Keep, Sink, Source, SourceQueueWithComp
 import com.crobox.clickhouse.balancing.HostBalancer
 import com.crobox.clickhouse.internal.progress.QueryProgress._
 import com.crobox.clickhouse.internal.progress.{QueryProgress, StreamingProgressClickhouseTransport}
-import com.crobox.clickhouse.{ClickhouseExecutionException, TooManyQueriesException}
+import com.crobox.clickhouse.{ClickhouseExecutionException, QueryTimeoutException, TooManyQueriesException}
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Random, Success}
 
@@ -65,13 +67,33 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
     // cancelled -- one per request plus one per retry, each retained for the lifetime of the hub.
     val progressSubscription = progressQueue.map(subscribeToProgress(internalQueryIdentifier, _))
 
-    executeWithRetries(totalRetries, totalRetries, progressQueue, settings) { () =>
+    val attempts = executeWithRetries(totalRetries, totalRetries, progressQueue, settings) { () =>
       executeRequestInternal(hostBalancer.nextHost, query, internalQueryIdentifier, settings, entity, progressQueue)
-    }.andThen { case _ =>
+    }
+
+    withTimeout(attempts, query, settings).andThen { case _ =>
       progressSubscription.foreach(_.shutdown())
       progressQueue.foreach(_.complete())
     }
   }
+
+  /**
+   * Bounds the whole call rather than one attempt, so the caller's wall clock is what the timeout describes -- a 30
+   * second timeout with three retries would otherwise take 120 seconds to fail.
+   *
+   * The deadline is set slightly past `max_execution_time` so the server's own TIMEOUT_EXCEEDED normally lands first,
+   * which reports the elapsed time; this only fires when the server never answers at all. Losing the race does not
+   * cancel the request, but the response is still consumed downstream, so the connection is returned to the pool.
+   */
+  private def withTimeout(result: Future[String], query: String, settings: QuerySettings): Future[String] =
+    settings.timeout match {
+      case None          => result
+      case Some(timeout) =>
+        val deadline = pekko.pattern.after(timeout + ClickHouseExecutor.TimeoutGrace, system.scheduler)(
+          Future.failed(QueryTimeoutException(timeout, query))
+        )
+        Future.firstCompletedOf(Seq(result, deadline))
+    }
 
   private def subscribeToProgress(
       internalQueryIdentifier: String,
@@ -171,4 +193,8 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
   }
 }
 
-object ClickHouseExecutor {}
+object ClickHouseExecutor {
+
+  /** Head start for the server's own timeout, whose error names the elapsed time where the client's cannot. */
+  private[internal] val TimeoutGrace: FiniteDuration = 1.second
+}

--- a/client/src/main/scala/com/crobox/clickhouse/internal/QuerySettings.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/internal/QuerySettings.scala
@@ -5,6 +5,7 @@ import com.typesafe.config.Config
 import org.apache.pekko.http.scaladsl.model.Uri.Query
 import org.apache.pekko.http.scaladsl.model.headers.HttpEncoding
 
+import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 
@@ -19,7 +20,8 @@ case class QuerySettings(
     idempotent: Option[Boolean] = None,
     retries: Option[Int] = None,
     requestCompressionType: Option[HttpEncoding] = None,
-    sslCertAuth: Option[Boolean] = None
+    sslCertAuth: Option[Boolean] = None,
+    timeout: Option[FiniteDuration] = None
 ) {
 
   def asQueryParams: Query =
@@ -31,7 +33,10 @@ case class QuerySettings(
         profile.map("profile" -> _) ++
         progressHeaders.map(progress => "send_progress_in_http_headers" -> (if (progress) "1" else "0")) ++
         httpCompression
-          .map(compression => "enable_http_compression" -> (if (compression) "1" else "0"))).toMap
+          .map(compression => "enable_http_compression" -> (if (compression) "1" else "0")) ++
+        // Seconds, fractional accepted. Bounds the work the server does; the client-side half of the same setting is
+        // applied by ClickHouseExecutor.
+        timeout.map(t => "max_execution_time" -> BigDecimal(t.toMillis)./(1000).toString)).toMap
     )
 
   def withFallback(config: Config): QuerySettings = {
@@ -47,7 +52,10 @@ case class QuerySettings(
       sslCertAuth = sslCertAuth.orElse(Try {
         val authConfig = config.getConfig(path("authentication"))
         authConfig.getBoolean("ssl-cert-auth")
-      }.toOption)
+      }.toOption),
+      timeout = timeout.orElse(Try(config.getDuration(path("timeout"))).toOption.collect {
+        case d if !d.isZero && !d.isNegative => Duration.fromNanos(d.toNanos)
+      })
     )
   }
 

--- a/client/src/test/scala/com/crobox/clickhouse/QueryTimeoutSpec.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/QueryTimeoutSpec.scala
@@ -1,0 +1,92 @@
+package com.crobox.clickhouse
+
+import com.crobox.clickhouse.internal.QuerySettings
+import com.crobox.clickhouse.internal.QuerySettings.ReadQueries
+import com.typesafe.config.ConfigValueFactory
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class QueryTimeoutSpec extends ClickhouseClientAsyncSpec {
+
+  private val client = new ClickhouseClient(Some(config))
+
+  private val slowQuery = "SELECT count() FROM numbers(100000000000)"
+
+  it should "fail a query that runs past its timeout" in {
+    val started = System.nanoTime()
+    client
+      .query(slowQuery)(QuerySettings(ReadQueries, timeout = Some(1.second), retries = Some(0)))
+      .failed
+      .map { failure =>
+        val elapsed = (System.nanoTime() - started).nanos
+        withClue(s"failed with $failure after $elapsed: ") {
+          failure shouldBe a[ClickhouseExecutionException]
+          elapsed should be < 20.seconds
+        }
+      }
+  }
+
+  it should "leave a query that finishes inside its timeout alone" in
+    client
+      .query("SELECT 1")(QuerySettings(ReadQueries, timeout = Some(30.seconds)))
+      .map(_.trim shouldBe "1")
+
+  it should "not retry a timeout, since the deadline covers the whole call" in
+    Future.successful(QueryTimeoutException(1.second, "SELECT 1").retryable shouldBe false)
+
+  it should "take the timeout from config when the caller sets none" in {
+    val timed = config.withValue(
+      "crobox.clickhouse.client.settings.timeout",
+      ConfigValueFactory.fromAnyRef("2 seconds")
+    )
+    val clientConfig = timed.getConfig("crobox.clickhouse.client")
+    Future.successful(QuerySettings(ReadQueries).withFallback(clientConfig).timeout shouldBe Some(2.seconds))
+  }
+
+  it should "let the caller override the configured timeout" in {
+    val timed = config.withValue(
+      "crobox.clickhouse.client.settings.timeout",
+      ConfigValueFactory.fromAnyRef("2 seconds")
+    )
+    val clientConfig = timed.getConfig("crobox.clickhouse.client")
+    Future.successful(
+      QuerySettings(ReadQueries, timeout = Some(5.seconds)).withFallback(clientConfig).timeout shouldBe Some(5.seconds)
+    )
+  }
+
+  it should "stay unbounded when nothing configures a timeout" in
+    Future.successful(
+      QuerySettings(ReadQueries).withFallback(config.getConfig("crobox.clickhouse.client")).timeout shouldBe None
+    )
+
+  // The half max_execution_time cannot cover: a host that accepts the connection and then says nothing. Retries are
+  // left on to show the deadline bounds the whole call rather than each attempt.
+  it should "free the caller when the server never answers, without multiplying by the retries" in {
+    val listener  = new java.net.ServerSocket(0)
+    val accepting = new Thread(() => while (!listener.isClosed) scala.util.Try(listener.accept()))
+    accepting.setDaemon(true)
+    accepting.start()
+
+    val stalled = new ClickhouseClient(
+      Some(
+        config
+          .withValue("crobox.clickhouse.client.connection.port", ConfigValueFactory.fromAnyRef(listener.getLocalPort))
+          .withValue("crobox.clickhouse.client.connection.host", ConfigValueFactory.fromAnyRef("localhost"))
+      )
+    )
+
+    val started = System.nanoTime()
+    stalled
+      .query("SELECT 1")(QuerySettings(ReadQueries, timeout = Some(1.second), retries = Some(3)))
+      .failed
+      .map { failure =>
+        val elapsed = (System.nanoTime() - started).nanos
+        listener.close()
+        withClue(s"failed with $failure after $elapsed: ") {
+          failure shouldBe a[QueryTimeoutException]
+          elapsed should be < 10.seconds
+        }
+      }
+  }
+}

--- a/client/src/test/scala/com/crobox/clickhouse/internal/QueryTimeoutTest.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/internal/QueryTimeoutTest.scala
@@ -1,0 +1,22 @@
+package com.crobox.clickhouse.internal
+
+import com.crobox.clickhouse.internal.QuerySettings.AllQueries
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+
+class QueryTimeoutTest extends AnyFlatSpecLike with Matchers {
+
+  it should "send the timeout as max_execution_time in seconds" in {
+    QuerySettings(AllQueries, timeout = Some(30.seconds)).asQueryParams.get("max_execution_time") shouldBe Some("30")
+  }
+
+  it should "send a sub-second timeout as a fraction" in {
+    QuerySettings(AllQueries, timeout = Some(500.millis)).asQueryParams.get("max_execution_time") shouldBe Some("0.5")
+  }
+
+  it should "send nothing when no timeout is set" in {
+    QuerySettings(AllQueries).asQueryParams.get("max_execution_time") shouldBe None
+  }
+}


### PR DESCRIPTION
Closes #330. One setting — `QuerySettings.timeout` — applied as **both** bounds the issue asks about:

- **ClickHouse's `max_execution_time`**, in seconds, so the server stops doing the work
- **a deadline on the client call**, so a host that accepts the connection and then says nothing still frees the caller

```scala
client.query(sql)(QuerySettings(ReadQueries, timeout = Some(30.seconds)))
```
```hocon
crobox.clickhouse.client.settings.timeout = 30 seconds
```

Verified against 25.3 that `max_execution_time` is in seconds and accepts fractions, and that exceeding it returns `Code: 159 TIMEOUT_EXCEEDED`.

## Two decisions that differ from the issue's sketch

**It bounds the whole call, not each attempt.** The issue guesses a timeout should *"consume a retry rather than be terminal"*. I went the other way: with three retries, a 30-second timeout would take two minutes to fail, which is not what a caller asking for 30 seconds means. So `QueryTimeoutException` is **not** retryable and the deadline wraps the retry loop. There's a test asserting a 1-second timeout with 3 retries still fails in under 10 seconds rather than 4× the deadline.

**It's one setting, not two.** The issue frames server-side and client-side as alternatives. But a caller wants "fail if this takes longer than N" — not a choice between a server bound that can't see a stalled socket and a client bound that leaves the server churning. One knob sets both.

## Detail worth knowing

The client deadline sits **one second past** `max_execution_time`, so the server's own `TIMEOUT_EXCEEDED` normally lands first — it names the elapsed time, which a client-side timeout cannot. The client deadline is the backstop for when the server never answers at all.

Losing that race does not cancel the in-flight request; the response is still consumed downstream, so the connection returns to the pool rather than leaking.

**Default is unset**, matching every release before 2.0. Adding a default would start failing long analytical queries that work today — the fix here is making a bound *possible* and discoverable, not imposing one.

## Verification

- `scalafmtCheckAll` clean; `+compile +Test/compile +It/compile` green on 2.13 and 3.3.
- 7 new client tests: parameter rendering (whole and fractional seconds, absent), a slow query failing inside its timeout, a fast query unaffected, config default, caller override, unbounded by default, and `QueryTimeoutException` being non-retryable.
- **The stalled-server case is really tested**, not asserted: a `ServerSocket` that accepts and never answers, with retries left on, asserting both that `QueryTimeoutException` is raised and that the deadline is not multiplied by the retries. That's the half `max_execution_time` cannot cover, so it needed proving.
- 323 dsl unit and 139 integration tests unchanged. The two `client` failures are the usual environmental pair (missing local keystore, non-clustered server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)