### PR TITLE
Render cast defaults through QueryValue, not toString

### DIFF
--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
@@ -40,6 +40,9 @@ class SqlValidationITSpec extends DslITSpec {
    */
   case class Construct(ast: String, query: OperationalQuery, level: ValidationLevel = Semantic)
 
+  private val stampInAmsterdam =
+    java.time.ZonedDateTime.of(2020, 6, 1, 12, 0, 0, 0, java.time.ZoneId.of("Europe/Amsterdam"))
+
   private val oneDay = MultiInterval(
     java.time.ZonedDateTime.of(2020, 1, 1, 0, 0, 0, 0, java.time.ZoneOffset.UTC),
     java.time.ZonedDateTime.of(2020, 1, 8, 0, 0, 0, 0, java.time.ZoneOffset.UTC),
@@ -428,10 +431,16 @@ class SqlValidationITSpec extends DslITSpec {
     sem("FixedString", select(toFixedString("ab", 2))),
     sem("StringCutToZero", select(toStringCutToZero("ab"))),
     sem("Reinterpret", select(reinterpret[Long](toUInt64("1")))),
-    // The Or* variants render a different arm each, and the OrDefault one renders a nested cast of the default.
+    // The Or* variants render a different arm each. OrDefault renders the default value, which went through toString
+    // and so emitted literals the server could not parse for every non-numeric type.
     sem("UInt32", select(toUInt32OrZero("x"))),
     sem("UInt32", select(toUInt32OrNull("x"))),
-    sem("UInt32", select(toUInt32OrDefault("x", 0)))
+    sem("UInt32", select(toUInt32OrDefault("x", 0))),
+    sem("Int16", select(toInt16OrDefault("x", (-7).toShort))),
+    sem("Float64", select(toFloat64OrDefault("x", 1.5))),
+    sem("DateRep", select(toDateOrDefault("x", stampInAmsterdam))),
+    sem("DateTimeRep", select(toDateTimeOrDefault("x", stampInAmsterdam))),
+    sem("Uuid", select(toUUIDOrDefault("x", toUUID("00000000-0000-0000-0000-000000000001"))))
   )
 
   private val dateTimeConstructs = {

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/TypeCastFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/TypeCastFunctionTokenizer.scala
@@ -1,49 +1,80 @@
 package com.crobox.clickhouse.dsl.language
 
 import com.crobox.clickhouse.dsl._
+import com.crobox.clickhouse.dsl.marshalling.QueryValue
 import com.crobox.clickhouse.dsl.schemabuilder.ColumnType
 import com.crobox.clickhouse.dsl.schemabuilder.ColumnType.SimpleColumnType
+
+import java.time.ZonedDateTime
 
 trait TypeCastFunctionTokenizer {
   self: ClickhouseTokenizerModule =>
 
   protected def tokenizeTypeCastColumn(col: TypeCastColumn[_])(implicit ctx: TokenizeContext): String = {
-    def tknz[T](
-        column: TableColumn[T],
+    def tknz(
+        column: TableColumn[_],
         valueType: SimpleColumnType,
         orZero: Boolean,
         orNull: Boolean,
-        defaultValue: Option[T]
-    ): String = {
-      val postfix = if (orNull) "OrNull" else if (orZero) "OrZero" else ""
-      val value   = defaultValue match {
-        case Some(value) =>
-          s"to${valueType}OrDefault(${tokenizeColumn(column)}, ${tokenizeTypeCastColumn(Cast(value.toString, valueType))})"
-        case _ =>
-          s"to$valueType${postfix}(${tokenizeColumn(column)})"
+        defaultLiteral: Option[String]
+    ): String =
+      defaultLiteral match {
+        case Some(literal) =>
+          s"to${valueType}OrDefault(${tokenizeColumn(column)}${Tokens.Delimiter}cast($literal AS $valueType))"
+        case None =>
+          val postfix = if (orNull) "OrNull" else if (orZero) "OrZero" else ""
+          s"to$valueType$postfix(${tokenizeColumn(column)})"
       }
-      value
-    }
+
+    // The default is an expression of the target type, so the value's own QueryValue is what knows its literal form.
+    // toString gave '1970-01-01T00:00Z' for a ZonedDateTime and the case class's own toString -- object hash included
+    // -- for a UUID, and the server can parse neither.
+    def lit[T](value: T)(implicit qv: QueryValue[T]): String = qv(value)
 
     col match {
-      case c: UInt8               => tknz(c.tableColumn.column, ColumnType.UInt8, c.orZero, c.orNull, c.orDefault)
-      case c: UInt16              => tknz(c.tableColumn.column, ColumnType.UInt16, c.orZero, c.orNull, c.orDefault)
-      case c: UInt32              => tknz(c.tableColumn.column, ColumnType.UInt32, c.orZero, c.orNull, c.orDefault)
-      case c: UInt64              => tknz(c.tableColumn.column, ColumnType.UInt64, c.orZero, c.orNull, c.orDefault)
-      case c: Int8                => tknz(c.tableColumn.column, ColumnType.Int8, c.orZero, c.orNull, c.orDefault)
-      case c: Int16               => tknz(c.tableColumn.column, ColumnType.Int16, c.orZero, c.orNull, c.orDefault)
-      case c: Int32               => tknz(c.tableColumn.column, ColumnType.Int32, c.orZero, c.orNull, c.orDefault)
-      case c: Int64               => tknz(c.tableColumn.column, ColumnType.Int64, c.orZero, c.orNull, c.orDefault)
-      case c: Float32             => tknz(c.tableColumn.column, ColumnType.Float32, c.orZero, c.orNull, c.orDefault)
-      case c: Float64             => tknz(c.tableColumn.column, ColumnType.Float64, c.orZero, c.orNull, c.orDefault)
-      case c: DateRep             => tknz(c.tableColumn.column, ColumnType.Date, c.orZero, c.orNull, c.orDefault)
-      case c: DateTimeRep         => tknz(c.tableColumn.column, ColumnType.DateTime, c.orZero, c.orNull, c.orDefault)
-      case c: Uuid                => tknz(c.tableColumn.column, ColumnType.UUID, c.orZero, c.orNull, c.orDefault)
-      case StringRep(tableColumn) => s"toString(${tokenizeColumn(tableColumn.column)})"
+      case c: UInt8  => tknz(c.tableColumn.column, ColumnType.UInt8, c.orZero, c.orNull, c.orDefault.map(lit(_)))
+      case c: UInt16 =>
+        // No QueryValue[Short]; widening to Int renders the same digits.
+        tknz(c.tableColumn.column, ColumnType.UInt16, c.orZero, c.orNull, c.orDefault.map(v => lit(v.toInt)))
+      case c: UInt32 => tknz(c.tableColumn.column, ColumnType.UInt32, c.orZero, c.orNull, c.orDefault.map(lit(_)))
+      case c: UInt64 => tknz(c.tableColumn.column, ColumnType.UInt64, c.orZero, c.orNull, c.orDefault.map(lit(_)))
+      case c: Int8   => tknz(c.tableColumn.column, ColumnType.Int8, c.orZero, c.orNull, c.orDefault.map(lit(_)))
+      case c: Int16  =>
+        tknz(c.tableColumn.column, ColumnType.Int16, c.orZero, c.orNull, c.orDefault.map(v => lit(v.toInt)))
+      case c: Int32       => tknz(c.tableColumn.column, ColumnType.Int32, c.orZero, c.orNull, c.orDefault.map(lit(_)))
+      case c: Int64       => tknz(c.tableColumn.column, ColumnType.Int64, c.orZero, c.orNull, c.orDefault.map(lit(_)))
+      case c: Float32     => tknz(c.tableColumn.column, ColumnType.Float32, c.orZero, c.orNull, c.orDefault.map(lit(_)))
+      case c: Float64     => tknz(c.tableColumn.column, ColumnType.Float64, c.orZero, c.orNull, c.orDefault.map(lit(_)))
+      case c: DateRep     => tknz(c.tableColumn.column, ColumnType.Date, c.orZero, c.orNull, c.orDefault.map(lit(_)))
+      case c: DateTimeRep => tokenizeDateTimeRep(c)
+      // The default here is already a column expression rather than a value, so it renders as one.
+      case c: Uuid =>
+        tknz(c.tableColumn.column, ColumnType.UUID, c.orZero, c.orNull, c.orDefault.map(tokenizeColumn))
+      case StringRep(tableColumn)              => s"toString(${tokenizeColumn(tableColumn.column)})"
       case FixedString(tableColumn, n)         => s"toFixedString(${tokenizeColumn(tableColumn.column)},$n)"
       case StringCutToZero(tableColumn)        => s"toStringCutToZero(${tokenizeColumn(tableColumn.column)})"
       case Reinterpret(typeCastColumn)         => s"reinterpretAs${tokenizeTypeCastColumn(typeCastColumn).substring(2)}"
       case Cast(tableColumn, simpleColumnType) => s"cast(${tokenizeColumn(tableColumn.column)} AS $simpleColumnType)"
+    }
+  }
+
+  /**
+   * `toDateTimeOrDefault` is the one shape that does not fit the others: the server reads its second argument as a
+   * timezone, so the default has to come third. With the default second it fails with ILLEGAL_TYPE_OF_ARGUMENT.
+   *
+   * The literal carries no zone of its own, so it is parsed in the default's zone rather than the server's, which is
+   * what keeps it the instant the caller passed.
+   */
+  private def tokenizeDateTimeRep(rep: DateTimeRep)(implicit ctx: TokenizeContext): String = {
+    val column = tokenizeColumn(rep.tableColumn.column)
+    rep.orDefault match {
+      case Some(value) =>
+        val zone    = value.getZone.getId
+        val literal = implicitly[QueryValue[ZonedDateTime]].apply(value)
+        s"toDateTimeOrDefault($column${Tokens.Delimiter}'$zone'${Tokens.Delimiter}toDateTime($literal, '$zone'))"
+      case None =>
+        val postfix = if (rep.orNull) "OrNull" else if (rep.orZero) "OrZero" else ""
+        s"toDateTime$postfix($column)"
     }
   }
 }

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/TypeCaseFunctionTokenizerTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/TypeCaseFunctionTokenizerTest.scala
@@ -3,6 +3,8 @@ package com.crobox.clickhouse.dsl.language
 import com.crobox.clickhouse.DslTestSpec
 import com.crobox.clickhouse.dsl._
 
+import java.time.{ZoneId, ZoneOffset, ZonedDateTime}
+
 class TypeCaseFunctionTokenizerTest extends DslTestSpec {
 
   it should "succeed for UUID functions" in {
@@ -11,5 +13,48 @@ class TypeCaseFunctionTokenizerTest extends DslTestSpec {
     ) should matchSQL("SELECT toUUID('00000000-0000-0000-0000-000000000000')")
     toSQL(select(toUUIDOrZero(const("123")))) should matchSQL("SELECT toUUIDOrZero('123')")
     toSQL(select(toUUIDOrNull(const("123")))) should matchSQL("SELECT toUUIDOrNull('123')")
+  }
+
+  // The default used to render through toString, so a ZonedDateTime became '1970-01-01T00:00Z' and a UUID became the
+  // case class's own toString. The server parses neither.
+  "OrDefault" should "render a datetime default the server can parse" in {
+    val stamp = ZonedDateTime.of(2020, 6, 1, 12, 0, 0, 0, ZoneId.of("Europe/Amsterdam"))
+    toSQL(select(toDateTimeOrDefault(col3, stamp)), false) should matchSQL(
+      "SELECT toDateTimeOrDefault(column_3, 'Europe/Amsterdam', toDateTime('2020-06-01 12:00:00', 'Europe/Amsterdam'))"
+    )
+  }
+
+  it should "render a date default the server can parse" in {
+    val stamp = ZonedDateTime.of(2020, 6, 1, 12, 0, 0, 0, ZoneOffset.UTC)
+    toSQL(select(toDateOrDefault(col3, stamp)), false) should matchSQL(
+      "SELECT toDateOrDefault(column_3, cast('2020-06-01 12:00:00' AS Date))"
+    )
+  }
+
+  it should "render a uuid default as the column expression it is" in {
+    toSQL(select(toUUIDOrDefault(col3, toUUID(const("00000000-0000-0000-0000-000000000001")))), false) should matchSQL(
+      "SELECT toUUIDOrDefault(column_3, cast(toUUID('00000000-0000-0000-0000-000000000001') AS UUID))"
+    )
+  }
+
+  it should "render numeric defaults" in {
+    toSQL(select(toUInt8OrDefault(col3, 7.toByte)), false) should matchSQL(
+      "SELECT toUInt8OrDefault(column_3, cast(7 AS UInt8))"
+    )
+    toSQL(select(toUInt16OrDefault(col3, 7.toShort)), false) should matchSQL(
+      "SELECT toUInt16OrDefault(column_3, cast(7 AS UInt16))"
+    )
+    toSQL(select(toInt16OrDefault(col3, (-7).toShort)), false) should matchSQL(
+      "SELECT toInt16OrDefault(column_3, cast(-7 AS Int16))"
+    )
+    toSQL(select(toFloat64OrDefault(col3, 1.5)), false) should matchSQL(
+      "SELECT toFloat64OrDefault(column_3, cast(1.5 AS Float64))"
+    )
+  }
+
+  it should "leave the OrZero and OrNull forms alone" in {
+    toSQL(select(toDateTimeOrZero(col3)), false) should matchSQL("SELECT toDateTimeOrZero(column_3)")
+    toSQL(select(toDateTimeOrNull(col3)), false) should matchSQL("SELECT toDateTimeOrNull(column_3)")
+    toSQL(select(toDateTime(col3)), false) should matchSQL("SELECT toDateTime(column_3)")
   }
 }


### PR DESCRIPTION
Fixes the RC1 report: `TypeCastFunctionTokenizer` built the `OrDefault` argument as `Cast(value.toString, valueType)`, so the default went through `QueryValue[String]` on a `toString` rather than the value's own `QueryValue`.

## What it emitted, against 25.3

| emitted | server |
|---|---|
| `toDateTimeOrDefault(c, cast('1970-01-01T00:00Z' AS DateTime))` | `Code: 41. Cannot parse time component of DateTime 00:00Z` |
| `toDateOrDefault(c, cast('1970-01-01T00:00Z' AS Date))` | `Code: 6. syntax error at position 10` |
| `toUUIDOrDefault(c, cast('Uuid(…Magnets$$anon$1@39380cc8,false,None,false)' AS UUID))` | `Code: 6. Cannot parse string 'Uuid…` |
| `toUInt8OrDefault(c, cast('1' AS UInt8))` | works |

The UUID form rendered the case class's own `toString`, **object hash included**, so the SQL was not even stable between runs. Numerics survived by accident — `'1'` casts fine.

## `toDateTimeOrDefault` needed more than the literal

The server reads its second argument as a timezone, so two arguments fail even with a correct literal:

```
SELECT toDateTimeOrDefault('x', cast('1970-01-01 00:00:00' AS DateTime))
Code: 43. A value of illegal type was provided as 2nd argument 'timezone'
```

It now emits the three-argument form with the default's own zone, and parses the literal in that zone so the value stays the instant the caller gave:

```sql
toDateTimeOrDefault(c, 'Europe/Amsterdam',
                    toDateTime('2020-06-01 12:00:00', 'Europe/Amsterdam'))
-- unix 1591005600 = 12:00 Amsterdam. Round trip intact.
```

It is the only member of the family with that arity — `toDateOrDefault`, `toUUIDOrDefault` and the numerics all take the default second.

## Changed output

Numeric defaults lose their quotes: `cast(7 AS UInt8)` rather than `cast('7' AS UInt8)`. The server accepts both.

## Why the harness missed it

The only `OrDefault` construct registered was `toUInt32OrDefault` — the one family that worked by accident, which gave false confidence the arm was covered. The date, datetime, uuid and remaining numeric forms are registered now, so all 390 constructs go through `EXPLAIN QUERY TREE` on every CI server. Golden tests cover each rendering, including that `OrZero`, `OrNull` and the bare form are untouched.

## Verified

- 387 dsl unit tests on 2.13.18 and 3.3.8
- 146 dsl integration tests against 25.3

Pre-existing in 1.3.0, so this is a fix for 2.0.0 rather than an RC regression.

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)