### PR TITLE
Stop ordering by an alias from duplicating it in the projection

### DIFF
--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
@@ -642,6 +642,14 @@ class SqlValidationITSpec extends DslITSpec {
       "order by an expression differing from the projection",
       select(sum(col2)).from(TwoTestTable).orderBy(uniq(col2))
     ),
+    Construct(
+      "order by an alias, which must not be projected a second time",
+      select(uniq(col2) as "value").from(TwoTestTable).orderBy(ref[Long]("value"))
+    ),
+    Construct(
+      "group by an alias, which must not be projected a second time",
+      select(col3 as "value").from(TwoTestTable).groupBy(ref[String]("value"))
+    ),
     Construct("re-aliased column", select((shieldId as "from_pv") as "from_start").from(OneTestTable)),
     Construct(
       "an inner alias referenced from the enclosing query",

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/OperationalQuery.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/OperationalQuery.scala
@@ -220,6 +220,27 @@ trait OperationalQuery extends Query {
     OperationalQuery(internalQuery.copy(unionAll = internalQuery.unionAll :+ otherQuery))
   }
 
+  /**
+   * The name a column publishes to the enclosing scope, where it has one.
+   *
+   * `Column.name` is not that. An `ExpressionColumn` is constructed with its argument's name, so `sum(x).name` is `x`
+   * -- which is why de-duplicating on `name` left the grouping column out of `select(sum(x)).groupBy(x)`. Only these
+   * three name their own output, and only they can stand in for one another.
+   */
+  private def publishedName(column: Column): Option[String] = column match {
+    case c: AliasedColumn[_] => Option(c.alias)
+    case c: NativeColumn[_]  => Option(c.name)
+    case c: RefColumn[_]     => Option(c.ref)
+    case _                   => None
+  }
+
+  /**
+   * Adds the `GROUP BY` / `ORDER BY` columns that the projection does not already produce.
+   *
+   * "Already produce" is two things, and matching only one of them has broken in both directions: by name alone drops a
+   * grouping column that an aggregate over it appears to shadow, and by value alone appends a second `value` for
+   * `ORDER BY value` over a `... AS value`, silently widening every row.
+   */
   private def mergeOperationalColumns(newOrderingColumns: Seq[Column]): Option[SelectQuery] = {
     val selectForGroup = internalQuery.select
 
@@ -232,9 +253,11 @@ trait OperationalQuery extends Query {
       newOrderingColumns
     }
 
-    // By value rather than by name, for the same reason as SelectQuery.addColumn: `groupBy(x)` on a query already
-    // selecting `sum(x)` used to leave the grouping column out of the projection entirely.
-    val filteredDuplicates = filteredSelectAll.filterNot(selectForGroupCols.contains)
+    val published = selectForGroupCols.flatMap(publishedName).toSet
+
+    val filteredDuplicates = filteredSelectAll.filterNot { candidate =>
+      selectForGroupCols.contains(candidate) || publishedName(candidate).exists(published.contains)
+    }
 
     val selectWithOrderColumns = selectForGroupCols ++ filteredDuplicates
 

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/ColumnIdentityTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/ColumnIdentityTest.scala
@@ -66,6 +66,33 @@ class ColumnIdentityTest extends DslTestSpec {
     sql(select(shieldId as "a" as "b" as "c")) should matchSQL("SELECT shield_id AS c")
   }
 
+  // Ordering by an alias must not append a second copy of it to the projection. By-value de-duplication alone did,
+  // which widened every row of every query that orders by an aggregate's alias.
+  "Ordering by an alias" should "not duplicate the aliased column" in {
+    sql(select(uniq(col2) as "value").from(TwoTestTable).orderBy(ref[Long]("value"))) should matchSQL(
+      s"SELECT uniq(column_2) AS value FROM ${TwoTestTable.quoted} ORDER BY value ASC"
+    )
+  }
+
+  it should "not duplicate it when grouping either" in {
+    sql(select(col3 as "value").from(TwoTestTable).groupBy(ref[String]("value"))) should matchSQL(
+      s"SELECT column_3 AS value FROM ${TwoTestTable.quoted} GROUP BY value"
+    )
+  }
+
+  it should "still project a grouping column the projection does not produce" in {
+    sql(select(col3 as "value").from(TwoTestTable).groupBy(col2)) should matchSQL(
+      s"SELECT column_3 AS value, column_2 FROM ${TwoTestTable.quoted} GROUP BY column_2"
+    )
+  }
+
+  // A stored column and an alias of the same name are the same identifier to the server, which resolves the alias.
+  it should "treat a native column of the alias name as already projected" in {
+    sql(select(col3 as "column_2").from(TwoTestTable).orderBy(col2)) should matchSQL(
+      s"SELECT column_3 AS column_2 FROM ${TwoTestTable.quoted} ORDER BY column_2 ASC"
+    )
+  }
+
   // The documented answer to #24: to refer to an alias from an enclosing query, reference it rather than re-aliasing.
   it should "reference an inner alias from an enclosing query" in {
     val fromPv = shieldId as "from_pv"


### PR DESCRIPTION
Fixes the RC1 blocker: 193 SQL-comparison failures across two consumers, one root cause.

```scala
select(uniq(col2) as "value").from(t).orderBy(ref[Long]("value"))
```

| | emitted |
|---|---|
| 1.3.0 | `SELECT uniq(column_2) AS value FROM t ORDER BY value ASC` |
| RC1 | `SELECT uniq(column_2) AS value, value FROM t ORDER BY value ASC` |
| this PR | `SELECT uniq(column_2) AS value FROM t ORDER BY value ASC` |

The server accepts the RC1 form and returns the column twice — `SELECT uniq(number) AS value, value FROM numbers(3)` gives `3  3` — so rows come back a column wider than intended, with no error.

## Root cause

`mergeOperationalColumns` de-duplicates the GROUP BY / ORDER BY columns it adds to the projection. 1.3.0 compared by name, #353 switched to by value. Both are wrong for the same reason: **`Column.name` is not an output name.**

```scala
abstract class ExpressionColumn[+V](targetColumn: Column) extends TableColumn[V](targetColumn.name)
// sum(col2).name == "column_2"
```

- **By name** an aggregate looks like the column it wraps, so `select(sum(x)).groupBy(x)` dropped the grouping column — the bug #353 fixed.
- **By value** a reference to an alias looks like a fresh expression, so it gets appended — this bug.

## The fix

Ask both questions: an entry is already produced if the projection contains it **by value**, or if it **publishes the same name** as something the projection publishes. Only `AliasedColumn`, `NativeColumn` and `RefColumn` publish a name; expression columns inherit their argument's, which is the trap both previous versions fell into.

Both #353 behaviours are kept, and are covered by existing tests:

| | |
|---|---|
| `select(sum(col2)).groupBy(col2)` | `SELECT sum(column_2), column_2 … GROUP BY column_2` |
| `select(sum(col2)).orderBy(uniq(col2))` | `SELECT sum(column_2), uniq(column_2) … ORDER BY uniq(column_2)` |

## Tests

Four cases added to `ColumnIdentityTest` — the two alias shapes, a grouping column the projection genuinely does not produce, and a native column sharing the alias name. Both alias shapes are also registered in `SqlValidationITSpec`, so the emitted SQL is checked against a real server on every CI run.

386 dsl unit tests on 2.13.18 and 3.3.8; 146 dsl integration tests against 25.3.

## Not part of this

`orderBy` given the `AliasedColumn` object itself renders `ORDER BY uniq(column_2) AS value`. The server accepts it and 1.3.0 did the same, so it is pre-existing and out of scope here.

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)