### PR TITLE
Support DateTime64, Variant, Dynamic, JSON and SimpleAggregateFunction

### DIFF
--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/schemabuilder/ModernColumnTypeIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/schemabuilder/ModernColumnTypeIT.scala
@@ -1,0 +1,78 @@
+package com.crobox.clickhouse.dsl.schemabuilder
+
+import com.crobox.clickhouse.DslITSpec
+import com.crobox.clickhouse.dsl._
+
+import java.time.ZonedDateTime
+
+/**
+ * Creates a real table for each type, because the rendering is only right if the server accepts the DDL. Verified
+ * against 25.3 that none of these needs an experimental flag.
+ */
+class ModernColumnTypeIT extends DslITSpec {
+
+  // `suffix`, not `name`: inside `new Table { override val name = ... }` a parameter called `name` is shadowed by
+  // the member being defined, which reads as null.
+  private def createWith(suffix: String, columnType: ColumnType): Unit =
+    createWith(suffix, columnType, columnType.toString)
+
+  private def createWith(suffix: String, columnType: ColumnType, expected: String): Unit = {
+    val db     = database
+    val column = NativeColumn[String]("c", columnType)
+    val create = CreateTable(
+      table = new Table {
+        override val database: String              = db
+        override val name: String                  = s"modern_$suffix"
+        override val columns: Seq[NativeColumn[_]] = Seq(column)
+      },
+      Engine.Memory
+    )
+    clickClient.execute(s"DROP TABLE IF EXISTS ${create.table.quoted}").futureValue
+    clickClient.execute(create.query).futureValue
+    // The server's own rendering of what it stored, which is the real confirmation.
+    val stored = clickClient
+      .query(s"SELECT type FROM system.columns WHERE database = '$db' AND table = 'modern_$suffix' AND name = 'c'")
+      .futureValue
+      .trim
+      // TabSeparated escapes the quotes in a timezone.
+      .replace("\\'", "'")
+    stored shouldBe expected
+  }
+
+  it should "create a DateTime64 column" in createWith("dt64", ColumnType.DateTime64(3))
+
+  it should "create a DateTime64 column with a timezone" in
+    createWith("dt64tz", ColumnType.DateTime64(6, Option("Europe/Amsterdam")))
+
+  // ClickHouse normalises a Variant's alternatives into sorted order, so what comes back is not what was declared.
+  it should "create a Variant column" in
+    createWith("variant", ColumnType.Variant(ColumnType.UInt64, ColumnType.String), "Variant(String, UInt64)")
+
+  it should "create a Dynamic column" in createWith("dynamic", ColumnType.Dynamic)
+
+  it should "create a JSON column" in createWith("json", ColumnType.JSON)
+
+  it should "create a SimpleAggregateFunction column" in
+    createWith("simpleagg", ColumnType.SimpleAggregateFunction("sum", ColumnType.UInt64))
+
+  it should "read a DateTime64 value back with its sub-second part" in {
+    val db     = database
+    val column = NativeColumn[ZonedDateTime]("c", ColumnType.DateTime64(9))
+    val create = CreateTable(
+      table = new Table {
+        override val database: String              = db
+        override val name: String                  = "modern_dt64_read"
+        override val columns: Seq[NativeColumn[_]] = Seq(column)
+      },
+      Engine.Memory
+    )
+    clickClient.execute(s"DROP TABLE IF EXISTS ${create.table.quoted}").futureValue
+    clickClient.execute(create.query).futureValue
+    clickClient
+      .execute(s"INSERT INTO ${create.table.quoted} VALUES ('2026-08-21 22:00:33.250000001')")
+      .futureValue
+
+    val row = queryExecutor.executeRows(select(column).from(create.table)).futureValue.rows.head
+    row.get(column).map(_.getNano) shouldBe Some(250000001)
+  }
+}

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/schemabuilder/Column.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/schemabuilder/Column.scala
@@ -59,6 +59,18 @@ object ColumnType {
 
   case object DateTime extends SimpleColumnType("DateTime")
 
+  /**
+   * `DateTime64(precision[, timezone])`, where precision is the number of fractional-second digits.
+   *
+   * The reader keeps all nine: ColumnDecoder parses the fractional part into a ZonedDateTime's nanoseconds.
+   */
+  case class DateTime64(precision: Int, timezone: Option[String] = None) extends ColumnType {
+    require(precision >= 0 && precision <= 9, s"DateTime64 precision must be between 0 and 9, got $precision")
+
+    override def toString: String =
+      timezone.map(zone => s"DateTime64($precision, '$zone')").getOrElse(s"DateTime64($precision)")
+  }
+
   case class Array(columnType: ColumnType) extends ColumnType {
     require(
       !columnType.isInstanceOf[Nested] && !columnType.isInstanceOf[Array],
@@ -87,6 +99,30 @@ object ColumnType {
   case class Nullable(columnType: ColumnType) extends ColumnType {
     override def toString: String = s"Nullable(${columnType.toString})"
   }
+
+  /** `Variant(A, B, ...)`: one value, one of several types, discriminated per row. */
+  case class Variant(columnType: ColumnType, nextTypes: ColumnType*) extends ColumnType {
+    require(nextTypes.nonEmpty, "Variant needs at least two alternatives")
+
+    override def toString: String = s"Variant(${(columnType +: nextTypes).mkString(", ")})"
+  }
+
+  /** `Dynamic`: any type, decided per row rather than declared. */
+  case object Dynamic extends SimpleColumnType("Dynamic")
+
+  /** The native `JSON` type, as opposed to the `visitParam*` functions that read JSON out of a String. */
+  case object JSON extends SimpleColumnType("JSON")
+
+  /**
+   * `SimpleAggregateFunction(f, types...)`.
+   *
+   * Unlike [[AggregateFunctionColumn]] this stores the aggregated value itself rather than an intermediate state, so it
+   * is read like an ordinary column and needs no `-Merge`.
+   */
+  case class SimpleAggregateFunction(function: String, columnType: ColumnType, nextTypes: ColumnType*)
+      extends SimpleColumnType(
+        s"SimpleAggregateFunction($function, ${(columnType +: nextTypes).map(_.toString).mkString(", ")})"
+      )
 }
 
 sealed trait DefaultValue

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/schemabuilder/ModernColumnTypeTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/schemabuilder/ModernColumnTypeTest.scala
@@ -1,0 +1,53 @@
+package com.crobox.clickhouse.dsl.schemabuilder
+
+import com.crobox.clickhouse.DslTestSpec
+
+class ModernColumnTypeTest extends DslTestSpec {
+
+  it should "render DateTime64 with a precision" in {
+    ColumnType.DateTime64(3).toString shouldBe "DateTime64(3)"
+  }
+
+  it should "render DateTime64 with a timezone" in {
+    ColumnType.DateTime64(6, Option("Europe/Amsterdam")).toString shouldBe "DateTime64(6, 'Europe/Amsterdam')"
+  }
+
+  it should "accept the full precision range" in {
+    ColumnType.DateTime64(0).toString shouldBe "DateTime64(0)"
+    ColumnType.DateTime64(9).toString shouldBe "DateTime64(9)"
+  }
+
+  it should "refuse a precision ClickHouse does not have" in {
+    an[IllegalArgumentException] should be thrownBy ColumnType.DateTime64(10)
+    an[IllegalArgumentException] should be thrownBy ColumnType.DateTime64(-1)
+  }
+
+  it should "render Variant" in {
+    ColumnType.Variant(ColumnType.UInt64, ColumnType.String).toString shouldBe "Variant(UInt64, String)"
+  }
+
+  it should "refuse a Variant with one alternative, which is just that type" in {
+    an[IllegalArgumentException] should be thrownBy ColumnType.Variant(ColumnType.UInt64)
+  }
+
+  it should "render Dynamic and JSON" in {
+    ColumnType.Dynamic.toString shouldBe "Dynamic"
+    ColumnType.JSON.toString shouldBe "JSON"
+  }
+
+  it should "render SimpleAggregateFunction" in {
+    ColumnType.SimpleAggregateFunction("sum", ColumnType.UInt64).toString shouldBe
+    "SimpleAggregateFunction(sum, UInt64)"
+  }
+
+  it should "render SimpleAggregateFunction with several argument types" in {
+    ColumnType.SimpleAggregateFunction("anyLast", ColumnType.UInt64, ColumnType.String).toString shouldBe
+    "SimpleAggregateFunction(anyLast, UInt64, String)"
+  }
+
+  it should "nest inside the wrappers that take a type" in {
+    ColumnType.Nullable(ColumnType.DateTime64(3)).toString shouldBe "Nullable(DateTime64(3))"
+    ColumnType.Array(ColumnType.Dynamic).toString shouldBe "Array(Dynamic)"
+    ColumnType.LowCardinality(ColumnType.JSON).toString shouldBe "LowCardinality(JSON)"
+  }
+}


### PR DESCRIPTION
Closes #329. None of the five had any representation in `ColumnType`.

| Type | Notes |
|---|---|
| `DateTime64(precision[, timezone])` | precision validated to 0–9, which is what the server accepts |
| `Variant(A, B, …)` | requires at least two alternatives — one is just that type |
| `Dynamic` | |
| `JSON` | the native type, not the `visitParam*` functions the DSL already wraps |
| `SimpleAggregateFunction(f, types…)` | stores the value rather than an intermediate state, unlike `AggregateFunction` |

## The decoder half is already done

The issue asks for `ColumnDecoder` instances "once #325 lands". That landed, and #352 then made the date parser read the fractional part into a `ZonedDateTime`'s nanoseconds — so `DateTime64` reads correctly today, and `Variant`/`Dynamic`/`JSON` fall through to the `JsValue` escape hatch. There's a test that inserts `2026-08-21 22:00:33.250000001` into a real `DateTime64(9)` column and reads all nine digits back.

## Validated by creating real tables

Rather than asserting on `toString`, each type creates an actual table and compares against the server's own rendering in `system.columns`. That surfaced two things worth knowing:

- **ClickHouse normalises a `Variant`'s alternatives into sorted order.** Declaring `Variant(UInt64, String)` stores `Variant(String, UInt64)`. The test pins the server's form, since fighting it would be pointless — but a user comparing declared against actual schema needs to expect it.
- **None of the five needs an experimental flag** on 25.3, which I checked before writing the IT so it wouldn't need settings plumbing.

It also caught a bug in my own test: inside `new Table { override val name = s"modern_$name" }` the interpolated `name` binds to the member being defined, not the parameter, so every table was created as `modern_null`. Renamed the parameter and left a note.

## Not included

`DateTime` with an explicit timezone. It's the same shape as `DateTime64`'s second argument and would be natural to add, but `DateTime` is currently a `case object` and giving it a parameter replaces existing public API — that deserves its own change rather than riding along here.

## Verification

- `scalafmtCheckAll` clean; `+compile +Test/compile +It/compile` green on 2.13 and 3.3.
- **333 unit tests** (+10 rendering, including precision bounds and nesting inside `Nullable`/`Array`/`LowCardinality`) and **146 integration tests** (+7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)