### PR TITLE
Add the window-only functions

### DIFF
--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/column/WindowFunctionsIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/column/WindowFunctionsIT.scala
@@ -1,0 +1,96 @@
+package com.crobox.clickhouse.dsl.column
+
+import com.crobox.clickhouse.DslITSpec
+import com.crobox.clickhouse.dsl._
+
+import java.util.UUID
+
+/**
+ * Behavioural cover for the window-only functions. `SqlValidationITSpec` already proves the server accepts what these
+ * render, which does not catch an argument order that resolves either way round -- `nth_value(offset, column)` type
+ * checks and resolves as happily as the right way round. These run the query and read the values back.
+ */
+class WindowFunctionsIT extends DslITSpec {
+
+  // Deliberately inserted out of order, so an ordering the query does not ask for cannot produce the expected answer.
+  override val table2Entries: Seq[Table2Entry] =
+    Seq(30, 10, 20).map(value => Table2Entry(UUID.randomUUID(), randomString, value, randomString, None))
+
+  private val byCol2 = WindowSpec(orderBy = Seq(col2))
+
+  private def framed(start: FrameBound, end: FrameBound): WindowSpec =
+    byCol2.copy(frame = Option(WindowFrame(FrameMode.Rows, start, Option(end))))
+
+  /** Runs `column` over the fixture and reads it back in window order. */
+  private def ints(column: TableColumn[_]): Seq[Int] =
+    queryExecutor
+      .executeRows(select(col2, column as "result") from TwoTestTable orderBy col2)
+      .futureValue
+      .rows
+      .map(_.requiredByName[Int]("result"))
+
+  "row_number" should "number the rows in window order" in {
+    ints(rowNumber().over(byCol2)) shouldBe Seq(1, 2, 3)
+  }
+
+  "rank and dense_rank" should "agree when there are no ties" in {
+    ints(rank().over(byCol2)) shouldBe Seq(1, 2, 3)
+    ints(denseRank().over(byCol2)) shouldBe Seq(1, 2, 3)
+  }
+
+  "ntile" should "spread the rows over the buckets" in {
+    ints(ntile(3).over(byCol2)) shouldBe Seq(1, 2, 3)
+  }
+
+  // The default is 0 rather than a sentinel like -1 because column_2 is UInt32 and a negative literal widens the
+  // supertype to Int64, which the server rejects outright.
+  "lagInFrame" should "read the previous row, falling back on the default" in {
+    ints(
+      lagInFrame(col2, Option(const(1L)), Option(const(0)))
+        .over(framed(FrameBound.Preceding(1), FrameBound.CurrentRow))
+    ) shouldBe Seq(0, 10, 20)
+  }
+
+  it should "reject a default that widens the column's type" in {
+    val query = select(
+      lagInFrame(col2, Option(const(1L)), Option(const(-1)))
+        .over(framed(FrameBound.Preceding(1), FrameBound.CurrentRow)) as "result"
+    ) from TwoTestTable
+    val failure = queryExecutor.executeRows(query).failed.futureValue
+    failure.getMessage should include("is not the same as the argument type")
+  }
+
+  "leadInFrame" should "read the next row, falling back on the default" in {
+    ints(
+      leadInFrame(col2, Option(const(1L)), Option(const(0)))
+        .over(framed(FrameBound.CurrentRow, FrameBound.Following(1)))
+    ) shouldBe Seq(20, 30, 0)
+  }
+
+  // The one that would pass a rendering check with its arguments the wrong way round.
+  "nth_value" should "read the nth row of the frame, counting from one" in {
+    ints(
+      nthValue(col2, 2).over(framed(FrameBound.UnboundedPreceding, FrameBound.UnboundedFollowing))
+    ) shouldBe Seq(20, 20, 20)
+  }
+
+  "argMin and argMax" should "return the argument from the row holding the extreme value" in {
+    val row = queryExecutor
+      .executeRows(select(argMin(col2, col2) as "low", argMax(col2, col2) as "high") from TwoTestTable)
+      .futureValue
+      .rows
+      .head
+    row.requiredByName[Int]("low") shouldBe 10
+    row.requiredByName[Int]("high") shouldBe 30
+  }
+
+  "count" should "differ from count DISTINCT only when there are duplicates" in {
+    val row = queryExecutor
+      .executeRows(select(count(col2) as "all", countDistinct(col2) as "distinct") from TwoTestTable)
+      .futureValue
+      .rows
+      .head
+    row.requiredByName[Int]("all") shouldBe 3
+    row.requiredByName[Int]("distinct") shouldBe 3
+  }
+}

--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
@@ -519,7 +519,41 @@ class SqlValidationITSpec extends DslITSpec {
     sem("State", select(state[TableColumn[Double], Double](sum(col2))) from TwoTestTable),
     // Syntax only: sumMerge needs an AggregateFunction(sum, ...) column to read, and the test tables hold plain values.
     syn("Merge", select(merge[TableColumn[StateResult[Double]], Double](sum(col2))) from TwoTestTable),
-    sem("TimeSeries", select(timeSeries(timestampColumn, oneDay)) from OneTestTable)
+    sem("TimeSeries", select(timeSeries(timestampColumn, oneDay)) from OneTestTable),
+    sem("ArgMin", select(argMin(col2, col3)) from TwoTestTable),
+    sem("ArgMax", select(argMax(col2, col3)) from TwoTestTable)
+  )
+
+  /**
+   * Window-only functions, each behind the `OVER` that ClickHouse requires -- without one the server answers
+   * BAD_ARGUMENTS, "can only be used as a window function", which is why the builders return something that is not a
+   * Column.
+   */
+  private val windowConstructs = Seq(
+    sem("RowNumber", select(rowNumber().over(WindowSpec(orderBy = Seq(col2)))) from TwoTestTable),
+    sem("Rank", select(rank().over(WindowSpec(orderBy = Seq(col2)))) from TwoTestTable),
+    sem("DenseRank", select(denseRank().over(WindowSpec(orderBy = Seq(col2)))) from TwoTestTable),
+    sem("PercentRank", select(percentRank().over(WindowSpec(orderBy = Seq(col2)))) from TwoTestTable),
+    sem("Ntile", select(ntile(4).over(WindowSpec(orderBy = Seq(col2)))) from TwoTestTable),
+    sem(
+      "LagInFrame",
+      // The default has to land on column_2's own UInt32; a Float64 one is rejected outright.
+      select(lagInFrame(col2, Option(const(1L)), Option(const(0))).over(WindowSpec(orderBy = Seq(col2))))
+        from TwoTestTable
+    ),
+    sem(
+      "LeadInFrame",
+      select(
+        leadInFrame(col2, Option(const(1L)))
+          .over(
+            WindowSpec(
+              orderBy = Seq(col2),
+              frame = Option(WindowFrame(FrameMode.Rows, FrameBound.CurrentRow, Option(FrameBound.Following(1))))
+            )
+          )
+      ) from TwoTestTable
+    ),
+    sem("NthValue", select(nthValue(col2, 2).over(WindowSpec(orderBy = Seq(col2)))) from TwoTestTable)
   )
 
   /** AST nodes covered above; these are what the coverage ratchet counts. */
@@ -529,7 +563,7 @@ class SqlValidationITSpec extends DslITSpec {
       encodingConstructs ++ ipConstructs ++ splitMergeConstructs ++ emptyConstructs ++ higherOrderConstructs ++
       arrayConstructs ++ urlConstructs ++ hashConstructs ++ distanceConstructs ++ stringConstructs ++
       stringSearchConstructs ++ miscConstructs ++ arithmeticConstructs ++ operatorConstructs ++ typeCastConstructs ++
-      dateTimeConstructs ++ aggregationConstructs
+      dateTimeConstructs ++ aggregationConstructs ++ windowConstructs
 
   /**
    * Whole-query shapes rather than individual functions, so they are validated but not counted towards AST coverage.

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/AggregationFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/AggregationFunctions.scala
@@ -20,7 +20,8 @@ trait AggregationFunctions {
   /**
    * `OVER` lives here rather than on TableColumn because ClickHouse requires an aggregate or window function before it:
    * `v OVER ()`, `1 OVER ()` and `toUInt32(v) OVER ()` are all rejected by the server, so restricting the entry point
-   * turns those into compile errors. Window-only functions added later should extend this or share a marker with it.
+   * turns those into compile errors. Unlike [[WindowFunctions.WindowOnlyFunction]] the window is optional here, since
+   * an aggregate is valid with or without one.
    */
   abstract class AggregateFunction[+V](targetColumn: Column) extends ExpressionColumn[V](targetColumn) {
 
@@ -34,7 +35,18 @@ trait AggregationFunctions {
     def over(): WindowFunction[V] = over(WindowSpec())
   }
 
-  case class Count(column: Option[Column] = None) extends AggregateFunction[Long](column.getOrElse(EmptyColumn))
+  case class Count(column: Option[Column] = None, distinct: Boolean = false)
+      extends AggregateFunction[Long](column.getOrElse(EmptyColumn)) {
+
+    require(column.isDefined || !distinct, "count(DISTINCT) needs a column")
+  }
+
+  /**
+   * `argMin`/`argMax`: the value of `arg` on the row where `value` is smallest/largest. The result type follows `arg`.
+   */
+  case class ArgMin[A, V](arg: TableColumn[A], value: TableColumn[V]) extends AggregateFunction[A](arg)
+
+  case class ArgMax[A, V](arg: TableColumn[A], value: TableColumn[V]) extends AggregateFunction[A](arg)
 
   case class Avg[V](tableColumn: TableColumn[V]) extends AggregateFunction[Double](tableColumn)
 
@@ -57,6 +69,16 @@ trait AggregationFunctions {
   def count(): Count = Count()
 
   def count(column: TableColumn[_]): Count = Count(Option(column))
+
+  /**
+   * `count(DISTINCT column)`. ClickHouse rewrites this to `uniqExact` by default -- see the
+   * `count_distinct_implementation` setting -- so [[UniqFunctions.uniqExact]] says the same thing more directly.
+   */
+  def countDistinct(column: TableColumn[_]): Count = Count(Option(column), distinct = true)
+
+  def argMin[A, V](arg: TableColumn[A], value: TableColumn[V]): ArgMin[A, V] = ArgMin(arg, value)
+
+  def argMax[A, V](arg: TableColumn[A], value: TableColumn[V]): ArgMax[A, V] = ArgMax(arg, value)
 
   def average[T](tableColumn: TableColumn[T]): Avg[T] = Avg(tableColumn)
 

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/ClickhouseColumnFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/ClickhouseColumnFunctions.scala
@@ -35,5 +35,6 @@ trait ClickhouseColumnFunctions
     with StringSearchFunctions
     with TypeCastFunctions
     with URLFunctions
+    with WindowFunctions
 
 object ClickhouseColumnFunctions extends ClickhouseColumnFunctions {}

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/WindowFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/WindowFunctions.scala
@@ -1,0 +1,106 @@
+package com.crobox.clickhouse.dsl.column
+
+import com.crobox.clickhouse.dsl._
+
+trait WindowFunctions { self: Magnets =>
+
+  /**
+   * A function ClickHouse accepts only with `OVER`. On its own each of these fails with "The function 'row_number' can
+   * only be used as a window function, not as an aggregate function".
+   *
+   * Deliberately not a [[com.crobox.clickhouse.dsl.Column]]: `over` is the only way to reach one, so
+   * `select(rowNumber())` is a compile error rather than a server error. Same reasoning that puts `over` on
+   * [[AggregationFunctions.AggregateFunction]] rather than on `TableColumn` -- there the restriction rules out
+   * `v OVER ()`, here it rules out a window function without its window.
+   */
+  final class WindowOnlyFunction[+V] private[column] (private[dsl] val call: WindowOnlyFunctionCol[V]) {
+
+    /** `OVER (spec)`. */
+    def over(spec: WindowSpec): WindowFunction[V] = WindowFunction(call, WindowRef.Inline(spec))
+
+    /** `OVER name`, referring to a definition in the query's `WINDOW` clause. */
+    def over(window: NamedWindow): WindowFunction[V] = WindowFunction(call, WindowRef.Named(window.name))
+
+    /** `OVER ()`, an unpartitioned, unordered window over the whole result. */
+    def over(): WindowFunction[V] = over(WindowSpec())
+  }
+
+  abstract class WindowOnlyFunctionCol[+V](targetColumn: Column) extends ExpressionColumn[V](targetColumn)
+
+  case class RowNumber()   extends WindowOnlyFunctionCol[Long](EmptyColumn)
+  case class Rank()        extends WindowOnlyFunctionCol[Long](EmptyColumn)
+  case class DenseRank()   extends WindowOnlyFunctionCol[Long](EmptyColumn)
+  case class PercentRank() extends WindowOnlyFunctionCol[Double](EmptyColumn)
+
+  case class Ntile(buckets: Long) extends WindowOnlyFunctionCol[Long](EmptyColumn) {
+
+    // The server rejects both a non-constant and a non-positive bucket count with BAD_ARGUMENTS; a constant is all this
+    // signature accepts, so only the range is left to check.
+    require(buckets > 0, s"ntile needs a positive bucket count, got $buckets")
+  }
+
+  /**
+   * `lagInFrame`/`leadInFrame`, which read a row offset away from the current one, clamped to the window frame. Note
+   * that the default frame runs to the current row, so a lead needs an explicit frame to see anything.
+   *
+   * `default` is the value for rows whose offset falls outside the frame; without it the column's own default is used.
+   * It is a [[com.crobox.clickhouse.dsl.Column]] rather than a `V` so an expression can be passed -- use `const(...)`
+   * for a plain value. The server requires the supertype of the column's type and the default's to *be* the column's
+   * type, which is stricter than it sounds: against a `UInt32` column `const(0)` is fine, but `const(-1)` widens to
+   * `Int64` and `const(0d)` to `Float64`, and both are rejected with "is not the same as the argument type". Cast the
+   * default when the value has to be out of the column's range. Not checked here, because `TableColumn` is covariant --
+   * a mismatched pair would infer a common supertype for `V` rather than fail.
+   */
+  case class LagInFrame[V](
+      column: TableColumn[V],
+      offset: Option[Column] = None,
+      default: Option[Column] = None
+  ) extends WindowOnlyFunctionCol[V](column) {
+    require(offset.isDefined || default.isEmpty, "lagInFrame needs an offset before a default")
+  }
+
+  case class LeadInFrame[V](
+      column: TableColumn[V],
+      offset: Option[Column] = None,
+      default: Option[Column] = None
+  ) extends WindowOnlyFunctionCol[V](column) {
+    require(offset.isDefined || default.isEmpty, "leadInFrame needs an offset before a default")
+  }
+
+  /** `nth_value`, the value at a one-based position within the frame. */
+  case class NthValue[V](column: TableColumn[V], offset: Long) extends WindowOnlyFunctionCol[V](column) {
+
+    // The server rejects 0 with "The offset for function nth_value must be in (1, ...]".
+    require(offset >= 1, s"nth_value offsets are one-based, got $offset")
+  }
+
+  /** Position within the partition, counting from 1, with no regard for ties. */
+  def rowNumber(): WindowOnlyFunction[Long] = new WindowOnlyFunction(RowNumber())
+
+  /** Position within the partition, where ties share a position and the next position skips the gap. */
+  def rank(): WindowOnlyFunction[Long] = new WindowOnlyFunction(Rank())
+
+  /** Position within the partition, where ties share a position and the next position does not skip. */
+  def denseRank(): WindowOnlyFunction[Long] = new WindowOnlyFunction(DenseRank())
+
+  /** [[rank]] scaled into `[0, 1]`. */
+  def percentRank(): WindowOnlyFunction[Double] = new WindowOnlyFunction(PercentRank())
+
+  /** Splits the partition into `buckets` groups of as near equal size as the row count allows. */
+  def ntile(buckets: Long): WindowOnlyFunction[Long] = new WindowOnlyFunction(Ntile(buckets))
+
+  def lagInFrame[V](
+      column: TableColumn[V],
+      offset: Option[Column] = None,
+      default: Option[Column] = None
+  ): WindowOnlyFunction[V] = new WindowOnlyFunction(LagInFrame(column, offset, default))
+
+  def leadInFrame[V](
+      column: TableColumn[V],
+      offset: Option[Column] = None,
+      default: Option[Column] = None
+  ): WindowOnlyFunction[V] = new WindowOnlyFunction(LeadInFrame(column, offset, default))
+
+  def nthValue[V](column: TableColumn[V], offset: Long): WindowOnlyFunction[V] =
+    new WindowOnlyFunction(NthValue(column, offset))
+}

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/AggregationFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/AggregationFunctionTokenizer.scala
@@ -35,9 +35,15 @@ trait AggregationFunctionTokenizer { this: ClickhouseTokenizerModule =>
       agg: AggregateFunction[_]
   )(implicit ctx: TokenizeContext): (String, String) =
     agg match {
-      case AnyResult(column, modifier)        => (s"any${tokenizeAnyModifier(modifier)}", tokenizeColumn(column))
-      case Avg(column)                        => ("avg", tokenizeColumn(column))
-      case Count(column)                      => ("count", tokenizeColumn(column.getOrElse(EmptyColumn)))
+      case AnyResult(column, modifier) => (s"any${tokenizeAnyModifier(modifier)}", tokenizeColumn(column))
+      case Avg(column)                 => ("avg", tokenizeColumn(column))
+      case ArgMin(arg, value)          =>
+        ("argMin", s"${tokenizeColumn(arg)}${Tokens.Delimiter}${tokenizeColumn(value)}")
+      case ArgMax(arg, value) =>
+        ("argMax", s"${tokenizeColumn(arg)}${Tokens.Delimiter}${tokenizeColumn(value)}")
+      case Count(column, distinct) =>
+        val prefix = if (distinct) "DISTINCT " else ""
+        ("count", prefix + tokenizeColumn(column.getOrElse(EmptyColumn)))
       case FirstValue(column)                 => ("first_value", tokenizeColumn(column))
       case GroupArray(tableColumn, maxValues) =>
         ("groupArray", s"${maxValues.map(_.toString + ")(").getOrElse("")}${tokenizeColumn(tableColumn)}")

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -102,6 +102,7 @@ trait ClickhouseTokenizerModule
     with StringSearchFunctionTokenizer
     with TypeCastFunctionTokenizer
     with URLFunctionTokenizer
+    with WindowFunctionTokenizer
     with EmptyFunctionTokenizer {
 
   private lazy val logger = Logger(LoggerFactory.getLogger(getClass.getName))
@@ -340,6 +341,7 @@ trait ClickhouseTokenizerModule
       case col: StringSearchFunc[_]             => tokenizeStringSearchFunction(col)
       case col: TypeCastColumn[_]               => tokenizeTypeCastColumn(col)
       case col: URLFunction[_]                  => tokenizeURLFunction(col)
+      case col: WindowOnlyFunctionCol[_]        => tokenizeWindowOnlyFunction(col)
       case All()                                => "*"
       case RawColumn(rawSql)                    => rawSql
       case Conditional(cases, default, multiIf) =>

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/WindowFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/WindowFunctionTokenizer.scala
@@ -1,0 +1,24 @@
+package com.crobox.clickhouse.dsl.language
+
+import com.crobox.clickhouse.dsl._
+
+trait WindowFunctionTokenizer { self: ClickhouseTokenizerModule =>
+
+  def tokenizeWindowOnlyFunction(col: WindowOnlyFunctionCol[_])(implicit ctx: TokenizeContext): String = {
+    // lagInFrame and leadInFrame share a shape: the column, then whichever of offset and default are set. A default
+    // without an offset is refused at construction, so the two Options cannot leave a hole in the argument list.
+    def inFrame(name: String, column: Column, offset: Option[Column], default: Option[Column]): String =
+      s"$name(${(column +: (offset ++ default).toSeq).map(tokenizeColumn).mkString(Tokens.Delimiter)})"
+
+    col match {
+      case RowNumber()                          => "row_number()"
+      case Rank()                               => "rank()"
+      case DenseRank()                          => "dense_rank()"
+      case PercentRank()                        => "percent_rank()"
+      case Ntile(buckets)                       => s"ntile($buckets)"
+      case LagInFrame(column, offset, default)  => inFrame("lagInFrame", column, offset, default)
+      case LeadInFrame(column, offset, default) => inFrame("leadInFrame", column, offset, default)
+      case NthValue(column, offset)             => s"nth_value(${tokenizeColumn(column)}${Tokens.Delimiter}$offset)"
+    }
+  }
+}

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/WindowFunctionTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/WindowFunctionTest.scala
@@ -128,6 +128,66 @@ class WindowFunctionTest extends DslTestSpec {
     )
   }
 
+  "A window-only function" should "render row_number" in {
+    sql(select(rowNumber().over(WindowSpec(orderBy = Seq(col2)))).from(TwoTestTable)) should matchSQL(
+      s"SELECT row_number() OVER (ORDER BY column_2 ASC) FROM ${TwoTestTable.quoted}"
+    )
+  }
+
+  it should "render the other rankings" in {
+    sql(select(rank().over(), denseRank().over(), percentRank().over(), ntile(4).over()).from(TwoTestTable)) should
+    matchSQL(
+      s"SELECT rank() OVER (), dense_rank() OVER (), percent_rank() OVER (), ntile(4) OVER () " +
+        s"FROM ${TwoTestTable.quoted}"
+    )
+  }
+
+  it should "render lagInFrame at each arity" in {
+    sql(
+      select(
+        lagInFrame(col2).over(),
+        lagInFrame(col2, Option(const(2))).over(),
+        lagInFrame(col2, Option(const(2)), Option(const(99))).over()
+      ).from(TwoTestTable)
+    ) should matchSQL(
+      s"SELECT lagInFrame(column_2) OVER (), lagInFrame(column_2, 2) OVER (), " +
+        s"lagInFrame(column_2, 2, 99) OVER () FROM ${TwoTestTable.quoted}"
+    )
+  }
+
+  it should "render leadInFrame and nth_value" in {
+    sql(select(leadInFrame(col2, Option(const(1))).over(), nthValue(col2, 2).over()).from(TwoTestTable)) should
+    matchSQL(
+      s"SELECT leadInFrame(column_2, 1) OVER (), nth_value(column_2, 2) OVER () FROM ${TwoTestTable.quoted}"
+    )
+  }
+
+  it should "work through a named window" in {
+    val w = NamedWindow("w", WindowSpec(partitionBy = Seq(col3), orderBy = Seq(col2)))
+    sql(select(rowNumber().over(w)).from(TwoTestTable).window(w)) should matchSQL(
+      s"SELECT row_number() OVER w FROM ${TwoTestTable.quoted} " +
+        s"WINDOW w AS (PARTITION BY column_3 ORDER BY column_2 ASC)"
+    )
+  }
+
+  // The server rejects `row_number()` on its own with "can only be used as a window function", so the builders return
+  // something that is not a Column and `over` is the only way out of it.
+  it should "not be selectable without a window" in {
+    """select(rowNumber())""" shouldNot typeCheck
+  }
+
+  it should "refuse a non-positive ntile bucket count" in {
+    an[IllegalArgumentException] should be thrownBy ntile(0)
+  }
+
+  it should "refuse a zero nth_value offset" in {
+    an[IllegalArgumentException] should be thrownBy nthValue(col2, 0)
+  }
+
+  it should "refuse a default without an offset" in {
+    an[IllegalArgumentException] should be thrownBy lagInFrame(col2, None, Option(const(1)))
+  }
+
   // The server parses WITH FILL inside OVER and then ignores it: no error, no filled rows. Refused at construction
   // rather than emitting a clause that does nothing.
   "A window spec" should "refuse an ordering that carries WITH FILL" in {

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/AggregationFunctionTokenizerTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/AggregationFunctionTokenizerTest.scala
@@ -23,6 +23,24 @@ class AggregationFunctionTokenizerTest extends DslTestSpec {
     )
   }
 
+  it should "argMin and argMax" in {
+    toSQL(select(argMin(col1, col2), argMax(col1, col2)), false) should matchSQL(
+      "SELECT argMin(column_1, column_2), argMax(column_1, column_2)"
+    )
+  }
+
+  it should "count with and without DISTINCT" in {
+    toSQL(select(count(), count(col1), countDistinct(col1)), false) should matchSQL(
+      "SELECT count(), count(column_1), count(DISTINCT column_1)"
+    )
+  }
+
+  it should "combine argMin with a combinator" in {
+    toSQL(select(aggIf(col1.isEq("abc"))(argMax(col1, col2))), false) should matchSQL(
+      "SELECT argMaxIf(column_1, column_2, column_1 = 'abc')"
+    )
+  }
+
   it should "anyIf in groupArray" in {
     toSQL(select(aggIf(col1.isEq("abc"))(uniq(col2))), false) should matchSQL(
       "SELECT uniqIf(column_2, column_1 = 'abc')"


### PR DESCRIPTION
`#359` added `OVER`, `WINDOW` and `QUALIFY` along with the whole `WindowSpec` / `WindowFrame` model, but not the functions that need them. `over` was defined only on `AggregateFunction`, and `raw("row_number()")` returns a `RawColumn`, which has no `over` — so `row_number() OVER (PARTITION BY … ORDER BY …)` could only be written as one raw string, bypassing the model `#359` had just built.

## What this adds

`rowNumber`, `rank`, `denseRank`, `percentRank`, `ntile`, `lagInFrame`, `leadInFrame`, `nthValue`, plus `argMin`/`argMax` and `count(DISTINCT)` — the last three are ordinary aggregates, so they compose with the combinators and with `OVER`.

`cume_dist` is deliberately left out: it does not exist in 25.3, the oldest release the CI matrix covers, so the validation harness could not check it. Neither do `lag`/`lead`; the docs page describes a newer version than the support matrix.

## The `over` plumbing

The builders return `WindowOnlyFunction`, which is **not** a `Column`. The server answers `BAD_ARGUMENTS` — *"can only be used as a window function"* — for every one of these without `OVER`, and making `over` the only way to reach a `Column` turns that into a compile error. This is the same reasoning that put `over` on `AggregateFunction` rather than on `TableColumn`, pointed the other way: there the restriction rules out `v OVER ()`, here it rules out a window function without its window.

## The lag/lead default

Typed as `Column` rather than `V` because `TableColumn` is covariant — a mismatched pair would infer a common supertype for `V` rather than fail, so the type rule cannot be enforced in the signature. It is a strict rule: against a `UInt32` column `const(0)` passes, but `const(-1)` widens to `Int64` and `const(0d)` to `Float64`, and the server rejects both with *"is not the same as the argument type"*. Spelled out in the scaladoc and pinned by a test.

## Testing

`WindowFunctionsIT` executes the queries rather than only rendering them: an argument order reversed in `nth_value` or `lagInFrame` renders and resolves just as happily as the right one. Every new node is registered in `SqlValidationITSpec`, so `UnregisteredBaseline` stays at 0.

Green on 2.13.18 and 3.3.8, and against a live 25.3 server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
