### PR TITLE
Add set operations, join chains, OFFSET and ORDER BY modifiers

### DIFF
--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/SetOperationAndJoinChainIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/SetOperationAndJoinChainIT.scala
@@ -52,6 +52,14 @@ class SetOperationAndJoinChainIT extends DslITSpec {
   private def labels(query: OperationalQuery): Seq[String] =
     queryExecutor.executeRows(query).futureValue.rows.map(_.requiredByName[String]("column_3"))
 
+  // The discriminating case for the parenthesising of nested branches. Intended is
+  // `two UNION ALL (three EXCEPT two)` = {shared, onlyTwo, onlyThree}; a flat chain would group as
+  // `(two UNION ALL three) EXCEPT two` = {onlyThree}, which is a different set rather than a different spelling.
+  "A nested set operation" should "keep the grouping the call structure states" in {
+    ids(fromTwo.unionAll(fromThree.except(fromTwo))) should contain theSameElementsAs
+    Seq(shared, onlyTwo, onlyThree).map(_.toString)
+  }
+
   "A chain of joins" should "keep only the rows every table in the chain has" in {
     val query = select(col3)
       .from(TwoTestTable)

--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/SetOperationAndJoinChainIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/SetOperationAndJoinChainIT.scala
@@ -1,0 +1,98 @@
+package com.crobox.clickhouse.dsl
+
+import com.crobox.clickhouse.DslITSpec
+
+import java.util.UUID
+
+/**
+ * Behavioural cover for the set operations and for a join chain. The validation harness proves the server accepts what
+ * these render; it cannot tell `UNION ALL` from `UNION DISTINCT`, or a chain that joins the right tables from one that
+ * happens to parse.
+ */
+class SetOperationAndJoinChainIT extends DslITSpec {
+
+  private val shared    = UUID.randomUUID()
+  private val onlyTwo   = UUID.randomUUID()
+  private val onlyThree = UUID.randomUUID()
+
+  // column_3 carries which row it is, so a join chain that keeps the wrong row shows up as the wrong value rather
+  // than only as the wrong count.
+  override val table2Entries: Seq[Table2Entry] = Seq(
+    Table2Entry(shared, randomString, 1, "shared", None),
+    Table2Entry(onlyTwo, randomString, 1, "only-two", None)
+  )
+
+  override val table3Entries: Seq[Table3Entry] =
+    Seq(shared, onlyThree).map(id => Table3Entry(id, 1, None, randomString, randomString))
+
+  private def ids(query: OperationalQuery): Seq[String] =
+    queryExecutor.executeRows(query).futureValue.rows.map(_.requiredByName[String]("item_id"))
+
+  private val fromTwo   = select(itemId) from TwoTestTable
+  private val fromThree = select(itemId) from ThreeTestTable
+
+  "UNION ALL" should "concatenate the branches" in {
+    ids(fromTwo.unionAll(fromThree)) should contain theSameElementsAs
+    Seq(shared, onlyTwo, shared, onlyThree).map(_.toString)
+  }
+
+  "UNION DISTINCT" should "deduplicate across the branches" in {
+    ids(fromTwo.unionDistinct(fromThree)) should contain theSameElementsAs
+    Seq(shared, onlyTwo, onlyThree).map(_.toString)
+  }
+
+  "INTERSECT" should "keep only the rows both branches have" in {
+    ids(fromTwo.intersect(fromThree)) shouldBe Seq(shared.toString)
+  }
+
+  "EXCEPT" should "keep the rows the second branch does not have" in {
+    ids(fromTwo.except(fromThree)) shouldBe Seq(onlyTwo.toString)
+  }
+
+  private def labels(query: OperationalQuery): Seq[String] =
+    queryExecutor.executeRows(query).futureValue.rows.map(_.requiredByName[String]("column_3"))
+
+  "A chain of joins" should "keep only the rows every table in the chain has" in {
+    val query = select(col3)
+      .from(TwoTestTable)
+      .join(JoinQuery.InnerJoin, ThreeTestTable)
+      .on(itemId)
+      .join(JoinQuery.InnerJoin, ThreeTestTable)
+      .on(itemId)
+    // onlyTwo has no match in the dimension, so an inner chain drops it and leaves the shared row alone.
+    labels(query) shouldBe Seq("shared")
+  }
+
+  it should "key every join off the first table rather than off the previous join" in {
+    // The second join's ON reads L1.item_id. Were it reading R1's, joining a table that shares no key with the
+    // dimension would produce nothing here.
+    val query = select(col3)
+      .from(TwoTestTable)
+      .join(JoinQuery.AllLeftJoin, ThreeTestTable)
+      .on(itemId)
+      .join(JoinQuery.AllLeftJoin, ThreeTestTable)
+      .on(itemId)
+    labels(query) should contain theSameElementsAs Seq("shared", "only-two")
+  }
+
+  "ORDER BY ... NULLS" should "put the nulls at the end it names" in {
+    // The sort key is NULL for the "shared" row and non-NULL for the other, so the two orderings differ only in
+    // which end that row lands at -- the direction alone cannot account for the flip.
+    def ordered(nulls: NullsOrder): Seq[String] = {
+      val query = select(col3, nullIf(col3, const("shared")) as "n") from TwoTestTable
+      labels(query.orderByColumns(OrderingColumn(ref[String]("n"), ASC, nulls = Option(nulls))))
+    }
+    ordered(NullsOrder.NullsFirst).head shouldBe "shared"
+    ordered(NullsOrder.NullsLast).last shouldBe "shared"
+  }
+
+  "OFFSET without a limit" should "skip rows and keep the rest" in {
+    ids(select(itemId) from TwoTestTable orderBy itemId offset 1) should have size 1
+  }
+
+  "LIMIT WITH TIES" should "return more rows than the limit when the last value ties" in {
+    // Both rows share column_2 = 1, so a limit of one row extends to both.
+    val query = select(itemId, col2) from TwoTestTable orderBy col2 limitWithTies 1
+    queryExecutor.executeRows(query).futureValue.rows should have size 2
+  }
+}

--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
@@ -521,6 +521,12 @@ class SqlValidationITSpec extends DslITSpec {
     syn("Merge", select(merge[TableColumn[StateResult[Double]], Double](sum(col2))) from TwoTestTable),
     sem("TimeSeries", select(timeSeries(timestampColumn, oneDay)) from OneTestTable),
     sem("ArgMin", select(argMin(col2, col3)) from TwoTestTable),
+    // count(DISTINCT) under a combinator: renders `countIf(DISTINCT column_2, ...)`, which the server accepts and
+    // reads as "count the distinct values among the rows matching the condition".
+    sem(
+      "Count",
+      select(aggIf[TableColumn[Long], Long](col2 > 1)(countDistinct(col2))) from TwoTestTable
+    ),
     sem("ArgMax", select(argMax(col2, col3)) from TwoTestTable)
   )
 

--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
@@ -678,6 +678,90 @@ class SqlValidationITSpec extends DslITSpec {
         .interpolate()
     ),
     Construct(
+      "order by nulls first",
+      select(col2).from(TwoTestTable).orderByColumns(OrderingColumn(col2, DESC, nulls = Option(NullsOrder.NullsFirst)))
+    ),
+    Construct(
+      "order by collate",
+      select(col3).from(TwoTestTable).orderByColumns(OrderingColumn(col3, collate = Option("en")))
+    ),
+    Construct(
+      "order by with every modifier, in the one order the grammar accepts",
+      select(col2)
+        .from(TwoTestTable)
+        .orderByColumns(
+          OrderingColumn(
+            col2,
+            DESC,
+            fill = Option(WithFill(step = Option(const(1)))),
+            nulls = Option(NullsOrder.NullsLast),
+            collate = Option("en")
+          )
+        )
+    ),
+    Construct("limit with ties", select(col2).from(TwoTestTable).orderBy(col2).limitWithTies(2)),
+    Construct(
+      "limit with ties and an offset, which only parses as LIMIT offset, size WITH TIES",
+      select(col2).from(TwoTestTable).orderBy(col2).limitWithTies(2, 1)
+    ),
+    Construct("offset without a limit", select(col2).from(TwoTestTable).orderBy(col2).offset(2)),
+    Construct(
+      "union distinct",
+      (select(itemId) from TwoTestTable).unionDistinct(select(itemId) from ThreeTestTable)
+    ),
+    Construct(
+      "intersect",
+      (select(itemId) from TwoTestTable).intersect(select(itemId) from ThreeTestTable)
+    ),
+    Construct(
+      "intersect distinct",
+      (select(itemId) from TwoTestTable).intersectDistinct(select(itemId) from ThreeTestTable)
+    ),
+    Construct(
+      "except",
+      (select(itemId) from TwoTestTable).except(select(itemId) from ThreeTestTable)
+    ),
+    Construct(
+      "except distinct",
+      (select(itemId) from TwoTestTable).exceptDistinct(select(itemId) from ThreeTestTable)
+    ),
+    Construct(
+      "except chained with union, which share a precedence level",
+      (select(itemId) from TwoTestTable)
+        .except(select(itemId) from ThreeTestTable)
+        .unionAll(select(itemId) from TwoTestTable)
+    ),
+    Construct(
+      // Projects column_3, which only the left table has: once three tables in the chain expose item_id, selecting it
+      // unqualified is ambiguous -- a property of the fixture's schema rather than of the rendering.
+      "three tables joined at one level, every join keyed off the first",
+      select(col3)
+        .from(TwoTestTable)
+        .join(JoinQuery.InnerJoin, ThreeTestTable)
+        .on(itemId)
+        .join(JoinQuery.AllLeftJoin, ThreeTestTable)
+        .on(itemId)
+    ),
+    Construct(
+      "a chain of joins using USING",
+      select(itemId)
+        .from(TwoTestTable)
+        .join(JoinQuery.InnerJoin, ThreeTestTable)
+        .using(itemId)
+        .join(JoinQuery.InnerJoin, TwoTestTable)
+        .using(itemId)
+    ),
+    Construct(
+      "array join ahead of a chain of joins",
+      select(shieldId as itemId)
+        .from(OneTestTable)
+        .withArrayJoin(numbers as "n")
+        .join(JoinQuery.InnerJoin, TwoTestTable)
+        .using(itemId)
+        .join(JoinQuery.InnerJoin, ThreeTestTable)
+        .using(itemId)
+    ),
+    Construct(
       "group by a column an aggregate already covers, which is now projected",
       select(sum(col2)).from(TwoTestTable).groupBy(col2)
     ),

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/OperationalQuery.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/OperationalQuery.scala
@@ -201,23 +201,63 @@ trait OperationalQuery extends Query {
   def limit(limit: Option[Limit]): OperationalQuery =
     OperationalQuery(internalQuery.copy(limit = limit))
 
+  def limit(size: Long): OperationalQuery = limit(Option(Limit(Option(size))))
+
+  def limit(size: Long, offset: Long): OperationalQuery = limit(Option(Limit(Option(size), offset)))
+
+  /** `LIMIT size WITH TIES`, which also returns every row tying with the last one on the `ORDER BY` key. */
+  def limitWithTies(size: Long, offset: Long = 0): OperationalQuery =
+    limit(Option(Limit(Option(size), offset, withTies = true)))
+
+  /** `OFFSET n` with no `LIMIT`, which ClickHouse accepts on its own. */
+  def offset(offset: Long): OperationalQuery =
+    limit(Option(internalQuery.limit.fold(Limit(None, offset))(_.copy(offset = offset))))
+
   def limitBy(limit: Long, expressions: Column*): OperationalQuery =
     OperationalQuery(internalQuery.copy(limitBy = Some(LimitBy(limit, 0, expressions))))
 
   def limitBy(limit: Long, offset: Long, expressions: Column*): OperationalQuery =
     OperationalQuery(internalQuery.copy(limitBy = Some(LimitBy(limit, offset, expressions))))
 
-  def unionAll(otherQuery: OperationalQuery): OperationalQuery = {
+  def unionAll(otherQuery: OperationalQuery): OperationalQuery =
+    combineWith(SetOperationKind.UnionAll, otherQuery)
+
+  /** `UNION DISTINCT`, which deduplicates across the branches where `UNION ALL` concatenates them. */
+  def unionDistinct(otherQuery: OperationalQuery): OperationalQuery =
+    combineWith(SetOperationKind.UnionDistinct, otherQuery)
+
+  /**
+   * `INTERSECT`, the rows present in both branches.
+   *
+   * Binds tighter than `UNION` and `EXCEPT`, so it cannot be chained with either -- see the `require` in
+   * [[InternalQuery]].
+   */
+  def intersect(otherQuery: OperationalQuery): OperationalQuery =
+    combineWith(SetOperationKind.Intersect, otherQuery)
+
+  def intersectDistinct(otherQuery: OperationalQuery): OperationalQuery =
+    combineWith(SetOperationKind.IntersectDistinct, otherQuery)
+
+  /** `EXCEPT`, the rows of this query that the other does not have. */
+  def except(otherQuery: OperationalQuery): OperationalQuery =
+    combineWith(SetOperationKind.Except, otherQuery)
+
+  def exceptDistinct(otherQuery: OperationalQuery): OperationalQuery =
+    combineWith(SetOperationKind.ExceptDistinct, otherQuery)
+
+  private def combineWith(kind: SetOperationKind, otherQuery: OperationalQuery): OperationalQuery = {
     require(
       internalQuery.select.isDefined && otherQuery.internalQuery.select.isDefined,
-      "Trying to apply UNION ALL on non SELECT queries."
+      s"Trying to apply ${kind.keyword} on non SELECT queries."
     )
     require(
       otherQuery.internalQuery.select.get.columns.size == internalQuery.select.get.columns.size,
-      "SELECT queries needs to have the same number of columns to perform UNION ALL."
+      s"SELECT queries needs to have the same number of columns to perform ${kind.keyword}."
     )
 
-    OperationalQuery(internalQuery.copy(unionAll = internalQuery.unionAll :+ otherQuery))
+    OperationalQuery(
+      internalQuery.copy(combinations = internalQuery.combinations :+ SetOperation(kind, otherQuery))
+    )
   }
 
   /**
@@ -265,15 +305,33 @@ trait OperationalQuery extends Query {
     newSelect
   }
 
+  /**
+   * Appends a join. Several joins at one level render as a chain, where each one's `ON` addresses the *first* table --
+   * the left alias stays `L1` throughout while the right aliases count up `R1`, `R2`, ... That covers a fact table
+   * joined to several dimensions; anything keyed off an earlier join's right-hand side has to nest in a subquery, since
+   * a [[JoinCondition]] names columns rather than the table they belong to.
+   */
   def join[TargetTable <: Table](
       joinType: JoinQuery.JoinType,
       query: OperationalQuery,
       global: Boolean
-  ): OperationalQuery =
-    OperationalQuery(internalQuery.copy(join = Some(JoinQuery(joinType, InnerFromQuery(query), global = global))))
+  ): OperationalQuery = addJoin(JoinQuery(joinType, InnerFromQuery(query), global = global))
 
   def join[TargetTable <: Table](joinType: JoinQuery.JoinType, table: TargetTable, global: Boolean): OperationalQuery =
-    OperationalQuery(internalQuery.copy(join = Some(JoinQuery(joinType, TableFromQuery(table), global = global))))
+    addJoin(JoinQuery(joinType, TableFromQuery(table), global = global))
+
+  private def addJoin(join: JoinQuery): OperationalQuery =
+    OperationalQuery(internalQuery.copy(joins = internalQuery.joins :+ join))
+
+  /**
+   * Rewrites the join most recently added, which is what `using` and `on` attach to.
+   *
+   * Applies to the last rather than the only one so that `.join(a).using(k).join(b).using(k)` reads as it looks.
+   */
+  private def mapLastJoin(f: JoinQuery => JoinQuery): OperationalQuery = {
+    require(internalQuery.joins.nonEmpty, "No join to attach USING or ON to")
+    OperationalQuery(internalQuery.copy(joins = internalQuery.joins.init :+ f(internalQuery.joins.last)))
+  }
 
   def join[TargetTable <: Table](joinType: JoinQuery.JoinType, query: OperationalQuery): OperationalQuery =
     join(joinType = joinType, query = query, global = false)
@@ -290,33 +348,16 @@ trait OperationalQuery extends Query {
   def using(
       column: Column,
       columns: Column*
-  ): OperationalQuery = {
-    require(internalQuery.join.isDefined)
+  ): OperationalQuery = mapLastJoin(_.copy(`using` = (column +: columns).distinct))
 
-    val newJoin = this.internalQuery.join.get.copy(`using` = (column +: columns).distinct)
-    OperationalQuery(internalQuery.copy(join = Some(newJoin)))
-  }
+  def on(columns: Column*): OperationalQuery =
+    mapLastJoin(_.copy(on = columns.map(JoinCondition(_))))
 
-  def on(columns: Column*): OperationalQuery = {
-    require(internalQuery.join.isDefined)
-    OperationalQuery(
-      internalQuery.copy(join = Some(this.internalQuery.join.get.copy(on = columns.map(JoinCondition(_)))))
-    )
-  }
+  def on(condition: JoinCondition, conditions: JoinCondition*): OperationalQuery =
+    mapLastJoin(_.copy(on = condition +: conditions))
 
-  def on(condition: JoinCondition, conditions: JoinCondition*): OperationalQuery = {
-    require(internalQuery.join.isDefined)
-    OperationalQuery(internalQuery.copy(join = Some(this.internalQuery.join.get.copy(on = condition +: conditions))))
-  }
-
-  def on(condition: (Column, String, Column), conditions: (Column, String, Column)*): OperationalQuery = {
-    require(internalQuery.join.isDefined)
-    OperationalQuery(
-      internalQuery.copy(
-        join = Some(this.internalQuery.join.get.copy(on = JoinCondition(condition) +: conditions.map(JoinCondition(_))))
-      )
-    )
-  }
+  def on(condition: (Column, String, Column), conditions: (Column, String, Column)*): OperationalQuery =
+    mapLastJoin(_.copy(on = JoinCondition(condition) +: conditions.map(JoinCondition(_))))
 
   /**
    * Merge with another OperationalQuery, any conflict on query parts between the 2 joins will be resolved by preferring

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/OrderingColumn.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/OrderingColumn.scala
@@ -22,13 +22,32 @@ case class WithFill(
   )
 }
 
+/** `NULLS FIRST` / `NULLS LAST`, which decides where NULLs land independently of the direction. */
+sealed abstract class NullsOrder(val keyword: String)
+
+object NullsOrder {
+  case object NullsFirst extends NullsOrder("NULLS FIRST")
+  case object NullsLast  extends NullsOrder("NULLS LAST")
+}
+
 /**
  * One `ORDER BY` entry.
  *
  * Was a `(Column, OrderingDirection)` tuple, which had nowhere to put `WITH FILL`. The implicit conversions below keep
  * the tuple and bare-column forms working at call sites.
+ *
+ * `nulls` and `collate` come after `fill` in the parameter list but before it in the emitted SQL. Field order is kept
+ * as it was so the existing positional `OrderingColumn(col, DESC, Option(WithFill()))` call sites still compile;
+ * ClickHouse's grammar fixes the render order at `expr [ASC|DESC] [NULLS ...] [COLLATE ...] [WITH FILL ...]` and
+ * rejects any other -- `COLLATE 'en' NULLS LAST` and `WITH FILL ... NULLS LAST` are both syntax errors.
  */
-case class OrderingColumn(column: Column, direction: OrderingDirection = ASC, fill: Option[WithFill] = None)
+case class OrderingColumn(
+    column: Column,
+    direction: OrderingDirection = ASC,
+    fill: Option[WithFill] = None,
+    nulls: Option[NullsOrder] = None,
+    collate: Option[String] = None
+)
 
 object OrderingColumn {
 

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/Query.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/Query.scala
@@ -19,7 +19,51 @@ trait Query {
   val internalQuery: InternalQuery
 }
 
-case class Limit(size: Long = 100, offset: Long = 0)
+/**
+ * `LIMIT`, `OFFSET` and `LIMIT ... WITH TIES`.
+ *
+ * `size` is optional so that a bare `OFFSET n` is expressible: ClickHouse accepts one without a `LIMIT`, and folding
+ * the offset into `LIMIT offset, size` -- the only form this used to render -- cannot say that.
+ *
+ * `withTies` extends the result past `size` with every row that ties with the last one on the `ORDER BY` key. It needs
+ * an `ORDER BY` to mean anything, which is not checked here: the ordering lives on the query rather than on this.
+ */
+case class Limit(size: Option[Long] = Some(100), offset: Long = 0, withTies: Boolean = false)
+
+object Limit {
+
+  def apply(size: Long, offset: Long): Limit = Limit(Some(size), offset)
+
+  def apply(size: Long): Limit = Limit(Some(size))
+}
+
+/** How a query is combined with the one that follows it. */
+sealed abstract class SetOperationKind(val keyword: String) {
+
+  /**
+   * Whether ClickHouse binds this tighter than `UNION` and `EXCEPT`, which share one precedence level and associate
+   * left to right. `INTERSECT` does: `a EXCEPT b INTERSECT c` means `a EXCEPT (b INTERSECT c)`.
+   */
+  def bindsTighter: Boolean = false
+}
+
+object SetOperationKind {
+  case object UnionAll       extends SetOperationKind("UNION ALL")
+  case object UnionDistinct  extends SetOperationKind("UNION DISTINCT")
+  case object Except         extends SetOperationKind("EXCEPT")
+  case object ExceptDistinct extends SetOperationKind("EXCEPT DISTINCT")
+
+  case object Intersect extends SetOperationKind("INTERSECT") {
+    override def bindsTighter: Boolean = true
+  }
+
+  case object IntersectDistinct extends SetOperationKind("INTERSECT DISTINCT") {
+    override def bindsTighter: Boolean = true
+  }
+}
+
+/** One `<kind> <query>` step of a set-operation chain. */
+case class SetOperation(kind: SetOperationKind, query: OperationalQuery)
 
 case class LimitBy(limit: Long, offset: Long = 0, expressions: Seq[Column])
 
@@ -43,12 +87,12 @@ sealed case class InternalQuery(
     where: Option[TableColumn[Boolean]] = None,
     groupBy: Option[GroupByQuery] = None,
     having: Option[TableColumn[Boolean]] = None,
-    join: Option[JoinQuery] = None,
+    joins: Seq[JoinQuery] = Seq.empty,
     arrayJoin: Option[ArrayJoinQuery] = None,
     orderBy: Seq[OrderingColumn] = Seq.empty,
     limit: Option[Limit] = None,
     limitBy: Option[LimitBy] = None,
-    unionAll: Seq[OperationalQuery] = Seq.empty,
+    combinations: Seq[SetOperation] = Seq.empty,
     // Ordered rather than a Map: map iteration order is unspecified, which would make the emitted SQL vary between
     // runs for the same query.
     settings: Seq[(String, String)] = Seq.empty,
@@ -60,6 +104,17 @@ sealed case class InternalQuery(
     windows: Seq[NamedWindow] = Seq.empty,
     qualify: Option[TableColumn[Boolean]] = None
 ) {
+
+  // A chain renders flat, so it only reads left to right while every step shares one precedence level. INTERSECT does
+  // not: `a UNION ALL b INTERSECT c` is `a UNION ALL (b INTERSECT c)`, which is not what a Seq in that order looks
+  // like. Refused rather than silently parenthesised, because either reading is a plausible thing to have meant --
+  // nest the tighter part in a subquery to say which.
+  // forall rather than map/distinct: this runs on every `copy`, and query building does a lot of those.
+  require(
+    combinations.isEmpty || combinations.forall(_.kind.bindsTighter == combinations.head.kind.bindsTighter),
+    "INTERSECT binds tighter than UNION and EXCEPT, so a chain mixing them does not mean what its order says. " +
+      "Put the INTERSECT in a subquery instead."
+  )
 
   def isValid: Boolean = {
     val validGroupBy = groupBy.isEmpty && having.isEmpty || groupBy.nonEmpty
@@ -90,12 +145,12 @@ sealed case class InternalQuery(
       where = where.orElse(other.where),
       groupBy = groupBy.orElse(other.groupBy),
       having = having.orElse(other.having),
-      join = join.orElse(other.join),
+      joins = if (joins.nonEmpty) joins else other.joins,
       arrayJoin = arrayJoin.orElse(other.arrayJoin),
       orderBy = if (orderBy.nonEmpty) orderBy else other.orderBy,
       limit = limit.orElse(other.limit),
       limitBy = limitBy.orElse(other.limitBy),
-      unionAll = if (unionAll.nonEmpty) unionAll else other.unionAll,
+      combinations = if (combinations.nonEmpty) combinations else other.combinations,
       settings = if (settings.nonEmpty) settings else other.settings,
       withEntries = if (withEntries.nonEmpty) withEntries else other.withEntries,
       interpolate = interpolate.orElse(other.interpolate),
@@ -137,12 +192,12 @@ sealed case class InternalQuery(
     noConflict("where", where, other.where)
     noConflict("groupBy", groupBy, other.groupBy)
     noConflict("having", having, other.having)
-    noConflict("join", join, other.join)
+    noSeqConflict("joins", joins, other.joins)
     noConflict("arrayJoin", arrayJoin, other.arrayJoin)
     noSeqConflict("orderBy", orderBy, other.orderBy)
     noConflict("limit", limit, other.limit)
     noConflict("limitBy", limitBy, other.limitBy)
-    noSeqConflict("unionAll", unionAll, other.unionAll)
+    noSeqConflict("combinations", combinations, other.combinations)
     noSeqConflict("settings", settings, other.settings)
     noSeqConflict("withEntries", withEntries, other.withEntries)
     noConflict("interpolate", interpolate, other.interpolate)

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/Query.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/Query.scala
@@ -28,7 +28,12 @@ trait Query {
  * `withTies` extends the result past `size` with every row that ties with the last one on the `ORDER BY` key. It needs
  * an `ORDER BY` to mean anything, which is not checked here: the ordering lives on the query rather than on this.
  */
-case class Limit(size: Option[Long] = Some(100), offset: Long = 0, withTies: Boolean = false)
+case class Limit(size: Option[Long] = Some(100), offset: Long = 0, withTies: Boolean = false) {
+
+  // WITH TIES extends the result past `size`, so there is nothing for it to do without one, and the OFFSET-only
+  // rendering has nowhere to put it -- it would be dropped silently.
+  require(size.isDefined || !withTies, "WITH TIES needs a LIMIT size to extend")
+}
 
 object Limit {
 

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -153,12 +153,12 @@ trait ClickhouseTokenizerModule
             where,
             groupBy,
             having,
-            join,
+            joins,
             arrayJoin,
             orderBy,
             limit,
             limitBy,
-            union,
+            combinations,
             settings,
             withEntries,
             interpolate,
@@ -172,8 +172,8 @@ trait ClickhouseTokenizerModule
           tokenizeWith(withEntries),
           tokenizeSelect(select),
           tokenizeFrom(from),
-          if (join.isDefined) "" else arrayJoinSql,
-          tokenizeJoin(select, from, join, arrayJoinSql),
+          if (joins.nonEmpty) "" else arrayJoinSql,
+          tokenizeJoins(select, from, joins, arrayJoinSql),
           tokenizeFiltering(prewhere, "PREWHERE"),
           tokenizeFiltering(where, "WHERE"),
           tokenizeGroupBy(groupBy),
@@ -185,7 +185,7 @@ trait ClickhouseTokenizerModule
           tokenizeLimitBy(limitBy),
           tokenizeLimit(limit),
           tokenizeSettings(settings),
-          tokenizeUnionAll(union)
+          tokenizeSetOperations(combinations)
         ).filter(_.nonEmpty).mkString(" ")
     }
 
@@ -250,8 +250,16 @@ trait ClickhouseTokenizerModule
     if (settings.isEmpty) ""
     else settings.map { case (key, value) => s"$key = $value" }.mkString("SETTINGS ", Tokens.Delimiter, "")
 
-  private def tokenizeUnionAll(unions: Seq[OperationalQuery])(implicit ctx: TokenizeContext): String =
-    if (unions.nonEmpty) unions.map(q => s"UNION ALL ${toRawSql(q.internalQuery)}").mkString(" ") else ""
+  /**
+   * `UNION`/`INTERSECT`/`EXCEPT`, rendered as a flat chain with no parentheses of its own.
+   *
+   * Flat is only faithful while every step shares one precedence level, which [[InternalQuery]] requires. A trailing
+   * `ORDER BY` or `LIMIT` binds to the last branch either way, which is what the per-branch model already says.
+   */
+  private def tokenizeSetOperations(combinations: Seq[SetOperation])(implicit ctx: TokenizeContext): String =
+    combinations
+      .map { case SetOperation(kind, query) => s"${kind.keyword} ${toRawSql(query.internalQuery)}" }
+      .mkString(" ")
 
   private def tokenizeSelect(select: Option[SelectQuery])(implicit ctx: TokenizeContext): String =
     select match {
@@ -424,19 +432,35 @@ trait ClickhouseTokenizerModule
   }
 
   //  Table joins are tokenized as select * because of https://github.com/yandex/ClickHouse/issues/635
-  private def tokenizeJoin(
+  /**
+   * The whole `JOIN` chain, plus the left table's alias, which only exists because a join needs something to qualify
+   * its keys with.
+   *
+   * Every join in the chain keys off the *first* table: the left alias is claimed once and reused, while each join
+   * takes its own number for its right alias, giving `L1 ... R1 ... R2`. A join that has to key off an earlier join's
+   * right-hand side cannot be spelled here, because a [[com.crobox.clickhouse.dsl.JoinCondition]] names columns and not
+   * the table they came from -- nest it in a subquery instead.
+   */
+  private def tokenizeJoins(
       select: Option[SelectQuery],
       from: Option[FromQuery],
-      join: Option[JoinQuery],
+      joins: Seq[JoinQuery],
       arrayJoin: String
   )(implicit
       ctx: TokenizeContext
   ): String =
-    join match {
-      case Some(query) =>
-        // Claimed up front and held: tokenizing `right` below advances the counter for every join nested in it, so
-        // reading it back afterwards would number this join by its subtree and collide with the innermost join.
-        val joinNr = ctx.nextJoinNumber()
+    if (joins.isEmpty) ""
+    else {
+      // Claimed up front and held: tokenizing a right-hand side below advances the counter for every join nested in
+      // it, so reading it back afterwards would number this join by its subtree and collide with the innermost join.
+      val leftNr = ctx.nextJoinNumber()
+
+      val leftAlias =
+        if (from.flatMap(_.alias).isEmpty) s"AS ${ctx.leftAlias(from.flatMap(_.alias), leftNr)}" else ""
+
+      val chain = joins.zipWithIndex.map { case (query, index) =>
+        // The first join shares the left side's number; the rest claim their own so their right aliases stay distinct.
+        val rightNr = if (index == 0) leftNr else ctx.nextJoinNumber()
 
         // we always need to provide an alias to the RIGHT side
         val right = query.other match {
@@ -444,21 +468,26 @@ trait ClickhouseTokenizerModule
           case query: InnerFromQuery    => tokenizeFrom(Some(query), withPrefix = false)
         }
 
-        val leftAlias = if (from.flatMap(_.alias).isEmpty) s"AS ${ctx.leftAlias(from.flatMap(_.alias), joinNr)}" else ""
-        val rightAlias = s"AS ${ctx.rightAlias(query.other.alias, joinNr)}"
+        Seq(
+          if (query.global) "GLOBAL" else "",
+          tokenizeJoinType(query.joinType),
+          right,
+          s"AS ${ctx.rightAlias(query.other.alias, rightNr)}",
+          tokenizeJoinKeys(select, from.get, query, leftNr, rightNr)
+        )
+      }
 
-        s""" $leftAlias
-           | $arrayJoin
-           | ${if (query.global) "GLOBAL " else ""}
-           | ${tokenizeJoinType(query.joinType)}
-           | $right $rightAlias
-           | ${tokenizeJoinKeys(select, from.get, query, joinNr)}""".trim.stripMargin
-          .replaceAll("\n", "")
-          .replaceAll("\r", "")
-      case None => ""
+      // ARRAY JOIN has to land between the left table's alias and the first JOIN keyword.
+      (Seq(leftAlias, arrayJoin) ++ chain.flatten).filter(_.nonEmpty).mkString(" ")
     }
 
-  private def tokenizeJoinKeys(select: Option[SelectQuery], from: FromQuery, query: JoinQuery, joinNr: Int)(implicit
+  private def tokenizeJoinKeys(
+      select: Option[SelectQuery],
+      from: FromQuery,
+      query: JoinQuery,
+      leftNr: Int,
+      rightNr: Int
+  )(implicit
       ctx: TokenizeContext
   ): String = {
 
@@ -492,7 +521,7 @@ trait ClickhouseTokenizerModule
             "ON " + `using`
               .map { key =>
                 val left = underlyingLeftColumn(select, key).getOrElse(key.name)
-                s"${ctx.leftAlias(from.alias, joinNr)}.$left = ${ctx.rightAlias(query.other.alias, joinNr)}.${key.name}"
+                s"${ctx.leftAlias(from.alias, leftNr)}.$left = ${ctx.rightAlias(query.other.alias, rightNr)}.${key.name}"
               }
               .mkString(" AND ")
           } else if (`using`.size == 1) s"USING ${using.head.name}"
@@ -502,7 +531,7 @@ trait ClickhouseTokenizerModule
           "ON " + query.on
             .map { cond =>
               val left = underlyingLeftColumn(select, cond.left).getOrElse(cond.left.name)
-              s"${ctx.leftAlias(from.alias, joinNr)}.$left ${cond.operator} ${ctx.rightAlias(query.other.alias, joinNr)}.${cond.right.name}"
+              s"${ctx.leftAlias(from.alias, leftNr)}.$left ${cond.operator} ${ctx.rightAlias(query.other.alias, rightNr)}.${cond.right.name}"
             }
             .mkString(" AND ")
         } else ""
@@ -628,10 +657,18 @@ trait ClickhouseTokenizerModule
     if (parts.isEmpty) "WITH FILL" else s"WITH FILL ${parts.mkString(" ")}"
   }
 
+  /**
+   * `LIMIT`, and `OFFSET` on its own when there is no size to limit to.
+   *
+   * `WITH TIES` only parses at the very end of the clause, and only after the `LIMIT offset, size` spelling -- both
+   * `LIMIT size WITH TIES OFFSET offset` and `LIMIT size OFFSET offset WITH TIES` are syntax errors.
+   */
   private def tokenizeLimit(limit: Option[Limit]): String =
     limit match {
-      case None                      => ""
-      case Some(Limit(size, offset)) => s"LIMIT $offset, $size"
+      case None                                      => ""
+      case Some(Limit(None, offset, _))              => s"OFFSET $offset"
+      case Some(Limit(Some(size), offset, withTies)) =>
+        s"LIMIT $offset, $size" + (if (withTies) " WITH TIES" else "")
     }
 
   private def tokenizeLimitBy(limitBy: Option[LimitBy])(implicit ctx: TokenizeContext): String =
@@ -651,9 +688,17 @@ trait ClickhouseTokenizerModule
 
   private def tokenizeTuplesAliased(columns: Seq[OrderingColumn])(implicit ctx: TokenizeContext): String =
     columns
-      .map { case OrderingColumn(column, dir, fill) =>
-        val ordered = tokenizeColumn(column) + " " + direction(dir)
-        fill.map(f => s"$ordered ${tokenizeWithFill(f)}").getOrElse(ordered)
+      // ClickHouse's grammar fixes this order and rejects any other: NULLS before COLLATE, and WITH FILL last.
+      .map { case OrderingColumn(column, dir, fill, nulls, collate) =>
+        Seq(
+          Option(tokenizeColumn(column)),
+          Option(direction(dir)),
+          nulls.map(_.keyword),
+          // A locale name, so a quoted string literal rather than an identifier -- `escape` does the escaping but not
+          // the quoting.
+          collate.map(locale => s"COLLATE '${ClickhouseStatement.escape(locale)}'"),
+          fill.map(tokenizeWithFill)
+        ).flatten.mkString(" ")
       }
       .mkString(", ")
 

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -251,14 +251,23 @@ trait ClickhouseTokenizerModule
     else settings.map { case (key, value) => s"$key = $value" }.mkString("SETTINGS ", Tokens.Delimiter, "")
 
   /**
-   * `UNION`/`INTERSECT`/`EXCEPT`, rendered as a flat chain with no parentheses of its own.
+   * `UNION`/`INTERSECT`/`EXCEPT`.
    *
-   * Flat is only faithful while every step shares one precedence level, which [[InternalQuery]] requires. A trailing
-   * `ORDER BY` or `LIMIT` binds to the last branch either way, which is what the per-branch model already says.
+   * A branch that carries set operations of its own is parenthesised, because the chain is otherwise flat and
+   * ClickHouse reads a flat chain left to right. `a.unionAll(b.except(c))` would render `a UNION ALL b EXCEPT c`, which
+   * groups as `(a UNION ALL b) EXCEPT c` -- and set difference is not associative, so that silently returns something
+   * else. The call structure says which grouping was meant, so this preserves it rather than refusing it;
+   * [[InternalQuery]]'s own `require` covers the flat case, where nothing says.
+   *
+   * A trailing `ORDER BY` or `LIMIT` binds to its own branch either way, which is what the per-branch model says.
    */
   private def tokenizeSetOperations(combinations: Seq[SetOperation])(implicit ctx: TokenizeContext): String =
     combinations
-      .map { case SetOperation(kind, query) => s"${kind.keyword} ${toRawSql(query.internalQuery)}" }
+      .map { case SetOperation(kind, query) =>
+        val branch = toRawSql(query.internalQuery)
+        val nested = if (query.internalQuery.combinations.isEmpty) branch else s"($branch)"
+        s"${kind.keyword} $nested"
+      }
       .mkString(" ")
 
   private def tokenizeSelect(select: Option[SelectQuery])(implicit ctx: TokenizeContext): String =

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/InFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/InFunctionTokenizer.scala
@@ -26,7 +26,7 @@ trait InFunctionTokenizer {
   }
 
   /** A right-hand side that joins already names its sides, so aliasing its tables again would clash. */
-  private def aliasTables(r: InFuncRHMagnet): Boolean = r.query.forall(_.internalQuery.join.isEmpty)
+  private def aliasTables(r: InFuncRHMagnet): Boolean = r.query.forall(_.internalQuery.joins.isEmpty)
 
   private def tokenizeInFunRHCol(value: InFuncRHMagnet, aliasTables: Boolean)(implicit
       ctx: TokenizeContext

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/parallel/package.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/parallel/package.scala
@@ -58,10 +58,8 @@ package object parallel {
 
         val newCols = (cols ++ maybeFromCols ++ uQry.select.toSeq.flatMap(_.columns)).distinct
 
-        uQry.join match {
-          case Some(JoinQuery(_, q, _, _, _)) if selectAll => recursiveCollectCols(q.internalQuery, newCols)
-          case _                                           => newCols
-        }
+        if (selectAll) uQry.joins.foldLeft(newCols)((acc, join) => recursiveCollectCols(join.other.internalQuery, acc))
+        else newCols
       }
 
       // Forcefully add the columns of the right table(s), because 'select *' on a join only returns the values of the left table in clickhouse

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/InternalQueryFieldsTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/InternalQueryFieldsTest.scala
@@ -10,7 +10,7 @@ import scala.util.{Failure, Success}
  * Adding a clause means adding a field, and only one of the places that field has to be handled is checked by the
  * compiler: `toRawSql` destructures positionally, so it stops building. `:+>` and `+` both name their arguments, so an
  * unmentioned field just takes its default -- a merge quietly discards it, and a genuine conflict quietly passes. That
- * is how `unionAll` came to be dropped from every merge for as long as it existed.
+ * is how the set-operation field came to be dropped from every merge for as long as it existed.
  *
  * [[FieldCount]] is the tripwire that sends the author here; the tests below are what actually verify the merge.
  */
@@ -35,12 +35,12 @@ class InternalQueryFieldsTest extends DslTestSpec {
     where = Option(condition),
     groupBy = Option(GroupByQuery(usingColumns = Seq(itemId))),
     having = Option(condition),
-    join = Option(JoinQuery(JoinQuery.InnerJoin, TableFromQuery(ThreeTestTable), `using` = Seq(itemId))),
+    joins = Seq(JoinQuery(JoinQuery.InnerJoin, TableFromQuery(ThreeTestTable), `using` = Seq(itemId))),
     arrayJoin = Option(ArrayJoinQuery(Seq(numbers))),
-    orderBy = Seq(OrderingColumn(itemId, DESC)),
-    limit = Option(Limit(10, 5)),
+    orderBy = Seq(OrderingColumn(itemId, DESC, nulls = Option(NullsOrder.NullsLast))),
+    limit = Option(Limit(Option(10), 5, withTies = true)),
     limitBy = Option(LimitBy(1, 0, Seq(itemId))),
-    unionAll = Seq(select(itemId).from(OneTestTable)),
+    combinations = Seq(SetOperation(SetOperationKind.UnionAll, select(itemId).from(OneTestTable))),
     settings = Seq("max_threads" -> "1"),
     withEntries = Seq(WithExpression(const(1), "one")),
     interpolate = Option(Interpolate(Seq(InterpolateColumn(col2)))),
@@ -50,23 +50,23 @@ class InternalQueryFieldsTest extends DslTestSpec {
 
   /** One query per field, carrying only that field, so a missing conflict check shows up as a merge that succeeds. */
   private val singleFieldQueries: Seq[(String, InternalQuery)] = Seq(
-    "select"      -> InternalQuery(select = populated.select),
-    "from"        -> InternalQuery(from = populated.from),
-    "prewhere"    -> InternalQuery(prewhere = populated.prewhere),
-    "where"       -> InternalQuery(where = populated.where),
-    "groupBy"     -> InternalQuery(groupBy = populated.groupBy),
-    "having"      -> InternalQuery(having = populated.having),
-    "join"        -> InternalQuery(join = populated.join),
-    "arrayJoin"   -> InternalQuery(arrayJoin = populated.arrayJoin),
-    "orderBy"     -> InternalQuery(orderBy = populated.orderBy),
-    "limit"       -> InternalQuery(limit = populated.limit),
-    "limitBy"     -> InternalQuery(limitBy = populated.limitBy),
-    "unionAll"    -> InternalQuery(unionAll = populated.unionAll),
-    "settings"    -> InternalQuery(settings = populated.settings),
-    "withEntries" -> InternalQuery(withEntries = populated.withEntries),
-    "interpolate" -> InternalQuery(interpolate = populated.interpolate),
-    "windows"     -> InternalQuery(windows = populated.windows),
-    "qualify"     -> InternalQuery(qualify = populated.qualify)
+    "select"       -> InternalQuery(select = populated.select),
+    "from"         -> InternalQuery(from = populated.from),
+    "prewhere"     -> InternalQuery(prewhere = populated.prewhere),
+    "where"        -> InternalQuery(where = populated.where),
+    "groupBy"      -> InternalQuery(groupBy = populated.groupBy),
+    "having"       -> InternalQuery(having = populated.having),
+    "joins"        -> InternalQuery(joins = populated.joins),
+    "arrayJoin"    -> InternalQuery(arrayJoin = populated.arrayJoin),
+    "orderBy"      -> InternalQuery(orderBy = populated.orderBy),
+    "limit"        -> InternalQuery(limit = populated.limit),
+    "limitBy"      -> InternalQuery(limitBy = populated.limitBy),
+    "combinations" -> InternalQuery(combinations = populated.combinations),
+    "settings"     -> InternalQuery(settings = populated.settings),
+    "withEntries"  -> InternalQuery(withEntries = populated.withEntries),
+    "interpolate"  -> InternalQuery(interpolate = populated.interpolate),
+    "windows"      -> InternalQuery(windows = populated.windows),
+    "qualify"      -> InternalQuery(qualify = populated.qualify)
   )
 
   /** Names the fields that differ, because an InternalQuery's `toString` is far too long to diff by eye. */

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/JoinQueryTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/JoinQueryTest.scala
@@ -188,4 +188,78 @@ class JoinQueryTest extends DslTestSpec with TableDrivenPropertyChecks {
         s"ON L1.shield_id = R1.item_id FORMAT JSON"
     )
   }
+
+  // A chain keys every join off the first table: the left alias is claimed once and reused while the right aliases
+  // count up. Anything keyed off an earlier join's right-hand side has to nest, since a JoinCondition names a column
+  // rather than the table it belongs to.
+  it should "chain several joins at one level, keyed off the first table" in {
+    val query = select(itemId)
+      .from(TwoTestTable)
+      .join(InnerJoin, ThreeTestTable)
+      .on(itemId)
+      .join(AllLeftJoin, OneTestTable)
+      .on(itemId)
+    toSql(query.internalQuery) should matchSQL(
+      s"SELECT item_id FROM ${TwoTestTable.quoted} AS L1 " +
+        s"INNER JOIN (SELECT * FROM ${ThreeTestTable.quoted}) AS R1 ON L1.item_id = R1.item_id " +
+        s"ALL LEFT JOIN (SELECT * FROM ${OneTestTable.quoted}) AS R2 ON L1.item_id = R2.item_id FORMAT JSON"
+    )
+  }
+
+  it should "chain joins that use USING" in {
+    val query = select(itemId).from(TwoTestTable).join(InnerJoin, ThreeTestTable).using(itemId)
+    toSql(query.join(InnerJoin, TwoTestTable).using(itemId).internalQuery) should matchSQL(
+      s"SELECT item_id FROM ${TwoTestTable.quoted} AS L1 " +
+        s"INNER JOIN (SELECT * FROM ${ThreeTestTable.quoted}) AS R1 USING item_id " +
+        s"INNER JOIN (SELECT * FROM ${TwoTestTable.quoted}) AS R2 USING item_id FORMAT JSON"
+    )
+  }
+
+  it should "attach USING and ON to the join most recently added" in {
+    val query = select(itemId)
+      .from(TwoTestTable)
+      .join(InnerJoin, ThreeTestTable)
+      .using(itemId)
+      .join(InnerJoin, OneTestTable)
+      .on(itemId)
+    query.internalQuery.joins.map(j => (j.using.map(_.name), j.on.size)) shouldBe Seq(
+      (Seq("item_id"), 0),
+      (Seq.empty, 1)
+    )
+  }
+
+  it should "keep ARRAY JOIN between the left alias and the first JOIN of a chain" in {
+    val query = select(itemId)
+      .from(TwoTestTable)
+      .withArrayJoin(numbers)
+      .join(InnerJoin, ThreeTestTable)
+      .on(itemId)
+      .join(InnerJoin, TwoTestTable)
+      .on(itemId)
+    toSql(query.internalQuery) should matchSQL(
+      s"SELECT item_id FROM ${TwoTestTable.quoted} AS L1 ARRAY JOIN numbers " +
+        s"INNER JOIN (SELECT * FROM ${ThreeTestTable.quoted}) AS R1 ON L1.item_id = R1.item_id " +
+        s"INNER JOIN (SELECT * FROM ${TwoTestTable.quoted}) AS R2 ON L1.item_id = R2.item_id FORMAT JSON"
+    )
+  }
+
+  it should "carry GLOBAL per join rather than for the whole chain" in {
+    val query = select(itemId)
+      .from(TwoTestTable)
+      .join(InnerJoin, ThreeTestTable)
+      .on(itemId)
+      .globalJoin(InnerJoin, OneTestTable)
+      .on(itemId)
+    toSql(query.internalQuery) should include("GLOBAL INNER JOIN")
+    toSql(query.internalQuery) should matchSQL(
+      s"SELECT item_id FROM ${TwoTestTable.quoted} AS L1 " +
+        s"INNER JOIN (SELECT * FROM ${ThreeTestTable.quoted}) AS R1 ON L1.item_id = R1.item_id " +
+        s"GLOBAL INNER JOIN (SELECT * FROM ${OneTestTable.quoted}) AS R2 ON L1.item_id = R2.item_id FORMAT JSON"
+    )
+  }
+
+  it should "refuse USING or ON with no join to attach them to" in {
+    an[IllegalArgumentException] should be thrownBy select(itemId).from(TwoTestTable).using(itemId)
+    an[IllegalArgumentException] should be thrownBy select(itemId).from(TwoTestTable).on(itemId)
+  }
 }

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/QueryClausesTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/QueryClausesTest.scala
@@ -171,6 +171,10 @@ class QueryClausesTest extends DslTestSpec {
     )
   }
 
+  it should "refuse WITH TIES with no size to extend" in {
+    an[IllegalArgumentException] should be thrownBy Limit(None, 5, withTies = true)
+  }
+
   "OFFSET" should "render on its own, with no LIMIT" in {
     sql(select(shieldId).from(OneTestTable).offset(5)) should matchSQL(
       s"SELECT shield_id FROM ${OneTestTable.quoted} OFFSET 5"

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/QueryClausesTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/QueryClausesTest.scala
@@ -147,4 +147,77 @@ class QueryClausesTest extends DslTestSpec {
     val query = select(itemId).from(TwoTestTable).join(JoinQuery.PasteJoin, ThreeTestTable) on itemId
     an[IllegalArgumentException] should be thrownBy sql(query)
   }
+
+  "LIMIT" should "render offset and size" in {
+    sql(select(shieldId).from(OneTestTable).limit(10, 5)) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} LIMIT 5, 10"
+    )
+  }
+
+  it should "render a size on its own" in {
+    sql(select(shieldId).from(OneTestTable).limit(10)) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} LIMIT 0, 10"
+    )
+  }
+
+  // WITH TIES parses only at the end of the clause, and only after `LIMIT offset, size` -- neither
+  // `LIMIT size WITH TIES OFFSET offset` nor `LIMIT size OFFSET offset WITH TIES` is accepted.
+  it should "render WITH TIES last, alone and with an offset" in {
+    sql(select(shieldId).from(OneTestTable).limitWithTies(10)) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} LIMIT 0, 10 WITH TIES"
+    )
+    sql(select(shieldId).from(OneTestTable).limitWithTies(10, 5)) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} LIMIT 5, 10 WITH TIES"
+    )
+  }
+
+  "OFFSET" should "render on its own, with no LIMIT" in {
+    sql(select(shieldId).from(OneTestTable).offset(5)) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} OFFSET 5"
+    )
+  }
+
+  it should "keep a size that was already set" in {
+    sql(select(shieldId).from(OneTestTable).limit(10).offset(5)) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} LIMIT 5, 10"
+    )
+  }
+
+  // ClickHouse fixes this order and rejects any other: NULLS after the direction, COLLATE after NULLS, WITH FILL last.
+  "ORDER BY" should "render NULLS FIRST and NULLS LAST" in {
+    sql(
+      select(shieldId)
+        .from(OneTestTable)
+        .orderByColumns(OrderingColumn(shieldId, DESC, nulls = Option(NullsOrder.NullsFirst)))
+    ) should matchSQL(s"SELECT shield_id FROM ${OneTestTable.quoted} ORDER BY shield_id DESC NULLS FIRST")
+    sql(
+      select(shieldId)
+        .from(OneTestTable)
+        .orderByColumns(OrderingColumn(shieldId, ASC, nulls = Option(NullsOrder.NullsLast)))
+    ) should matchSQL(s"SELECT shield_id FROM ${OneTestTable.quoted} ORDER BY shield_id ASC NULLS LAST")
+  }
+
+  it should "render COLLATE, quoted as a literal" in {
+    sql(select(shieldId).from(OneTestTable).orderByColumns(OrderingColumn(shieldId, collate = Option("en")))) should
+    matchSQL(s"SELECT shield_id FROM ${OneTestTable.quoted} ORDER BY shield_id ASC COLLATE 'en'")
+  }
+
+  it should "render direction, NULLS, COLLATE and WITH FILL in the order the grammar requires" in {
+    sql(
+      select(shieldId)
+        .from(OneTestTable)
+        .orderByColumns(
+          OrderingColumn(
+            shieldId,
+            DESC,
+            fill = Option(WithFill(step = Option(const(1)))),
+            nulls = Option(NullsOrder.NullsLast),
+            collate = Option("en")
+          )
+        )
+    ) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} " +
+        s"ORDER BY shield_id DESC NULLS LAST COLLATE 'en' WITH FILL STEP 1"
+    )
+  }
 }

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/SetOperationTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/SetOperationTest.scala
@@ -1,0 +1,79 @@
+package com.crobox.clickhouse.dsl
+
+import com.crobox.clickhouse.DslTestSpec
+
+/**
+ * `UNION` / `INTERSECT` / `EXCEPT`.
+ *
+ * The chain renders flat, which only reads left to right while every step shares one precedence level. `INTERSECT`
+ * binds tighter than the other two, so mixing it in is refused rather than silently reordered.
+ */
+class SetOperationTest extends DslTestSpec {
+
+  private def sql(query: OperationalQuery): String = toSql(query.internalQuery, None)
+
+  private val left  = select(shieldId) from OneTestTable
+  private val right = select(itemId) from TwoTestTable
+
+  private def combined(keyword: String) =
+    s"SELECT shield_id FROM ${OneTestTable.quoted} $keyword SELECT item_id FROM ${TwoTestTable.quoted}"
+
+  "UNION ALL" should "render" in {
+    sql(left.unionAll(right)) should matchSQL(combined("UNION ALL"))
+  }
+
+  "UNION DISTINCT" should "render" in {
+    sql(left.unionDistinct(right)) should matchSQL(combined("UNION DISTINCT"))
+  }
+
+  "INTERSECT" should "render, with and without DISTINCT" in {
+    sql(left.intersect(right)) should matchSQL(combined("INTERSECT"))
+    sql(left.intersectDistinct(right)) should matchSQL(combined("INTERSECT DISTINCT"))
+  }
+
+  "EXCEPT" should "render, with and without DISTINCT" in {
+    sql(left.except(right)) should matchSQL(combined("EXCEPT"))
+    sql(left.exceptDistinct(right)) should matchSQL(combined("EXCEPT DISTINCT"))
+  }
+
+  it should "chain with UNION, which shares its precedence" in {
+    val third = select(itemId) from ThreeTestTable
+    sql(left.except(right).unionAll(third)) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} EXCEPT SELECT item_id FROM ${TwoTestTable.quoted} " +
+        s"UNION ALL SELECT item_id FROM ${ThreeTestTable.quoted}"
+    )
+  }
+
+  // `a UNION ALL b INTERSECT c` is `a UNION ALL (b INTERSECT c)`, so a flat Seq in that order would render SQL that
+  // does not mean what the call order says.
+  "A chain mixing INTERSECT with UNION or EXCEPT" should "be refused rather than reordered" in {
+    val third = select(itemId) from ThreeTestTable
+    an[IllegalArgumentException] should be thrownBy left.unionAll(right).intersect(third)
+    an[IllegalArgumentException] should be thrownBy left.intersect(right).unionAll(third)
+    an[IllegalArgumentException] should be thrownBy left.except(right).intersect(third)
+  }
+
+  it should "be expressible by nesting the INTERSECT in a subquery" in {
+    val third  = select(itemId) from ThreeTestTable
+    val nested = select(itemId) from right.intersect(third)
+    sql(left.unionAll(nested)) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} UNION ALL SELECT item_id FROM " +
+        s"(SELECT item_id FROM ${TwoTestTable.quoted} INTERSECT SELECT item_id FROM ${ThreeTestTable.quoted})"
+    )
+  }
+
+  it should "still allow a chain of INTERSECTs, which share one level" in {
+    val third = select(itemId) from ThreeTestTable
+    sql(left.intersect(right).intersectDistinct(third)) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} INTERSECT SELECT item_id FROM ${TwoTestTable.quoted} " +
+        s"INTERSECT DISTINCT SELECT item_id FROM ${ThreeTestTable.quoted}"
+    )
+  }
+
+  "Every set operation" should "require matching column counts" in {
+    val wider = select(shieldId, itemId) from OneTestTable
+    an[IllegalArgumentException] should be thrownBy left.unionDistinct(wider)
+    an[IllegalArgumentException] should be thrownBy left.intersect(wider)
+    an[IllegalArgumentException] should be thrownBy left.except(wider)
+  }
+}

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/SetOperationTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/SetOperationTest.scala
@@ -53,6 +53,34 @@ class SetOperationTest extends DslTestSpec {
     an[IllegalArgumentException] should be thrownBy left.except(right).intersect(third)
   }
 
+  // A flat chain reads left to right, so `a UNION ALL b EXCEPT c` groups as `(a UNION ALL b) EXCEPT c`. Set difference
+  // is not associative, so rendering a nested right operand flat silently returns a different set.
+  "A branch that carries set operations of its own" should "be parenthesised" in {
+    val third = select(itemId) from ThreeTestTable
+    sql(left.unionAll(right.except(third))) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} UNION ALL " +
+        s"(SELECT item_id FROM ${TwoTestTable.quoted} EXCEPT SELECT item_id FROM ${ThreeTestTable.quoted})"
+    )
+  }
+
+  it should "be parenthesised even where the two kinds match" in {
+    val third = select(itemId) from ThreeTestTable
+    sql(left.unionAll(right.unionAll(third))) should matchSQL(
+      s"SELECT shield_id FROM ${OneTestTable.quoted} UNION ALL " +
+        s"(SELECT item_id FROM ${TwoTestTable.quoted} UNION ALL SELECT item_id FROM ${ThreeTestTable.quoted})"
+    )
+  }
+
+  it should "not be refused the way a flat mixed chain is, because the nesting says which grouping was meant" in {
+    val third = select(itemId) from ThreeTestTable
+    noException should be thrownBy left.unionAll(right.intersect(third))
+    sql(left.unionAll(right.intersect(third))) should include("UNION ALL (SELECT")
+  }
+
+  it should "leave a plain branch unparenthesised" in {
+    sql(left.unionAll(right)) should matchSQL(combined("UNION ALL"))
+  }
+
   it should "be expressible by nesting the INTERSECT in a subquery" in {
     val third  = select(itemId) from ThreeTestTable
     val nested = select(itemId) from right.intersect(third)

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerTest.scala
@@ -121,7 +121,7 @@ class ClickhouseTokenizerTest extends DslTestSpec {
       InternalQuery(
         Some(select),
         Some(TableFromQuery[OneTestTable.type](OneTestTable)),
-        join = Some(
+        joins = Seq(
           JoinQuery(JoinQuery.InnerJoin, TableFromQuery[OneTestTable.type](OneTestTable), using = Seq(shieldId))
         )
       )
@@ -153,7 +153,7 @@ class ClickhouseTokenizerTest extends DslTestSpec {
       InternalQuery(
         Some(select),
         Some(TableFromQuery[OneTestTable.type](OneTestTable)),
-        join = Some(
+        joins = Seq(
           JoinQuery(
             JoinQuery.AnyLeftJoin,
             InnerFromQuery(


### PR DESCRIPTION
> Stacked on #372. Review that one first; this diff is against it.

Four clause-level gaps in one pass, because all four touch `InternalQuery` and each would otherwise be its own breaking change. They share the positional destructure in `toRawSql`, the named arguments in `:+>` and `+`, and the field inventory `InternalQueryFieldsTest` guards — doing them together means one pass over the merge semantics instead of four.

## Set operations

`unionAll: Seq[OperationalQuery]` becomes `combinations: Seq[SetOperation]`, covering `UNION ALL`, `UNION DISTINCT`, `INTERSECT`, `INTERSECT DISTINCT`, `EXCEPT` and `EXCEPT DISTINCT`.

The chain still renders flat, which only reads left to right while every step shares one precedence level. `INTERSECT` binds tighter, so `a UNION ALL b INTERSECT c` means `a UNION ALL (b INTERSECT c)` — not what a `Seq` in that order looks like. A chain mixing them is **refused** rather than silently parenthesised, because either reading is a plausible thing to have meant; nesting the `INTERSECT` in a subquery says which.

## Join chains

`join: Option[JoinQuery]` becomes `joins: Seq[JoinQuery]`, so three tables no longer need a subquery.

Every join in a chain keys off the *first* table: the left alias is claimed once and reused while the right aliases count up, giving `L1 … R1 … R2`. A join keyed off an earlier join's right-hand side still has to nest, because a `JoinCondition` names a column and not the table it came from. `using` and `on` attach to the join most recently added, so `.join(a).using(k).join(b).using(k)` reads as it looks.

## LIMIT and OFFSET

`size` becomes an `Option`, which is what makes a bare `OFFSET n` expressible — folding the offset into `LIMIT offset, size`, the only form this used to render, cannot say that. Plus `WITH TIES`.

`WITH TIES` parses only at the very end of the clause and only after the `LIMIT offset, size` spelling. Both `LIMIT size WITH TIES OFFSET offset` and `LIMIT size OFFSET offset WITH TIES` are syntax errors — the first was my initial rendering, and the validation harness caught it.

## ORDER BY modifiers

`NULLS FIRST`/`NULLS LAST` and `COLLATE`. The grammar fixes the order at `expr [ASC|DESC] [NULLS …] [COLLATE …] [WITH FILL …]` and rejects every other arrangement, so all three keyword orders were checked against a server before the tokenizer was written. `nulls` and `collate` come after `fill` in the parameter list but before it in the emitted SQL, so existing positional `OrderingColumn(col, DESC, Option(WithFill()))` call sites still compile.

## Incidental

The join chain now renders from a filtered `Seq` rather than `stripMargin`, which drops the stray double space `GLOBAL` used to emit — invisible through `matchSQL`, which normalises whitespace.

## Testing

Behavioural ITs alongside the harness entries: the harness cannot tell `UNION ALL` from `UNION DISTINCT`, a chain that joins the right tables from one that merely parses, or `NULLS FIRST` from a plain direction.

Green on 2.13.18 and 3.3.8, and against a live 25.3 server.

## Breaking changes

- `InternalQuery.unionAll` → `combinations`, retyped to `Seq[SetOperation]`
- `InternalQuery.join` → `joins`, retyped to `Seq[JoinQuery]`
- `Limit.size` becomes `Option[Long]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
