### PR TITLE
Open the FROM ADT for table functions

### DIFF
--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/TableFunctionIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/TableFunctionIT.scala
@@ -1,0 +1,55 @@
+package com.crobox.clickhouse.dsl
+
+import com.crobox.clickhouse.{dsl, DslITSpec}
+
+/**
+ * Table functions executed rather than only rendered, so an argument order that parses either way is still caught.
+ *
+ * Qualified as `dsl.numbers` / `dsl.all`: an inherited member shadows an imported one, and this spec inherits both a
+ * `numbers` column from the test schema and ScalaTest's `all` matcher.
+ */
+class TableFunctionIT extends DslITSpec {
+
+  private def longs(query: OperationalQuery, column: String): Seq[Long] =
+    queryExecutor.executeRows(query).futureValue.rows.map(_.requiredByName[Long](column))
+
+  "numbers" should "count up from zero" in {
+    longs(select(dsl.all) from dsl.numbers(3), "number") shouldBe Seq(0, 1, 2)
+  }
+
+  it should "count up from the offset when given one" in {
+    longs(select(dsl.all) from dsl.numbers(10, 3), "number") shouldBe Seq(10, 11, 12)
+  }
+
+  "zeros" should "produce the row count without a counter" in {
+    val rows = queryExecutor.executeRows(select(dsl.all) from dsl.zeros(3)).futureValue.rows
+    rows should have size 3
+    rows.head.names shouldBe Seq("zero")
+  }
+
+  "values" should "build an inline table, in row order" in {
+    val rows = queryExecutor
+      .executeRows(select(dsl.all) from dsl.values(tuple(const(1), const("x")), tuple(const(2), const("y"))))
+      .futureValue
+      .rows
+    rows.map(_.requiredByName[String]("c2")) shouldBe Seq("x", "y")
+  }
+
+  it should "name and type the columns when given a structure" in {
+    val rows = queryExecutor
+      .executeRows(select(dsl.all) from valuesWithStructure("a UInt32", const(7), const(8)))
+      .futureValue
+      .rows
+    rows.map(_.requiredByName[Int]("a")) shouldBe Seq(7, 8)
+  }
+
+  "A table function" should "work under an alias and as a join right-hand side" in {
+    longs(select(ref[Long]("number")) from (dsl.numbers(2), "n"), "number") shouldBe Seq(0, 1)
+
+    // CROSS JOIN against two generated rows doubles the left side.
+    val crossed = select(shieldId).from(OneTestTable).join(JoinQuery.CrossJoin, dsl.numbers(2))
+    queryExecutor.executeRows(crossed).futureValue.rows should have size (table1Entries.size * 2)
+  }
+
+  override val table1Entries: Seq[Table1Entry] = Seq(Table1Entry(java.util.UUID.randomUUID()))
+}

--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
@@ -683,6 +683,44 @@ class SqlValidationITSpec extends DslITSpec {
         .orderByColumns(OrderingColumn(col2, ASC, Option(WithFill())))
         .interpolate()
     ),
+    Construct("numbers", select(com.crobox.clickhouse.dsl.all).from(com.crobox.clickhouse.dsl.numbers(3))),
+    Construct(
+      "numbers from an offset",
+      select(com.crobox.clickhouse.dsl.all).from(com.crobox.clickhouse.dsl.numbers(10, 3))
+    ),
+    Construct("zeros", select(com.crobox.clickhouse.dsl.all).from(com.crobox.clickhouse.dsl.zeros(3))),
+    Construct(
+      "values as rows",
+      select(com.crobox.clickhouse.dsl.all)
+        .from(com.crobox.clickhouse.dsl.values(tuple(const(1), const("x")), tuple(const(2), const("y"))))
+    ),
+    Construct(
+      "values with a structure",
+      select(com.crobox.clickhouse.dsl.all).from(valuesWithStructure("a UInt32", const(1), const(2)))
+    ),
+    Construct("merge", select(com.crobox.clickhouse.dsl.all).from(mergeTables("system", "^one$"))),
+    Construct("generateRandom", select(com.crobox.clickhouse.dsl.all).from(generateRandom("a UInt8"))),
+    Construct(
+      "generateRandom, seeded",
+      select(com.crobox.clickhouse.dsl.all).from(generateRandom("a UInt8", 1, 1, 1))
+    ),
+    Construct("remote", select(count()).from(remote("localhost:9000", "system", "one"))),
+    // Syntax only: resolving a cluster reads the server's own configuration, and the test server declares only
+    // `default` -- which is a property of the fixture rather than of the rendering.
+    syn("cluster", select(count()).from(cluster("test_cluster", "system", "one"))),
+    Construct(
+      "a table function with an alias",
+      select(ref[Long]("number")).from(com.crobox.clickhouse.dsl.numbers(3), "n")
+    ),
+    Construct(
+      "a table function as a join right-hand side",
+      select(shieldId).from(OneTestTable).join(JoinQuery.CrossJoin, com.crobox.clickhouse.dsl.numbers(3))
+    ),
+    Construct(
+      "a table function as a subquery source",
+      select(com.crobox.clickhouse.dsl.all)
+        .from(select(com.crobox.clickhouse.dsl.all).from(com.crobox.clickhouse.dsl.numbers(3)))
+    ),
     Construct(
       "order by nulls first",
       select(col2).from(TwoTestTable).orderByColumns(OrderingColumn(col2, DESC, nulls = Option(NullsOrder.NullsFirst)))

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/FromQuery.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/FromQuery.scala
@@ -9,6 +9,15 @@ package com.crobox.clickhouse.dsl
  */
 case class Sample(rate: Double, offset: Option[Double] = None)
 
+/**
+ * A table function standing where a table would, as in `FROM numbers(10)`.
+ *
+ * Arguments are [[Column]]s so that the existing literal rendering applies -- `const("system")` becomes `'system'`. A
+ * table function that takes a query rather than values, such as `view`, has no representation here; the DSL already
+ * puts a subquery in `FROM` directly.
+ */
+case class TableFunction(name: String, args: Seq[Column] = Seq.empty)
+
 sealed trait FromQuery extends Query with OperationalQuery {
   override val internalQuery: InternalQuery = InternalQuery(from = Some(this))
   val alias: Option[String]
@@ -34,3 +43,13 @@ sealed case class TableFromQuery[T <: Table](
     finalized: Boolean = false,
     sampling: Option[Sample] = None
 ) extends FromQuery
+
+/**
+ * `FROM <function>(args)`.
+ *
+ * Neither FINAL nor SAMPLE applies: both read something the table's engine declares, and a function has no engine.
+ */
+sealed case class TableFunctionFromQuery(function: TableFunction, alias: Option[String] = None) extends FromQuery {
+  override val finalized                = false
+  override val sampling: Option[Sample] = None
+}

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/OperationalQuery.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/OperationalQuery.scala
@@ -41,8 +41,9 @@ trait OperationalQuery extends Query {
     OperationalQuery(
       internalQuery.from
         .map {
-          case query: InnerFromQuery    => internalQuery.copy(from = Some(query.copy(alias = Option(alias))))
-          case table: TableFromQuery[_] => internalQuery.copy(from = Some(table.copy(alias = Option(alias))))
+          case query: InnerFromQuery      => internalQuery.copy(from = Some(query.copy(alias = Option(alias))))
+          case table: TableFromQuery[_]   => internalQuery.copy(from = Some(table.copy(alias = Option(alias))))
+          case fn: TableFunctionFromQuery => internalQuery.copy(from = Some(fn.copy(alias = Option(alias))))
         }
         .getOrElse(internalQuery)
     )
@@ -56,6 +57,13 @@ trait OperationalQuery extends Query {
   def from(query: OperationalQuery): OperationalQuery =
     OperationalQuery(internalQuery.copy(from = Some(InnerFromQuery(query))))
 
+  /** `FROM <function>(args)`, as in `select(all).from(numbers(10))`. */
+  def from(function: TableFunctionFromQuery): OperationalQuery =
+    OperationalQuery(internalQuery.copy(from = Some(function)))
+
+  def from(function: TableFunctionFromQuery, alias: String): OperationalQuery =
+    OperationalQuery(internalQuery.copy(from = Some(function.copy(alias = Option(alias)))))
+
   def from(query: OperationalQuery, alias: String): OperationalQuery =
     OperationalQuery(internalQuery.copy(from = Some(InnerFromQuery(query, alias = Option(alias)))))
 
@@ -67,6 +75,8 @@ trait OperationalQuery extends Query {
         .map {
           case _: InnerFromQuery =>
             throw new IllegalArgumentException("It's ILLEGAL to set FINAL on a (sub)query FROM query")
+          case _: TableFunctionFromQuery =>
+            throw new IllegalArgumentException("It's ILLEGAL to set FINAL on a table function: it has no engine")
           case table: TableFromQuery[_] =>
             internalQuery.copy(from = Option(table.copy(finalized = true)))
         }
@@ -87,6 +97,8 @@ trait OperationalQuery extends Query {
         .map {
           case _: InnerFromQuery =>
             throw new IllegalArgumentException("It's ILLEGAL to set SAMPLE on a (sub)query FROM query")
+          case _: TableFunctionFromQuery =>
+            throw new IllegalArgumentException("It's ILLEGAL to set SAMPLE on a table function: it has no sampling key")
           case table: TableFromQuery[_] =>
             internalQuery.copy(from = Option(table.copy(sampling = Option(Sample(rate, offset)))))
         }
@@ -332,6 +344,22 @@ trait OperationalQuery extends Query {
     require(internalQuery.joins.nonEmpty, "No join to attach USING or ON to")
     OperationalQuery(internalQuery.copy(joins = internalQuery.joins.init :+ f(internalQuery.joins.last)))
   }
+
+  /**
+   * A table function on the right-hand side.
+   *
+   * Needed as its own overload because [[FromQuery]] extends [[OperationalQuery]]: without it a table function takes
+   * the subquery overload, is wrapped in an `InnerFromQuery`, and renders as `(FROM numbers(3))` -- a `SELECT`-less
+   * subquery.
+   */
+  def join(joinType: JoinQuery.JoinType, function: TableFunctionFromQuery, global: Boolean): OperationalQuery =
+    addJoin(JoinQuery(joinType, function, global = global))
+
+  def join(joinType: JoinQuery.JoinType, function: TableFunctionFromQuery): OperationalQuery =
+    join(joinType = joinType, function = function, global = false)
+
+  def globalJoin(joinType: JoinQuery.JoinType, function: TableFunctionFromQuery): OperationalQuery =
+    join(joinType = joinType, function = function, global = true)
 
   def join[TargetTable <: Table](joinType: JoinQuery.JoinType, query: OperationalQuery): OperationalQuery =
     join(joinType = joinType, query = query, global = false)

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/TableFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/TableFunctions.scala
@@ -1,0 +1,86 @@
+package com.crobox.clickhouse.dsl
+
+import com.crobox.clickhouse.dsl.marshalling.QueryValueFormats._
+
+/**
+ * Table functions, which stand where a table would in `FROM`.
+ *
+ * [[tableFunction]] reaches any of them, including the ones with no wrapper here and any the server gains later; the
+ * named builders below exist for the common ones. Their arguments are [[Column]]s, so `const` renders a literal and
+ * `tuple` renders a row.
+ *
+ * https://clickhouse.com/docs/sql-reference/table-functions
+ */
+trait TableFunctions {
+
+  /** Any table function, by name. The escape hatch, and what every builder below is built on. */
+  def tableFunction(name: String, args: Column*): TableFunctionFromQuery =
+    TableFunctionFromQuery(TableFunction(name, args))
+
+  /** `numbers(count)`, a single UInt64 column counting up from zero. */
+  def numbers(count: Long): TableFunctionFromQuery = tableFunction("numbers", const(count))
+
+  /** `numbers(start, count)`. */
+  def numbers(start: Long, count: Long): TableFunctionFromQuery =
+    tableFunction("numbers", const(start), const(count))
+
+  /** `zeros(count)`, which is [[numbers]] without the counter -- cheaper when only the row count matters. */
+  def zeros(count: Long): TableFunctionFromQuery = tableFunction("zeros", const(count))
+
+  /** `values(rows)`, an inline table. Build each row with `tuple(...)`; a single-column table can take bare values. */
+  def values(row: Column, rows: Column*): TableFunctionFromQuery = tableFunction("values", (row +: rows): _*)
+
+  /** `values('structure', rows)`, naming and typing the columns rather than leaving them as `c1`, `c2`. */
+  def valuesWithStructure(structure: String, row: Column, rows: Column*): TableFunctionFromQuery =
+    tableFunction("values", (const(structure) +: row +: rows): _*)
+
+  /**
+   * `merge(database, tablesRegexp)`, reading every table in `database` whose name matches.
+   *
+   * Named `mergeTables` rather than `merge`: the `-Merge` aggregate combinator already holds that name in the same
+   * import, and an overload between a combinator and a table function would resolve by argument type rather than by
+   * intent.
+   */
+  def mergeTables(database: String, tablesRegexp: String): TableFunctionFromQuery =
+    tableFunction("merge", const(database), const(tablesRegexp))
+
+  /** `remote(addresses, database, table)`. */
+  def remote(addresses: String, database: String, table: String): TableFunctionFromQuery =
+    tableFunction("remote", const(addresses), const(database), const(table))
+
+  def remote(
+      addresses: String,
+      database: String,
+      table: String,
+      user: String,
+      password: String
+  ): TableFunctionFromQuery =
+    tableFunction("remote", const(addresses), const(database), const(table), const(user), const(password))
+
+  /** `cluster(name, database, table)`, which reads a cluster from the server's own configuration. */
+  def cluster(name: String, database: String, table: String): TableFunctionFromQuery =
+    tableFunction("cluster", const(name), const(database), const(table))
+
+  /** `clusterAllReplicas(name, database, table)`, which unlike [[cluster]] reads every replica rather than one. */
+  def clusterAllReplicas(name: String, database: String, table: String): TableFunctionFromQuery =
+    tableFunction("clusterAllReplicas", const(name), const(database), const(table))
+
+  /** `generateRandom('structure')`, rows of random values matching the structure. */
+  def generateRandom(structure: String): TableFunctionFromQuery =
+    tableFunction("generateRandom", const(structure))
+
+  /** `generateRandom('structure', seed, maxStringLength, maxArrayLength)`, for a reproducible sequence. */
+  def generateRandom(
+      structure: String,
+      randomSeed: Long,
+      maxStringLength: Long,
+      maxArrayLength: Long
+  ): TableFunctionFromQuery =
+    tableFunction(
+      "generateRandom",
+      const(structure),
+      const(randomSeed),
+      const(maxStringLength),
+      const(maxArrayLength)
+    )
+}

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -290,9 +290,11 @@ trait ClickhouseTokenizerModule
   ): String = {
     require(from != null)
     val fromClause = from match {
-      case Some(query: InnerFromQuery)    => s"(${toRawSql(query.innerQuery.internalQuery).trim})"
-      case Some(table: TableFromQuery[_]) => table.table.quoted + ctx.tableAlias(table.table)
-      case _                              => return ""
+      case Some(query: InnerFromQuery)      => s"(${toRawSql(query.innerQuery.internalQuery).trim})"
+      case Some(table: TableFromQuery[_])   => table.table.quoted + ctx.tableAlias(table.table)
+      case Some(fn: TableFunctionFromQuery) =>
+        s"${fn.function.name}(${fn.function.args.map(tokenizeColumn).mkString(Tokens.Delimiter)})"
+      case _ => return ""
     }
 
     val prefix = if (withPrefix) "FROM" else ""
@@ -474,7 +476,9 @@ trait ClickhouseTokenizerModule
         // we always need to provide an alias to the RIGHT side
         val right = query.other match {
           case table: TableFromQuery[_] => s"(SELECT * ${tokenizeFrom(Some(table))})"
-          case query: InnerFromQuery    => tokenizeFrom(Some(query), withPrefix = false)
+          // Wrapped for the same reason a table is: a bare join right-hand side contributes no columns to `SELECT *`.
+          case fn: TableFunctionFromQuery => s"(SELECT * ${tokenizeFrom(Some(fn))})"
+          case query: InnerFromQuery      => tokenizeFrom(Some(query), withPrefix = false)
         }
 
         Seq(

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/misc/DSLImprovements.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/misc/DSLImprovements.scala
@@ -107,9 +107,11 @@ object DSLImprovements {
       OperationalQuery(query.internalQuery.copy(where = Some(comparison)))
     }
 
+    /** The table this selects from, where it is a table at all -- a subquery and a table function both give `None`. */
     def selectFromTable[T <: Table](): Option[T] = query.internalQuery.from.flatMap {
-      case _: InnerFromQuery    => None
-      case x: TableFromQuery[_] => Option(x.table.asInstanceOf[T])
+      case _: InnerFromQuery         => None
+      case _: TableFunctionFromQuery => None
+      case x: TableFromQuery[_]      => Option(x.table.asInstanceOf[T])
     }
 
     def insertConstraint(condition: Option[ExpressionColumn[Boolean]]): OperationalQuery =

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/package.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/package.scala
@@ -5,7 +5,7 @@ import com.crobox.clickhouse.dsl.marshalling.{QueryValue, QueryValueFormats}
 
 import scala.util.Try
 
-package object dsl extends ClickhouseColumnFunctions with QueryFactory with QueryValueFormats {
+package object dsl extends ClickhouseColumnFunctions with QueryFactory with QueryValueFormats with TableFunctions {
 
   /**
    * Exposes the OperationalQuery.+ operator on Try[OperationalQuery]

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/TableFunctionTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/TableFunctionTest.scala
@@ -75,4 +75,13 @@ class TableFunctionTest extends DslTestSpec {
     an[IllegalArgumentException] should be thrownBy select(dsl.all).from(dsl.numbers(3)).asFinal
     an[IllegalArgumentException] should be thrownBy select(dsl.all).from(dsl.numbers(3)).sample(0.1)
   }
+
+  // selectFromTable matched only the two cases FromQuery used to have, so a third made it throw MatchError at runtime
+  // for any query built on a table function. It is public API, so this is the regression the ADT change could cause.
+  it should "give None from selectFromTable rather than throwing" in {
+    import com.crobox.clickhouse.dsl.misc.DSLImprovements._
+    select(dsl.all).from(dsl.numbers(3)).selectFromTable[Table]() shouldBe None
+    select(itemId).from(TwoTestTable).selectFromTable[Table]() shouldBe Option(TwoTestTable)
+    select(itemId).from(select(itemId).from(TwoTestTable)).selectFromTable[Table]() shouldBe None
+  }
 }

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/TableFunctionTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/TableFunctionTest.scala
@@ -1,0 +1,78 @@
+package com.crobox.clickhouse.dsl
+
+import com.crobox.clickhouse.{dsl, DslTestSpec}
+
+/**
+ * Table functions in `FROM`.
+ *
+ * Qualified as `dsl.numbers` / `dsl.all` throughout: an inherited member shadows an imported one, and this spec
+ * inherits both a `numbers` column from the test schema and ScalaTest's `all` matcher. Neither collides for a caller
+ * who has not defined their own.
+ */
+class TableFunctionTest extends DslTestSpec {
+
+  private def sql(query: OperationalQuery): String = toSql(query.internalQuery, None)
+
+  it should "render numbers at both arities" in {
+    sql(select(dsl.all).from(dsl.numbers(3))) should matchSQL("SELECT * FROM numbers(3)")
+    sql(select(dsl.all).from(dsl.numbers(10, 3))) should matchSQL("SELECT * FROM numbers(10, 3)")
+  }
+
+  it should "render zeros" in {
+    sql(select(dsl.all).from(dsl.zeros(3))) should matchSQL("SELECT * FROM zeros(3)")
+  }
+
+  it should "render values, as rows and with a structure" in {
+    sql(select(dsl.all).from(dsl.values(tuple(const(1), const("x")), tuple(const(2), const("y"))))) should matchSQL(
+      "SELECT * FROM values((1, 'x'), (2, 'y'))"
+    )
+    sql(select(dsl.all).from(valuesWithStructure("a UInt32", const(1), const(2)))) should matchSQL(
+      "SELECT * FROM values('a UInt32', 1, 2)"
+    )
+  }
+
+  it should "render merge under its own builder name" in {
+    sql(select(dsl.all).from(mergeTables("system", "^one$"))) should matchSQL("SELECT * FROM merge('system', '^one$')")
+  }
+
+  it should "render remote and cluster" in {
+    sql(select(dsl.all).from(remote("localhost:9000", "system", "one"))) should matchSQL(
+      "SELECT * FROM remote('localhost:9000', 'system', 'one')"
+    )
+    sql(select(dsl.all).from(cluster("default", "system", "one"))) should matchSQL(
+      "SELECT * FROM cluster('default', 'system', 'one')"
+    )
+  }
+
+  it should "render generateRandom at both arities" in {
+    sql(select(dsl.all).from(generateRandom("a UInt8"))) should matchSQL("SELECT * FROM generateRandom('a UInt8')")
+    sql(select(dsl.all).from(generateRandom("a UInt8", 1, 2, 3))) should matchSQL(
+      "SELECT * FROM generateRandom('a UInt8', 1, 2, 3)"
+    )
+  }
+
+  it should "reach a function that has no builder" in {
+    sql(select(dsl.all).from(tableFunction("nulls", const(1)))) should matchSQL("SELECT * FROM nulls(1)")
+    sql(select(dsl.all).from(tableFunction("noArgsAtAll"))) should matchSQL("SELECT * FROM noArgsAtAll()")
+  }
+
+  it should "take an alias, both ways round" in {
+    sql(select(dsl.all).from(dsl.numbers(3), "n")) should matchSQL("SELECT * FROM numbers(3) AS n")
+    sql(select(dsl.all).from(dsl.numbers(3)).as("n")) should matchSQL("SELECT * FROM numbers(3) AS n")
+  }
+
+  it should "work as a subquery source and as a join right-hand side" in {
+    sql(select(dsl.all).from(select(dsl.all).from(dsl.numbers(3)))) should matchSQL(
+      "SELECT * FROM (SELECT * FROM numbers(3))"
+    )
+    sql(select(itemId).from(TwoTestTable).join(JoinQuery.CrossJoin, dsl.numbers(3))) should matchSQL(
+      s"SELECT item_id FROM ${TwoTestTable.quoted} AS L1 CROSS JOIN (SELECT * FROM numbers(3)) AS R1"
+    )
+  }
+
+  // Both read something the table's engine declares, and a function has no engine.
+  it should "refuse FINAL and SAMPLE" in {
+    an[IllegalArgumentException] should be thrownBy select(dsl.all).from(dsl.numbers(3)).asFinal
+    an[IllegalArgumentException] should be thrownBy select(dsl.all).from(dsl.numbers(3)).sample(0.1)
+  }
+}


### PR DESCRIPTION
> Stacked on #373. Review that one first; this diff is against it.

`FromQuery` was sealed with exactly two cases, so `FROM numbers(10)` was unreachable and nothing outside the package could add it.

Opening the ADT is the part that has to happen while the API can still break — a third case breaks exhaustive matches downstream. Individual functions are additive afterwards, which is why the set below is deliberately small: the point of the PR is the third case, not the roster.

## What this adds

`TableFunctionFromQuery`, plus builders for `numbers`, `zeros`, `values`, `merge`, `remote`, `cluster`, `clusterAllReplicas` and `generateRandom` — and a generic `tableFunction(name, args*)` so anything without a wrapper, or anything the server gains later, is reachable without waiting for one.

Arguments are `Column`s, which means the existing literal rendering applies: `const("system")` becomes `'system'` and `tuple(...)` becomes a row. Functions that take a *query* rather than values, such as `view`, have no representation here — a subquery already goes in `FROM` directly.

`file`/`url`/`s3` are left for later; they need credential and format plumbing that has nothing to do with the ADT change.

## Two collisions worth naming

**`mergeTables`, not `merge`.** The `-Merge` aggregate combinator already holds that name in the same import, and an overload between the two would resolve by argument type rather than by intent.

**`join` needed its own overload.** `FromQuery extends OperationalQuery`, so without a `TableFunctionFromQuery` overload a table function took the *subquery* overload, got wrapped in an `InnerFromQuery`, and rendered as `(FROM numbers(3))` — a `SELECT`-less subquery. The tests caught it.

## FINAL and SAMPLE

Refused, for the reason a subquery refuses them: both read something the table's engine declares, and a function has no engine.

## Testing

Registered in the validation harness, with `cluster` at syntax level only since resolving one reads the server's own configuration. `TableFunctionIT` executes them, so an argument order that parses either way is still caught.

Green on 2.13.18 and 3.3.8, and against a live 25.3 server.

## Breaking changes

- `FromQuery` gains a third case, so exhaustive matches over it need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
