### PR TITLE
Build the ArrayFlatten fixture with arrayOf

### DIFF
--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
@@ -164,7 +164,8 @@ class SqlValidationITSpec extends DslITSpec {
       sem("ArrayEmpty", select(arrayEmpty(nums))),
       sem("ArrayNotEmpty", select(arrayNotEmpty(nums))),
       sem("ArrayLength", select(arrayLength(nums))),
-      sem("ArrayFlatten", select(ArrayFlatten(Array(Array("1", "2"), Array("3")))))
+      // arrayOf rather than the DSL's `Array`, which shadows scala.Array here and reads like a native array call.
+      sem("ArrayFlatten", select(arrayFlatten(arrayOf(arrayOf("1", "2"), arrayOf("3")))))
     )
   }
 


### PR DESCRIPTION
Follow-up to a review note on #356, which merged before I pushed the change — so it needs its own PR rather than living on a dead branch.

The `ArrayFlatten` entry used the DSL's own `Array` case class, which shadows `scala.Array` under `import ...dsl._`. It worked, but read like a native array call. `arrayOf(arrayOf("1", "2"), arrayOf("3"))` says the same thing without depending on the shadow, and I confirmed the server accepts the result identically.

`ArrayFunctionsIT` builds it the same way — that's where I lifted the shape from — but I've left it alone so this stays a one-line change.

146 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)