### PR TITLE
Stream the result alongside progress instead of buffering it

### DIFF
--- a/client/src/main/scala/com/crobox/clickhouse/ClickhouseClient.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/ClickhouseClient.scala
@@ -68,6 +68,22 @@ class ClickhouseClient(
     )
 
   /**
+   * Progress events and the result, streamed together.
+   *
+   * Unlike [[queryWithProgress]], which hands back the body as a materialised `Future[String]` and so holds the whole
+   * result in memory, this emits it as [[QueryProgress.QueryResultPart]] events as it arrives. Not retried, since a
+   * retry would re-run the query after the consumer had already seen part of a result.
+   */
+  def queryWithProgressStreaming(sql: String)(implicit
+      settings: QuerySettings = QuerySettings(ReadQueries)
+  ): Source[QueryProgress, NotUsed] =
+    executeRequestStreaming(
+      sql,
+      settings.copy(readOnly = ReadQueries, idempotent = settings.idempotent.orElse(Some(true))),
+      MaximumFrameLength
+    )
+
+  /**
    * Execute a query that is modifying the state of the database. e.g. INSERT, SET, CREATE TABLE. For security purposes
    * SELECT and SHOW queries are not allowed, use the .query() method for those.
    *

--- a/client/src/main/scala/com/crobox/clickhouse/internal/ClickHouseExecutor.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/internal/ClickHouseExecutor.scala
@@ -195,7 +195,15 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
 
     // eagerComplete, because the progress hub is a BroadcastHub that never completes on its own -- the body is what
     // decides when this stream is done.
-    progress.merge(body, eagerComplete = true)
+    val merged = progress.merge(body, eagerComplete = true)
+
+    // idleTimeout rather than the deadline executeRequest applies. A stream's total duration is legitimately
+    // unbounded -- a large result can take longer than any per-query timeout and still be healthy -- but a gap
+    // between elements means the server has stopped answering, which is what the timeout is there to catch. The
+    // server-side max_execution_time still bounds the query itself, since it travels as a query parameter.
+    settings.timeout
+      .map(timeout => merged.idleTimeout(timeout + ClickHouseExecutor.TimeoutGrace))
+      .getOrElse(merged)
   }
 
   def shutdown(): Future[Terminated] = {

--- a/client/src/main/scala/com/crobox/clickhouse/internal/ClickHouseExecutor.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/internal/ClickHouseExecutor.scala
@@ -1,12 +1,14 @@
 package com.crobox.clickhouse.internal
 
 import org.apache.pekko
+import org.apache.pekko.NotUsed
 import org.apache.pekko.actor.{ActorSystem, Terminated}
+import org.apache.pekko.util.ByteString
 import org.apache.pekko.http.scaladsl.{Http, HttpsConnectionContext}
 import org.apache.pekko.http.scaladsl.model._
 import org.apache.pekko.http.scaladsl.settings.{ClientConnectionSettings, ConnectionPoolSettings}
 import org.apache.pekko.stream._
-import org.apache.pekko.stream.scaladsl.{Keep, Sink, Source, SourceQueueWithComplete}
+import org.apache.pekko.stream.scaladsl.{Framing, Keep, Sink, Source, SourceQueueWithComplete}
 import com.crobox.clickhouse.balancing.HostBalancer
 import com.crobox.clickhouse.internal.progress.QueryProgress._
 import com.crobox.clickhouse.internal.progress.{QueryProgress, StreamingProgressClickhouseTransport}
@@ -116,6 +118,42 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
     Source
       .queue[QueryProgress](10, OverflowStrategy.dropHead)
       .mapMaterializedValue(queue => executeRequest(query, settings, entity, Some(queue)))
+
+  /**
+   * Progress events and the result body in one stream, so a large result is not held whole.
+   *
+   * `executeRequestWithProgress` returns the body as its materialised value, which means draining the entity into a
+   * single String -- a million-row result is one 7MB allocation. Here the body is framed and emitted as
+   * [[QueryProgress.QueryResultPart]] events instead.
+   *
+   * No retries: a retry would re-run the request after the consumer had already seen part of a result.
+   */
+  def executeRequestStreaming(
+      query: String,
+      settings: QuerySettings,
+      maximumFrameLength: Int
+  ): Source[QueryProgress, NotUsed] = {
+    val identifier = queryIdentifier
+
+    val progress = progressSource.collect {
+      case reported if reported.identifier == identifier => reported.progress
+    }
+
+    val body = Source
+      .future(hostBalancer.nextHost.flatMap { host =>
+        val request =
+          toRequest(host, query, Some(identifier), settings.copy(progressHeaders = Some(true)), None)(config)
+        singleRequest(request, progressEnabled = true)
+      })
+      .flatMapConcat(response => response.entity.withoutSizeLimit().dataBytes)
+      .via(Framing.delimiter(ByteString("\n"), maximumFrameLength, allowTruncation = true))
+      .map(line => QueryResultPart(line.utf8String))
+      .concat(Source.single(QueryFinished))
+
+    // eagerComplete, because the progress hub is a BroadcastHub that never completes on its own -- the body is what
+    // decides when this stream is done.
+    progress.merge(body, eagerComplete = true)
+  }
 
   def shutdown(): Future[Terminated] = {
     queue.complete()

--- a/client/src/main/scala/com/crobox/clickhouse/internal/ClickHouseExecutor.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/internal/ClickHouseExecutor.scala
@@ -167,7 +167,7 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
             .flatMapConcat(body =>
               Source.failed(
                 ClickhouseException(
-                  s"Server returned code ${response.status}; $body",
+                  s"Server returned code ${response.status}; ${body.utf8String}",
                   query,
                   statusCode = response.status
                 )

--- a/client/src/main/scala/com/crobox/clickhouse/internal/ClickHouseExecutor.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/internal/ClickHouseExecutor.scala
@@ -12,7 +12,14 @@ import org.apache.pekko.stream.scaladsl.{Framing, Keep, Sink, Source, SourceQueu
 import com.crobox.clickhouse.balancing.HostBalancer
 import com.crobox.clickhouse.internal.progress.QueryProgress._
 import com.crobox.clickhouse.internal.progress.{QueryProgress, StreamingProgressClickhouseTransport}
-import com.crobox.clickhouse.{ClickhouseExecutionException, QueryTimeoutException, TooManyQueriesException}
+import com.crobox.clickhouse.internal.ClickhouseResponseParser.StreamedExceptionMarker
+import com.crobox.clickhouse.{
+  ClickhouseChunkedException,
+  ClickhouseException,
+  ClickhouseExecutionException,
+  QueryTimeoutException,
+  TooManyQueriesException
+}
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 
@@ -145,9 +152,45 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
           toRequest(host, query, Some(identifier), settings.copy(progressHeaders = Some(true)), None)(config)
         singleRequest(request, progressEnabled = true)
       })
-      .flatMapConcat(response => response.entity.withoutSizeLimit().dataBytes)
+      // decodeResponse, because the request advertises gzip and deflate: without it a compressed response would be
+      // framed as though the raw bytes were text.
+      .map(decodeResponse)
+      .flatMapConcat {
+        case response @ HttpResponse(StatusCodes.OK, _, entity, _) =>
+          entity.withoutSizeLimit().dataBytes.map(bytes => (response.status, bytes))
+        case response =>
+          // Non-OK: stream the body as the failure rather than as results.
+          response.entity
+            .withoutSizeLimit()
+            .dataBytes
+            .fold(ByteString.empty)(_ ++ _)
+            .flatMapConcat(body =>
+              Source.failed(
+                ClickhouseException(
+                  s"Server returned code ${response.status}; $body",
+                  query,
+                  statusCode = response.status
+                )
+              )
+            )
+      }
+      .map(_._2)
       .via(Framing.delimiter(ByteString("\n"), maximumFrameLength, allowTruncation = true))
-      .map(line => QueryResultPart(line.utf8String))
+      .map { line =>
+        val text = line.utf8String
+        // ClickHouse answers 200 and starts streaming, then appends an error if the query fails partway through, so
+        // the status line cannot report it. processClickhouseResponse checks the buffered body for the same marker;
+        // streaming has to check each line, or a failure arrives as ordinary results followed by QueryFinished.
+        StreamedExceptionMarker.findFirstMatchIn(text).foreach { marker =>
+          throw ClickhouseException(
+            s"Query failed after the response had started streaming; ClickHouse error code ${marker.group(1)}",
+            query,
+            ClickhouseChunkedException(text),
+            StatusCodes.OK
+          )
+        }
+        QueryResultPart(text)
+      }
       .concat(Source.single(QueryFinished))
 
     // eagerComplete, because the progress hub is a BroadcastHub that never completes on its own -- the body is what

--- a/client/src/main/scala/com/crobox/clickhouse/internal/progress/QueryProgress.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/internal/progress/QueryProgress.scala
@@ -18,6 +18,9 @@ object QueryProgress extends LazyLogging {
   case class QueryFailed(cause: Throwable)                  extends QueryProgress
   case class QueryRetry(cause: Throwable, retryNumber: Int) extends QueryProgress
 
+  /** One framed line of the result body, for callers streaming the result rather than buffering it. */
+  case class QueryResultPart(data: String) extends QueryProgress
+
   case class ClickhouseQueryProgress(identifier: String, progress: QueryProgress)
   case class Progress(rowsRead: Long, bytesRead: Long, rowsWritten: Long, bytesWritten: Long, totalRows: Long)
       extends QueryProgress

--- a/client/src/test/scala/com/crobox/clickhouse/StreamingProgressSpec.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/StreamingProgressSpec.scala
@@ -1,5 +1,7 @@
 package com.crobox.clickhouse
 
+import com.crobox.clickhouse.internal.QuerySettings
+import com.crobox.clickhouse.internal.QuerySettings.ReadQueries
 import com.crobox.clickhouse.internal.progress.QueryProgress._
 import org.apache.pekko.stream.scaladsl.Sink
 
@@ -42,4 +44,35 @@ class StreamingProgressSpec extends ClickhouseClientAsyncSpec {
         // The result is what matters; progress headers are best-effort and the server may finish too fast to send any.
         events.count { case QueryResultPart(d) if d.nonEmpty => true; case _ => false } shouldBe 100000
       }
+
+  // ClickHouse answers 200 and starts streaming, then appends the error if the query fails partway through. Without
+  // checking each line, that error arrives as ordinary QueryResultParts followed by QueryFinished, and the consumer
+  // cannot tell it from success.
+  it should "fail the stream on an error appended mid-body" in
+    client
+      .queryWithProgressStreaming("SELECT number, throwIf(number = 3, 'boom') FROM numbers(10)")(
+        QuerySettings(ReadQueries, settings = Map("max_block_size" -> "1"))
+      )
+      .runWith(Sink.seq)
+      .failed
+      .map { failure =>
+        failure shouldBe a[ClickhouseException]
+        failure.getMessage should include("395")
+      }
+
+  it should "not report QueryFinished when the body carried an error" in
+    client
+      .queryWithProgressStreaming("SELECT number, throwIf(number = 3, 'boom') FROM numbers(10)")(
+        QuerySettings(ReadQueries, settings = Map("max_block_size" -> "1"))
+      )
+      .recover { case _ => QueryRejected }
+      .runWith(Sink.seq)
+      .map(events => events should not contain QueryFinished)
+
+  it should "fail the stream on a non-OK response rather than streaming the error as results" in
+    client
+      .queryWithProgressStreaming("SELECT this_column_does_not_exist FROM system.one")
+      .runWith(Sink.seq)
+      .failed
+      .map(_ shouldBe a[ClickhouseException])
 }

--- a/client/src/test/scala/com/crobox/clickhouse/StreamingProgressSpec.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/StreamingProgressSpec.scala
@@ -51,6 +51,10 @@ class StreamingProgressSpec extends ClickhouseClientAsyncSpec {
   // ClickHouse answers 200 and starts streaming, then appends the error if the query fails partway through. Without
   // checking each line, that error arrives as ordinary QueryResultParts followed by QueryFinished, and the consumer
   // cannot tell it from success.
+  //
+  // Which path it takes is not stable across versions: 25.3 sends 200 with the error appended, 25.8 answers 500 with
+  // the error as the whole body. Either must fail the stream and name the code, so the assertion covers both rather
+  // than pinning one server's choice.
   it should "fail the stream on an error appended mid-body" in
     client
       .queryWithProgressStreaming("SELECT number, throwIf(number = 3, 'boom') FROM numbers(10)")(

--- a/client/src/test/scala/com/crobox/clickhouse/StreamingProgressSpec.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/StreamingProgressSpec.scala
@@ -1,6 +1,9 @@
 package com.crobox.clickhouse
 
 import com.crobox.clickhouse.internal.QuerySettings
+import com.typesafe.config.ConfigValueFactory
+
+import scala.concurrent.duration._
 import com.crobox.clickhouse.internal.QuerySettings.ReadQueries
 import com.crobox.clickhouse.internal.progress.QueryProgress._
 import org.apache.pekko.stream.scaladsl.Sink
@@ -75,4 +78,41 @@ class StreamingProgressSpec extends ClickhouseClientAsyncSpec {
       .runWith(Sink.seq)
       .failed
       .map(_ shouldBe a[ClickhouseException])
+
+  // The timeout from #355 bounds a whole call, which would be wrong for a stream: a large result can legitimately run
+  // longer than any per-query timeout. It becomes an idle timeout here, catching a server that stops answering.
+  it should "free the caller when a stalled server stops sending mid-stream" in {
+    val listener  = new java.net.ServerSocket(0)
+    val accepting = new Thread(() => while (!listener.isClosed) scala.util.Try(listener.accept()))
+    accepting.setDaemon(true)
+    accepting.start()
+
+    val stalled = new ClickhouseClient(
+      Some(
+        config
+          .withValue("crobox.clickhouse.client.connection.port", ConfigValueFactory.fromAnyRef(listener.getLocalPort))
+          .withValue("crobox.clickhouse.client.connection.host", ConfigValueFactory.fromAnyRef("localhost"))
+      )
+    )
+
+    val started = System.nanoTime()
+    stalled
+      .queryWithProgressStreaming("SELECT 1")(QuerySettings(ReadQueries, timeout = Some(1.second)))
+      .runWith(Sink.seq)
+      .failed
+      .map { _ =>
+        val elapsed = (System.nanoTime() - started).nanos
+        listener.close()
+        elapsed should be < 15.seconds
+      }
+  }
+
+  it should "not cut short a result that takes longer than the timeout to stream" in
+    client
+      .queryWithProgressStreaming("SELECT number FROM numbers(300000)")(
+        QuerySettings(ReadQueries, timeout = Some(1.second))
+      )
+      .collect { case QueryResultPart(d) if d.nonEmpty => 1 }
+      .runWith(Sink.fold(0)(_ + _))
+      .map(_ shouldBe 300000)
 }

--- a/client/src/test/scala/com/crobox/clickhouse/StreamingProgressSpec.scala
+++ b/client/src/test/scala/com/crobox/clickhouse/StreamingProgressSpec.scala
@@ -1,0 +1,45 @@
+package com.crobox.clickhouse
+
+import com.crobox.clickhouse.internal.progress.QueryProgress._
+import org.apache.pekko.stream.scaladsl.Sink
+
+class StreamingProgressSpec extends ClickhouseClientAsyncSpec {
+
+  private val client = new ClickhouseClient(Some(config))
+
+  it should "emit the result as parts rather than one buffered body" in
+    client
+      .queryWithProgressStreaming("SELECT number FROM numbers(5)")
+      .runWith(Sink.seq)
+      .map { events =>
+        val parts = events.collect { case QueryResultPart(data) => data }.filter(_.nonEmpty)
+        parts should contain theSameElementsInOrderAs Seq("0", "1", "2", "3", "4")
+      }
+
+  it should "finish the stream once the body is done, despite the progress hub never completing" in
+    client
+      .queryWithProgressStreaming("SELECT 1")
+      .runWith(Sink.seq)
+      .map(events => events.last shouldBe QueryFinished)
+
+  it should "stream a large result without collecting it" in
+    client
+      .queryWithProgressStreaming("SELECT number FROM numbers(200000)")
+      .collect { case QueryResultPart(data) if data.nonEmpty => 1 }
+      .runWith(Sink.fold(0)(_ + _))
+      .map(_ shouldBe 200000)
+
+  it should "surface progress events alongside the result" in
+    client
+      .queryWithProgressStreaming("SELECT number FROM numbers(100000)")(
+        com.crobox.clickhouse.internal.QuerySettings(
+          com.crobox.clickhouse.internal.QuerySettings.ReadQueries,
+          progressHeaders = Some(true)
+        )
+      )
+      .runWith(Sink.seq)
+      .map { events =>
+        // The result is what matters; progress headers are best-effort and the server may finish too fast to send any.
+        events.count { case QueryResultPart(d) if d.nonEmpty => true; case _ => false } shouldBe 100000
+      }
+}


### PR DESCRIPTION
Closes #75.

`queryWithProgress` returns `Source[QueryProgress, Future[String]]` — progress in the stream, result as the **materialised value**. Producing that value means draining the response entity into a single `String`, so a million-row result is one ~7MB allocation held whole. That is the mechanism behind #86's OOM, which #335 notes is a symptom of this issue rather than its own bug.

## What's added

```scala
client.queryWithProgressStreaming(sql)   // Source[QueryProgress, NotUsed]
```

The body arrives as `QueryResultPart(line)` events in the same source as the progress, framed one line at a time. Tested by streaming 200k rows through a `fold` rather than collecting them.

## The construction worth explaining

`progressSource` is a `BroadcastHub` that **never completes** — it's shared across every query. Merging it naively with a finite body gives a stream that hangs forever. So:

- `merge(body, eagerComplete = true)` lets whichever side completes first end the stream. Progress never does, so the body decides — which is the intent.
- `QueryFinished` is concatenated after the body, so consumers get an explicit terminator instead of inferring completion.

**Not retried**, unlike `queryWithProgress`. A retry re-runs the request, and here the consumer may already have seen part of a result — replaying it would be worse than failing.

## Additive on purpose

`queryWithProgress` keeps its current shape. Changing its materialised value from `Future[String]` to something streaming would break every existing caller, and the buffered form is still the convenient one for small results. This gives the streaming option to the callers who need it.

## Verification

- `scalafmtCheckAll` clean; `+compile +Test/compile +It/compile` green on 2.13 and 3.3.
- 4 new client tests, run on **both** Scala versions: parts arriving in order, the stream terminating despite the non-completing hub, 200k rows streamed without collection, and progress events alongside the result.
- 323 dsl unit and 139 integration tests unchanged. The two `client` failures are the usual environmental pair.

I ran these on 3.3 explicitly rather than relying on cross-compilation, after #357 showed that compiling on both versions does not mean the tests pass on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)