### PR TITLE
Stop Magnet equality recursing until the stack runs out

### DIFF
--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/Magnets.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/Magnets.scala
@@ -38,10 +38,21 @@ trait Magnets {
    */
   trait Magnet[+C] {
     val column: TableColumn[C]
+  }
 
-    // Magnets are anonymous classes minted by implicit conversion, so without this two built from the same value
-    // compare unequal, and every AST node holding one inherits that. The wrapped column is the only state a magnet
-    // has and the only part that renders, so it is what equality is about.
+  /**
+   * Structural equality for the magnets the implicit conversions mint.
+   *
+   * Those are anonymous classes, so two built from the same value would compare unequal, and every AST node holding one
+   * would inherit that. The wrapped column is their only state and the only part that renders, so it is what equality
+   * is about.
+   *
+   * It deliberately does not live on [[Magnet]] itself. A concrete `equals` inherited from there suppresses the one the
+   * compiler synthesises for a case class, so every case class extending a magnet -- `IntDiv`, `Cast`, `FixedString`
+   * and the rest, whose `column` is `this` -- inherited `column == that.column` and recursed until the stack ran out.
+   * Off `Magnet`, those get their own field-wise equality back.
+   */
+  trait MagnetEquality { self: Magnet[_] =>
     override def equals(other: Any): Boolean = other match {
       case that: Magnet[_] => column == that.column
       case _               => false
@@ -86,12 +97,12 @@ trait Magnets {
   trait ConstOrColMagnet[+C] extends Magnet[C] with ScalaBooleanFunctionOps with InOps with NullableOps
 
   implicit def constOrColMagnetFromCol[C](s: TableColumn[C]): ConstOrColMagnet[C] =
-    new ConstOrColMagnet[C] {
+    new ConstOrColMagnet[C] with MagnetEquality {
       override val column: TableColumn[C] = s
     }
 
   implicit def constOrColMagnetFromConst[T: QueryValue](s: T): ConstOrColMagnet[T] =
-    new ConstOrColMagnet[T] {
+    new ConstOrColMagnet[T] with MagnetEquality {
       override val column: TableColumn[T] = Const(s)
     }
 
@@ -150,13 +161,13 @@ trait Magnets {
   sealed trait ArrayColMagnet[+C] extends Magnet[C]
 
   implicit def arrayColMagnetFromIterableConst[T: QueryValue](s: scala.Iterable[T]): ArrayColMagnet[scala.Iterable[T]] =
-    new ArrayColMagnet[scala.Iterable[T]] {
+    new ArrayColMagnet[scala.Iterable[T]] with MagnetEquality {
       val qvForIterable   = QueryValueFormats.queryValueToSeq(implicitly[QueryValue[T]])
       override val column = Const(s)(qvForIterable)
     }
 
   implicit def arrayColMagnetFromIterableCol[C](s: TableColumn[scala.Iterable[C]]): ArrayColMagnet[scala.Iterable[C]] =
-    new ArrayColMagnet[scala.Iterable[C]] {
+    new ArrayColMagnet[scala.Iterable[C]] with MagnetEquality {
       override val column = s
     }
 
@@ -184,22 +195,22 @@ trait Magnets {
       with EmptyNonEmptyCol[C]
 
   implicit def stringColMagnetFromString[T <: String: QueryValue](s: T): StringColMagnet[String] =
-    new StringColMagnet[String] {
+    new StringColMagnet[String] with MagnetEquality {
       override val column: TableColumn[String] = Const(s)
     }
 
   implicit def stringColMagnetFromStringCol[T <: TableColumn[String]](s: T): StringColMagnet[String] =
-    new StringColMagnet[String] {
+    new StringColMagnet[String] with MagnetEquality {
       override val column: TableColumn[String] = s
     }
 
   implicit def stringColMagnetFromUUID[T <: UUID: QueryValue](s: T): StringColMagnet[UUID] =
-    new StringColMagnet[UUID] {
+    new StringColMagnet[UUID] with MagnetEquality {
       override val column: TableColumn[UUID] = Const(s)
     }
 
   implicit def stringColMagnetFromUUIDCol[T <: TableColumn[UUID]](s: T): StringColMagnet[UUID] =
-    new StringColMagnet[UUID] {
+    new StringColMagnet[UUID] with MagnetEquality {
       override val column: TableColumn[UUID] = s
     }
 
@@ -212,7 +223,7 @@ trait Magnets {
   implicit def fixedStringColMagnetFromCol[T <: TableColumn[FixedStringBytes]](
       s: T
   ): FixedStringColMagnet[FixedStringBytes] =
-    new FixedStringColMagnet[FixedStringBytes] {
+    new FixedStringColMagnet[FixedStringBytes] with MagnetEquality {
       override val column: TableColumn[FixedStringBytes] = s
     }
 
@@ -227,22 +238,22 @@ trait Magnets {
   sealed trait DateOrDateTime[C] extends Magnet[C] with AddSubtractable[C] with ComparableWith[DateOrDateTime[_]]
 
   implicit def ddtFromDateCol[T <: TableColumn[LocalDate]](s: T): DateOrDateTime[LocalDate] =
-    new DateOrDateTime[LocalDate] {
+    new DateOrDateTime[LocalDate] with MagnetEquality {
       override val column = s
     }
 
   implicit def ddtFromDateTimeCol[T <: TableColumn[ZonedDateTime]](s: T): DateOrDateTime[ZonedDateTime] =
-    new DateOrDateTime[ZonedDateTime] {
+    new DateOrDateTime[ZonedDateTime] with MagnetEquality {
       override val column = s
     }
 
   implicit def ddtFromDate[T <: LocalDate: QueryValue](s: T): DateOrDateTime[LocalDate] =
-    new DateOrDateTime[LocalDate] {
+    new DateOrDateTime[LocalDate] with MagnetEquality {
       override val column = toDate(s)
     }
 
   implicit def ddtFromDateTime[T <: ZonedDateTime: QueryValue](s: T): DateOrDateTime[ZonedDateTime] =
-    new DateOrDateTime[ZonedDateTime] {
+    new DateOrDateTime[ZonedDateTime] with MagnetEquality {
       override val column = toDateTime(s)
     }
 
@@ -309,72 +320,72 @@ trait Magnets {
       with ArithmeticOps[C]
 
   implicit def numericFromLong[T <: Long: QueryValue](s: T): NumericCol[Long] =
-    new NumericCol[Long] {
+    new NumericCol[Long] with MagnetEquality {
       override val column = Const(s)
     }
 
   implicit def numericFromInt[T <: Int: QueryValue](s: T): NumericCol[Int] =
-    new NumericCol[Int] {
+    new NumericCol[Int] with MagnetEquality {
       override val column = Const(s)
     }
 
   implicit def numericFromDouble[T <: Double: QueryValue](s: T): NumericCol[Double] =
-    new NumericCol[Double] {
+    new NumericCol[Double] with MagnetEquality {
       override val column = Const(s)
     }
 
   implicit def numericFromFloat[T <: Float: QueryValue](s: T): NumericCol[Float] =
-    new NumericCol[Float] {
+    new NumericCol[Float] with MagnetEquality {
       override val column = Const(s)
     }
 
   implicit def numericFromBigInt[T <: BigInt: QueryValue](s: T): NumericCol[BigInt] =
-    new NumericCol[BigInt] {
+    new NumericCol[BigInt] with MagnetEquality {
       override val column = Const(s)
     }
 
   implicit def numericFromBigDecimal[T <: BigDecimal: QueryValue](s: T): NumericCol[BigDecimal] =
-    new NumericCol[BigDecimal] {
+    new NumericCol[BigDecimal] with MagnetEquality {
       override val column = Const(s)
     }
 
   implicit def numericFromBoolean[T <: Boolean: QueryValue](s: T): NumericCol[Boolean] =
-    new NumericCol[Boolean] {
+    new NumericCol[Boolean] with MagnetEquality {
       override val column = Const(s)
     }
 
   implicit def numericFromLongCol[T <: TableColumn[Long]](s: T): NumericCol[Long] =
-    new NumericCol[Long] {
+    new NumericCol[Long] with MagnetEquality {
       override val column = s
     }
 
   implicit def numericFromIntCol[T <: TableColumn[Int]](s: T): NumericCol[Int] =
-    new NumericCol[Int] {
+    new NumericCol[Int] with MagnetEquality {
       override val column = s
     }
 
   implicit def numericFromDoubleCol[T <: TableColumn[Double]](s: T): NumericCol[Double] =
-    new NumericCol[Double] {
+    new NumericCol[Double] with MagnetEquality {
       override val column = s
     }
 
   implicit def numericFromFloatCol[T <: TableColumn[Float]](s: T): NumericCol[Float] =
-    new NumericCol[Float] {
+    new NumericCol[Float] with MagnetEquality {
       override val column = s
     }
 
   implicit def numericFromBigIntCol[T <: TableColumn[BigInt]](s: T): NumericCol[BigInt] =
-    new NumericCol[BigInt] {
+    new NumericCol[BigInt] with MagnetEquality {
       override val column = s
     }
 
   implicit def numericFromBigDecimalCol[T <: TableColumn[BigDecimal]](s: T): NumericCol[BigDecimal] =
-    new NumericCol[BigDecimal] {
+    new NumericCol[BigDecimal] with MagnetEquality {
       override val column = s
     }
 
   implicit def numericFromBooleanCol[T <: TableColumn[Boolean]](s: T): NumericCol[Boolean] =
-    new NumericCol[Boolean] {
+    new NumericCol[Boolean] with MagnetEquality {
       override val column = s
     }
 
@@ -386,12 +397,12 @@ trait Magnets {
   implicit def emptyNonEmptyFromIterableCol[Elem, Collection[B] <: Iterable[B], ColType[A] <: TableColumn[A]](
       s: ColType[Collection[Elem]]
   ): EmptyNonEmptyCol[Collection[Elem]] =
-    new EmptyNonEmptyCol[Collection[Elem]] {
+    new EmptyNonEmptyCol[Collection[Elem]] with MagnetEquality {
       override val column: TableColumn[Collection[Elem]] = s
     }
 
   implicit def emptyNonEmptyFromIterable[T <: Iterable[_]: QueryValue](s: T): EmptyNonEmptyCol[T] =
-    new EmptyNonEmptyCol[T] {
+    new EmptyNonEmptyCol[T] with MagnetEquality {
       override val column = Const(s)
     }
 

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/MagnetEqualityTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/MagnetEqualityTest.scala
@@ -1,6 +1,7 @@
 package com.crobox.clickhouse.dsl
 
 import com.crobox.clickhouse.DslTestSpec
+import com.crobox.clickhouse.dsl.schemabuilder.ColumnType
 
 class MagnetEqualityTest extends DslTestSpec {
 
@@ -61,5 +62,36 @@ class MagnetEqualityTest extends DslTestSpec {
 
   it should "still tell IN over different literal collections apart" in {
     (col4 in Seq("a")) should not be (col4 in Seq("b"))
+  }
+
+  // These are the case classes whose `column` is `this`. A concrete equals on Magnet suppressed the one the compiler
+  // synthesises for a case class, so they inherited `column == that.column` -- `this == this` -- and every comparison
+  // or hash blew the stack. Reaching one only took a dedup that compares by value.
+  "A node whose column is itself" should "hash without recursing" in {
+    intDiv(timestampColumn, 1000).hashCode()
+    abs(col2).hashCode()
+    (col2 + 1).hashCode()
+    cast(col2, ColumnType.UInt32).hashCode()
+    toFixedString(col3, 2).hashCode()
+    succeed
+  }
+
+  it should "compare structurally rather than by identity" in {
+    intDiv(timestampColumn, 1000) shouldBe intDiv(timestampColumn, 1000)
+    abs(col2) shouldBe abs(col2)
+    cast(col2, ColumnType.UInt32) shouldBe cast(col2, ColumnType.UInt32)
+    toFixedString(col3, 2) shouldBe toFixedString(col3, 2)
+  }
+
+  it should "still tell different operands apart" in {
+    intDiv(timestampColumn, 1000) should not be intDiv(timestampColumn, 500)
+    abs(col2) should not be abs(timestampColumn)
+    toFixedString(col3, 2) should not be toFixedString(col3, 4)
+  }
+
+  it should "survive a dedup that compares by value" in {
+    val expr = toDateTime(intDiv(toUInt64rNull(timestampColumn), 1000))
+    Seq[Column](expr).contains(expr) shouldBe true
+    SelectQuery(Seq(expr)).addColumn(expr).columns should have size 1
   }
 }


### PR DESCRIPTION
Fixes the RC2 blocker: a `StackOverflowError` from any comparison or hash of an arithmetic expression, a cast, or a `toFixedString`.

```scala
intDiv(timestampColumn, 1000).hashCode()   // StackOverflowError
Seq[Column](expr).contains(expr)           // StackOverflowError
```

## Cause

#357 put `equals`/`hashCode` on `trait Magnet`, comparing the wrapped column. Four classes define their `column` as themselves — `ArithmeticFunctionCol`, `ArithmeticFunctionOp`, `Cast`, and `FixedString` (that last one added by #364) — so it reads `this == that.column` and `this.hashCode()`.

**Why it looked safe:** every concrete subclass is a case class, so the synthesised field-wise `equals` appears to win. It doesn't. The compiler synthesises `equals`/`hashCode` for a case class only when no concrete definition is inherited from a parent other than `AnyRef` (SLS 5.3.2), and `Magnet` supplied one. `Sum` — an `ExpressionColumn` but not a `Magnet` — kept its case-class equality throughout, and that contrast is what pinned it down.

**Why now:** nothing compared these nodes by value until `mergeOperationalColumns` began de-duplicating with `contains`. 1.3.0 de-duplicated by name and never called `equals` on them. RC1 had the same latent trap; the alias-duplication failures in #368 masked it.

## Fix

The equality moves to a `MagnetEquality` mixin, applied to the 29 anonymous magnets the implicit conversions mint — which is where #357 actually needed it. Nothing else changes about what magnets compare.

Off `Magnet`, the case classes get their synthesised equality back, so these nodes gain **correct** structural equality rather than merely stopping the overflow:

```scala
intDiv(ts, 1000) == intDiv(ts, 1000)  // true
intDiv(ts, 1000) == intDiv(ts, 500)   // false
toFixedString(col3, 2) == toFixedString(col3, 4)  // false
```

`InFuncRHMagnet` keeps its own `equals` — which also weighs `query` and `tableRef`, per the review on #357 — and deliberately does not get the mixin.

## Tests

Four cases added to `MagnetEqualityTest`: every previously-overflowing class hashes, compares structurally, tells differing operands apart, and survives a by-value dedup via the exact reported shape `toDateTime(intDiv(toUInt64rNull(x), 1000))`.

- 395 dsl unit tests on 2.13.18 and 3.3.8
- 146 dsl integration tests against 25.3
- client: 77 pass, 2 known environmental failures (`support SSL certs` needs a local keystore, `select cluster hosts` needs a clustered server)

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)