### PR TITLE
Type IPv6StringToNum and UUIDStringToNum as FixedString(16)

### DIFF
--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/column/EncodingFunctionsIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/column/EncodingFunctionsIT.scala
@@ -14,6 +14,7 @@ class EncodingFunctionsIT extends DslITSpec {
     val someUUID = UUID.randomUUID()
     r(uUIDNumToString(toFixedString("4151302937104031", 16))).nonEmpty shouldBe true
     r(uUIDStringToNum(someUUID)).nonEmpty shouldBe true
+    r(uUIDNumToString(uUIDStringToNum(someUUID))) shouldBe someUUID.toString
     r(bitmaskToList(2)).nonEmpty shouldBe true
     r(bitmaskToArray(2)).nonEmpty shouldBe true
   }

--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/column/IPFunctionsIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/column/IPFunctionsIT.scala
@@ -12,5 +12,6 @@ class IPFunctionsIT extends DslITSpec {
     r(iPv4NumToStringClassC(num)) shouldBe "0.0.0.xxx"
     r(iPv6NumToString(toFixedString("0", 16))) shouldBe "3000::"
     r(iPv6StringToNum("3000::")) shouldBe "0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0"
+    r(iPv6NumToString(iPv6StringToNum("3000::"))) shouldBe "3000::"
   }
 }

--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
@@ -66,8 +66,7 @@ class SqlValidationITSpec extends DslITSpec {
     sem("Hex", select(hex(255))),
     sem("Unhex", select(unhex("FF"))),
     sem("UUIDStringToNum", select(uUIDStringToNum("00000000-0000-0000-0000-000000000000"))),
-    // Needs FixedString(16); the DSL types this argument as String, so the cast has to be explicit.
-    sem("UUIDNumToString", select(uUIDNumToString(toFixedString("0000000000000000", 16)))),
+    sem("UUIDNumToString", select(uUIDNumToString(uUIDStringToNum("00000000-0000-0000-0000-000000000000")))),
     sem("BitmaskToList", select(bitmaskToList(5))),
     sem("BitmaskToArray", select(bitmaskToArray(5)))
   )
@@ -76,7 +75,7 @@ class SqlValidationITSpec extends DslITSpec {
     sem("IPv4NumToString", select(iPv4NumToString(3232235521L))),
     sem("IPv4StringToNum", select(iPv4StringToNum("192.168.0.1"))),
     sem("IPv4NumToStringClassC", select(iPv4NumToStringClassC(3232235521L))),
-    sem("IPv6NumToString", select(iPv6NumToString(toFixedString("0000000000000000", 16)))),
+    sem("IPv6NumToString", select(iPv6NumToString(iPv6StringToNum("::1")))),
     sem("IPv6StringToNum", select(iPv6StringToNum("::1")))
   )
 

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/FixedStringBytes.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/FixedStringBytes.scala
@@ -1,0 +1,7 @@
+package com.crobox.clickhouse.dsl
+
+/**
+ * The server's `FixedString(N)`: bytes rather than text. It has no values -- it exists so that the functions returning
+ * one (`IPv6StringToNum`, `UUIDStringToNum`) only fit the functions that accept one, which reject a plain `String`.
+ */
+sealed trait FixedStringBytes

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/EncodingFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/EncodingFunctions.scala
@@ -1,21 +1,21 @@
 package com.crobox.clickhouse.dsl.column
 
-import com.crobox.clickhouse.dsl.{Column, ExpressionColumn}
+import com.crobox.clickhouse.dsl.{Column, ExpressionColumn, FixedStringBytes}
 
 trait EncodingFunctions { self: Magnets =>
   abstract class EncodingFunction[O](val column: Column) extends ExpressionColumn[O](column)
 
-  case class Hex(col: HexCompatible[_])               extends EncodingFunction[String](col.column)
-  case class Unhex(col: StringColMagnet[_])           extends EncodingFunction[String](col.column)
-  case class UUIDStringToNum(col: StringColMagnet[_]) extends EncodingFunction[Byte](col.column)
-  case class UUIDNumToString(col: StringColMagnet[_]) extends EncodingFunction[Byte](col.column)
-  case class BitmaskToList(col: NumericCol[_])        extends EncodingFunction[String](col.column)
-  case class BitmaskToArray(col: NumericCol[_])       extends EncodingFunction[Iterable[Long]](col.column)
+  case class Hex(col: HexCompatible[_])                    extends EncodingFunction[String](col.column)
+  case class Unhex(col: StringColMagnet[_])                extends EncodingFunction[String](col.column)
+  case class UUIDStringToNum(col: StringColMagnet[_])      extends EncodingFunction[FixedStringBytes](col.column)
+  case class UUIDNumToString(col: FixedStringColMagnet[_]) extends EncodingFunction[String](col.column)
+  case class BitmaskToList(col: NumericCol[_])             extends EncodingFunction[String](col.column)
+  case class BitmaskToArray(col: NumericCol[_])            extends EncodingFunction[Iterable[Long]](col.column)
 
-  def hex(col: HexCompatible[_])               = Hex(col)
-  def unhex(col: StringColMagnet[_])           = Unhex(col)
-  def uUIDStringToNum(col: StringColMagnet[_]) = UUIDStringToNum(col)
-  def uUIDNumToString(col: StringColMagnet[_]) = UUIDNumToString(col)
-  def bitmaskToList(col: NumericCol[_])        = BitmaskToList(col)
-  def bitmaskToArray(col: NumericCol[_])       = BitmaskToArray(col)
+  def hex(col: HexCompatible[_])                    = Hex(col)
+  def unhex(col: StringColMagnet[_])                = Unhex(col)
+  def uUIDStringToNum(col: StringColMagnet[_])      = UUIDStringToNum(col)
+  def uUIDNumToString(col: FixedStringColMagnet[_]) = UUIDNumToString(col)
+  def bitmaskToList(col: NumericCol[_])             = BitmaskToList(col)
+  def bitmaskToArray(col: NumericCol[_])            = BitmaskToArray(col)
 }

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/IPFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/IPFunctions.scala
@@ -1,6 +1,6 @@
 package com.crobox.clickhouse.dsl.column
 
-import com.crobox.clickhouse.dsl.{Column, ExpressionColumn}
+import com.crobox.clickhouse.dsl.{Column, ExpressionColumn, FixedStringBytes}
 
 trait IPFunctions { self: Magnets =>
   abstract class IPFunction[O](col: Column) extends ExpressionColumn[O](col)
@@ -8,19 +8,15 @@ trait IPFunctions { self: Magnets =>
   case class IPv4NumToString(col: NumericCol[_])       extends IPFunction[String](col.column)
   case class IPv4StringToNum(col: StringColMagnet[_])  extends IPFunction[Long](col.column)
   case class IPv4NumToStringClassC(col: NumericCol[_]) extends IPFunction[String](col.column)
-  case class IPv6NumToString(col: StringColMagnet[_])  extends IPFunction[String](col.column)
-  case class IPv6StringToNum(col: StringColMagnet[_])  extends IPFunction[Long](col.column)
 
-  def iPv4NumToString(col: NumericCol[_])       = IPv4NumToString(col)
-  def iPv4StringToNum(col: StringColMagnet[_])  = IPv4StringToNum(col)
-  def iPv4NumToStringClassC(col: NumericCol[_]) = IPv4NumToStringClassC(col)
-  def iPv6NumToString(col: StringColMagnet[_])  = IPv6NumToString(col)
-  def iPv6StringToNum(col: StringColMagnet[_])  = IPv6StringToNum(col)
-  /*
-IPv4NumToString(num)
-IPv4StringToNum(s)
-IPv4NumToStringClassC(num)
-IPv6NumToString(x)
-IPv6StringToNum(s)
-   */
+  // IPv6StringToNum returns FixedString(16), and IPv6NumToString accepts nothing else -- passing it a String
+  // fails at the server with ILLEGAL_TYPE_OF_ARGUMENT.
+  case class IPv6NumToString(col: FixedStringColMagnet[_]) extends IPFunction[String](col.column)
+  case class IPv6StringToNum(col: StringColMagnet[_])      extends IPFunction[FixedStringBytes](col.column)
+
+  def iPv4NumToString(col: NumericCol[_])           = IPv4NumToString(col)
+  def iPv4StringToNum(col: StringColMagnet[_])      = IPv4StringToNum(col)
+  def iPv4NumToStringClassC(col: NumericCol[_])     = IPv4NumToStringClassC(col)
+  def iPv6NumToString(col: FixedStringColMagnet[_]) = IPv6NumToString(col)
+  def iPv6StringToNum(col: StringColMagnet[_])      = IPv6StringToNum(col)
 }

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/Magnets.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/Magnets.scala
@@ -3,7 +3,15 @@ package com.crobox.clickhouse.dsl.column
 import com.crobox.clickhouse.dsl.marshalling.QueryValueFormats._
 import com.crobox.clickhouse.dsl.marshalling.{QueryValue, QueryValueFormats}
 import com.crobox.clickhouse.dsl.schemabuilder.ColumnType.SimpleColumnType
-import com.crobox.clickhouse.dsl.{Const, EmptyColumn, ExpressionColumn, OperationalQuery, Table, TableColumn}
+import com.crobox.clickhouse.dsl.{
+  Const,
+  EmptyColumn,
+  ExpressionColumn,
+  FixedStringBytes,
+  OperationalQuery,
+  Table,
+  TableColumn
+}
 import java.time.{LocalDate, ZonedDateTime}
 
 import java.util.UUID
@@ -193,6 +201,19 @@ trait Magnets {
   implicit def stringColMagnetFromUUIDCol[T <: TableColumn[UUID]](s: T): StringColMagnet[UUID] =
     new StringColMagnet[UUID] {
       override val column: TableColumn[UUID] = s
+    }
+
+  /**
+   * Columns the server types as `FixedString(N)`. Separate from [[StringColMagnet]] because the functions that read one
+   * reject a plain `String`.
+   */
+  trait FixedStringColMagnet[C] extends Magnet[C] with HexCompatible[C]
+
+  implicit def fixedStringColMagnetFromCol[T <: TableColumn[FixedStringBytes]](
+      s: T
+  ): FixedStringColMagnet[FixedStringBytes] =
+    new FixedStringColMagnet[FixedStringBytes] {
+      override val column: TableColumn[FixedStringBytes] = s
     }
 
   /**

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/TypeCastFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/TypeCastFunctions.scala
@@ -279,7 +279,13 @@ trait TypeCastFunctions {
 
   def toUUIDOrZero(tableColumn: ConstOrColMagnet[_]): Uuid = Uuid(tableColumn, orZero = true)
 
-  case class FixedString(tableColumn: ConstOrColMagnet[_], n: Int) extends TypeCastColumn[String](tableColumn)
+  // Also a FixedStringColMagnet: this is the escape hatch for handing a FixedString(N) to IPv6NumToString or
+  // UUIDNumToString when the value did not come from one of the *StringToNum functions.
+  case class FixedString(tableColumn: ConstOrColMagnet[_], n: Int)
+      extends TypeCastColumn[String](tableColumn)
+      with FixedStringColMagnet[String] {
+    override val column: TableColumn[String] = this
+  }
 
   case class StringCutToZero(tableColumn: ConstOrColMagnet[_]) extends TypeCastColumn[String](tableColumn)
 

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/EncodingFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/EncodingFunctionTokenizer.scala
@@ -6,11 +6,11 @@ trait EncodingFunctionTokenizer {
   self: ClickhouseTokenizerModule =>
 
   def tokenizeEncodingFunction(col: EncodingFunction[_])(implicit ctx: TokenizeContext): String = col match {
-    case Hex(col: HexCompatible[_])               => s"hex(${tokenizeColumn(col.column)})"
-    case Unhex(col: StringColMagnet[_])           => s"unhex(${tokenizeColumn(col.column)})"
-    case UUIDStringToNum(col: StringColMagnet[_]) => s"UUIDStringToNum(${tokenizeColumn(col.column)})"
-    case UUIDNumToString(col: StringColMagnet[_]) => s"UUIDNumToString(${tokenizeColumn(col.column)})"
-    case BitmaskToList(col: NumericCol[_])        => s"bitmaskToList(${tokenizeColumn(col.column)})"
-    case BitmaskToArray(col: NumericCol[_])       => s"bitmaskToArray(${tokenizeColumn(col.column)})"
+    case Hex(col: HexCompatible[_])                    => s"hex(${tokenizeColumn(col.column)})"
+    case Unhex(col: StringColMagnet[_])                => s"unhex(${tokenizeColumn(col.column)})"
+    case UUIDStringToNum(col: StringColMagnet[_])      => s"UUIDStringToNum(${tokenizeColumn(col.column)})"
+    case UUIDNumToString(col: FixedStringColMagnet[_]) => s"UUIDNumToString(${tokenizeColumn(col.column)})"
+    case BitmaskToList(col: NumericCol[_])             => s"bitmaskToList(${tokenizeColumn(col.column)})"
+    case BitmaskToArray(col: NumericCol[_])            => s"bitmaskToArray(${tokenizeColumn(col.column)})"
   }
 }

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/IPFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/IPFunctionTokenizer.scala
@@ -6,11 +6,11 @@ trait IPFunctionTokenizer {
   self: ClickhouseTokenizerModule =>
 
   def tokenizeIPFunction(col: IPFunction[_])(implicit ctx: TokenizeContext): String = col match {
-    case IPv4NumToString(col: NumericCol[_])       => s"IPv4NumToString(${tokenizeColumn(col.column)})"
-    case IPv4StringToNum(col: StringColMagnet[_])  => s"IPv4StringToNum(${tokenizeColumn(col.column)})"
-    case IPv4NumToStringClassC(col: NumericCol[_]) => s"IPv4NumToStringClassC(${tokenizeColumn(col.column)})"
-    case IPv6NumToString(col: StringColMagnet[_])  => s"IPv6NumToString(${tokenizeColumn(col.column)})"
-    case IPv6StringToNum(col: StringColMagnet[_])  => s"IPv6StringToNum(${tokenizeColumn(col.column)})"
+    case IPv4NumToString(col: NumericCol[_])           => s"IPv4NumToString(${tokenizeColumn(col.column)})"
+    case IPv4StringToNum(col: StringColMagnet[_])      => s"IPv4StringToNum(${tokenizeColumn(col.column)})"
+    case IPv4NumToStringClassC(col: NumericCol[_])     => s"IPv4NumToStringClassC(${tokenizeColumn(col.column)})"
+    case IPv6NumToString(col: FixedStringColMagnet[_]) => s"IPv6NumToString(${tokenizeColumn(col.column)})"
+    case IPv6StringToNum(col: StringColMagnet[_])      => s"IPv6StringToNum(${tokenizeColumn(col.column)})"
   }
 
 }

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/FixedStringTypingTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/FixedStringTypingTest.scala
@@ -1,0 +1,52 @@
+package com.crobox.clickhouse.dsl
+
+import com.crobox.clickhouse.DslTestSpec
+
+class FixedStringTypingTest extends DslTestSpec {
+
+  private def sql(query: OperationalQuery): String = toSql(query.internalQuery, None)
+
+  "IPv6" should "round trip" in {
+    sql(select(iPv6NumToString(iPv6StringToNum("::1")))) should matchSQL(
+      "SELECT IPv6NumToString(IPv6StringToNum('::1'))"
+    )
+  }
+
+  it should "accept an explicit cast" in {
+    sql(select(iPv6NumToString(toFixedString(col3, 16)))) should matchSQL(
+      "SELECT IPv6NumToString(toFixedString(column_3,16))"
+    )
+  }
+
+  // The failure this typing exists to prevent: the server answers ILLEGAL_TYPE_OF_ARGUMENT, so it has to be a compile
+  // error rather than a query that renders and fails.
+  it should "refuse a plain string" in {
+    """select(iPv6NumToString("::1"))""" shouldNot typeCheck
+  }
+
+  it should "refuse a string column" in {
+    """select(iPv6NumToString(col3))""" shouldNot typeCheck
+  }
+
+  "UUID" should "round trip" in {
+    sql(select(uUIDNumToString(uUIDStringToNum(col3)))) should matchSQL(
+      "SELECT UUIDNumToString(UUIDStringToNum(column_3))"
+    )
+  }
+
+  it should "refuse a plain string" in {
+    """select(uUIDNumToString(col3))""" shouldNot typeCheck
+  }
+
+  "hex" should "accept a FixedString, which is how the bytes get printed" in {
+    sql(select(hex(iPv6StringToNum("::1")))) should matchSQL("SELECT hex(IPv6StringToNum('::1'))")
+    sql(select(hex(uUIDStringToNum(col3)))) should matchSQL("SELECT hex(UUIDStringToNum(column_3))")
+  }
+
+  // IPv4StringToNum returns UInt32, not FixedString(16), so it stays numeric and IPv4NumToString stays numeric too.
+  "IPv4" should "round trip through numbers" in {
+    sql(select(iPv4NumToString(iPv4StringToNum("1.2.3.4")))) should matchSQL(
+      "SELECT IPv4NumToString(IPv4StringToNum('1.2.3.4'))"
+    )
+  }
+}


### PR DESCRIPTION
Both `IPv6StringToNum` and `UUIDStringToNum` return `FixedString(16)` on the server, but the DSL declared them as `Long` and `Byte`, and their counterparts took a `StringColMagnet`. So the obvious composition did not compile:

```scala
iPv6NumToString(iPv6StringToNum("::1"))
// found: IPv6StringToNum, required: StringColMagnet[_]
```

…and the workaround that *did* compile passed a plain `String`, which the server rejects:

```
Code: 43. DB::Exception: Illegal type String of argument of function IPv6NumToString,
expected IPv6 or FixedString(16)
```

## What changed

- New phantom type `FixedStringBytes` for the server's `FixedString(N)` — bytes rather than text. It has no values; it exists so producers only fit consumers.
- New `FixedStringColMagnet` for columns carrying one.
- `IPv6StringToNum` / `UUIDStringToNum` return it; `IPv6NumToString` / `UUIDNumToString` require it. Passing a `String` is now a compile error rather than a query that renders and fails at the server.
- `toFixedString(x, n)` mixes the magnet in, so the explicit cast still works when the value did not come from a `*StringToNum`.
- `UUIDNumToString` was typed `Byte`; the server reports `String`, so it is now `String`.
- `IPv4StringToNum` is untouched — it returns `UInt32`, so `Long` is correct.

## Verified against 25.3

| query | result |
|---|---|
| `toTypeName(IPv6StringToNum('::1'))` | `FixedString(16)` |
| `toTypeName(UUIDStringToNum(...))` | `FixedString(16)` |
| `toTypeName(IPv4StringToNum('1.2.3.4'))` | `UInt32` |
| `toTypeName(UUIDNumToString(toFixedString(...,16)))` | `String` |
| `IPv6NumToString(IPv6StringToNum('::1'))` | `::1` |
| `UUIDNumToString(UUIDStringToNum(u))` | `u` |
| `hex(IPv6StringToNum('::1'))` | `000…001` |

## Tests

- `FixedStringTypingTest` — the round trips render, and the two `String` forms this typing exists to reject are asserted `shouldNot typeCheck`.
- `IPFunctionsIT` / `EncodingFunctionsIT` now execute the round trips against a real server.
- `SqlValidationITSpec` registers the round trip instead of the `toFixedString` workaround, so the comment explaining that workaround is gone.

378 dsl unit tests pass on 2.13.18 and 3.3.8; the three touched IT specs pass against 25.3.

Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)