### PR TITLE
Add the data-changing statements

### DIFF
--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/StatementIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/StatementIT.scala
@@ -1,0 +1,118 @@
+package com.crobox.clickhouse.dsl
+
+import com.crobox.clickhouse.DslITSpec
+import com.crobox.clickhouse.dsl.schemabuilder.{ColumnType, CreateTable, Engine}
+import spray.json.DefaultJsonProtocol._
+import spray.json.RootJsonFormat
+
+/**
+ * The data-changing statements, executed. Needs its own table: the shared fixtures are Engine.Memory, which supports
+ * neither lightweight deletes nor mutations, and a DROP PARTITION needs something partitioned to drop.
+ */
+class StatementIT extends DslITSpec {
+
+  private object MutableTable extends Table {
+    override val database             = StatementIT.this.database
+    override val name                 = "mutableTestTable"
+    val part: NativeColumn[Int]       = NativeColumn("part", ColumnType.UInt32)
+    val key: NativeColumn[Int]        = NativeColumn("key", ColumnType.UInt32)
+    val payload: NativeColumn[String] = NativeColumn("payload")
+    override val columns              = List(part, key, payload)
+  }
+
+  private case class Entry(part: Int, key: Int, payload: String)
+  private implicit val entryFormat: RootJsonFormat[Entry] = jsonFormat3(Entry.apply)
+
+  private val entries = Seq(Entry(1, 1, "a"), Entry(1, 2, "b"), Entry(2, 3, "c"))
+
+  private def reset(): Unit = {
+    clickClient
+      .execute(
+        CreateTable(
+          MutableTable,
+          Engine.MergeTree(partition = Seq(MutableTable.part.name), primaryKey = Seq(MutableTable.key)),
+          ifNotExists = true
+        ).query
+      )
+      .futureValue
+    clickClient.execute(s"TRUNCATE TABLE ${MutableTable.quoted}").futureValue
+    queryExecutor.insert(MutableTable, entries).futureValue
+  }
+
+  /**
+   * Mutations return once queued, so every statement here runs with mutations_sync so the assertion sees the result.
+   */
+  private implicit val synchronous: com.crobox.clickhouse.internal.QuerySettings =
+    com.crobox.clickhouse.internal.QuerySettings(settings = Map("mutations_sync" -> "2"))
+
+  private def payloads: Seq[String] =
+    queryExecutor
+      .executeRows(select(MutableTable.payload) from MutableTable orderBy MutableTable.key)
+      .futureValue
+      .rows
+      .map(_.requiredByName[String]("payload"))
+
+  private def keys: Seq[Int] =
+    queryExecutor
+      .executeRows(select(MutableTable.key) from MutableTable orderBy MutableTable.key)
+      .futureValue
+      .rows
+      .map(_.requiredByName[Int]("key"))
+
+  "DELETE FROM" should "remove exactly the rows the condition matches" in {
+    reset()
+    queryExecutor.executeStatement(DeleteFrom(MutableTable, MutableTable.key isEq 2)).futureValue
+    keys shouldBe Seq(1, 3)
+  }
+
+  "ALTER TABLE ... DELETE" should "remove the rows the condition matches" in {
+    reset()
+    queryExecutor.executeStatement(AlterDelete(MutableTable, MutableTable.key > 1)).futureValue
+    keys shouldBe Seq(1)
+  }
+
+  "ALTER TABLE ... UPDATE" should "assign to the rows the condition matches and no others" in {
+    reset()
+    queryExecutor
+      .executeStatement(
+        AlterUpdate(MutableTable, Seq(Assignment(MutableTable.payload, const("z"))), MutableTable.key isEq 2)
+      )
+      .futureValue
+    payloads shouldBe Seq("a", "z", "c")
+  }
+
+  it should "evaluate an expression on the right-hand side" in {
+    reset()
+    queryExecutor
+      .executeStatement(
+        AlterUpdate(
+          MutableTable,
+          Seq(Assignment(MutableTable.payload, concat(MutableTable.payload, const("!")))),
+          MutableTable.part isEq 1
+        )
+      )
+      .futureValue
+    payloads shouldBe Seq("a!", "b!", "c")
+  }
+
+  "DROP PARTITION" should "discard a partition addressed by id" in {
+    reset()
+    queryExecutor.executeStatement(DropPartition(MutableTable, PartitionRef.Id("1"))).futureValue
+    keys shouldBe Seq(3)
+  }
+
+  it should "discard a partition addressed by the partitioning expression" in {
+    reset()
+    queryExecutor.executeStatement(DropPartition(MutableTable, PartitionRef.Expression(const(2)))).futureValue
+    keys shouldBe Seq(1, 2)
+  }
+
+  // The whole point of taking a DSL condition rather than a string: nothing has to splice a rendered fragment.
+  "A statement's WHERE" should "escape a value rather than splice it" in {
+    reset()
+    queryExecutor
+      .executeStatement(DeleteFrom(MutableTable, MutableTable.payload isEq "' OR 1 = 1 --"))
+      .futureValue
+    keys shouldBe Seq(1, 2, 3)
+  }
+}

--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/schemabuilder/DecimalAndIPColumnTypeIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/schemabuilder/DecimalAndIPColumnTypeIT.scala
@@ -1,0 +1,65 @@
+package com.crobox.clickhouse.dsl.schemabuilder
+
+import com.crobox.clickhouse.DslITSpec
+import com.crobox.clickhouse.dsl._
+import spray.json.DefaultJsonProtocol._
+import spray.json.RootJsonFormat
+
+/**
+ * The declarations round-tripped through a real table: that the server accepts them, reports them back as expected, and
+ * that the existing decoders read the values without any new marshalling.
+ */
+class DecimalAndIPColumnTypeIT extends DslITSpec {
+
+  private object TypedTable extends Table {
+    override val database                = DecimalAndIPColumnTypeIT.this.database
+    override val name                    = "decimalAndIpTable"
+    val amount: NativeColumn[BigDecimal] = NativeColumn("amount", ColumnType.Decimal(10, 2))
+    val rate: NativeColumn[BigDecimal]   = NativeColumn("rate", ColumnType.Decimal32(4))
+    val big: NativeColumn[BigDecimal]    = NativeColumn("big", ColumnType.Decimal256(10))
+    val v4: NativeColumn[String]         = NativeColumn("v4", ColumnType.IPv4)
+    val v6: NativeColumn[String]         = NativeColumn("v6", ColumnType.IPv6)
+    override val columns                 = List(amount, rate, big, v4, v6)
+  }
+
+  private case class Entry(amount: BigDecimal, rate: BigDecimal, big: BigDecimal, v4: String, v6: String)
+  private implicit val entryFormat: RootJsonFormat[Entry] = jsonFormat5(Entry.apply)
+
+  private lazy val row = {
+    clickClient.execute(CreateTable(TypedTable, Engine.Memory, ifNotExists = true).query).futureValue
+    clickClient.execute(s"TRUNCATE TABLE ${TypedTable.quoted}").futureValue
+    queryExecutor
+      .insert(
+        TypedTable,
+        Seq(Entry(BigDecimal("1.25"), BigDecimal("2.5"), BigDecimal("3.125"), "10.0.0.1", "2001:db8::1"))
+      )
+      .futureValue
+    queryExecutor.executeRows(select(com.crobox.clickhouse.dsl.all) from TypedTable).futureValue.rows.head
+  }
+
+  it should "accept every declaration and report the type back" in {
+    // Decimal32(4) is Decimal(9, 4) and Decimal256(10) is Decimal(76, 10): the sized spelling is an alias, so the
+    // server reports the canonical form rather than the one that was declared.
+    row.header.declaredTypeOf("amount") shouldBe Option("Decimal(10, 2)")
+    row.header.declaredTypeOf("rate") shouldBe Option("Decimal(9, 4)")
+    row.header.declaredTypeOf("big") shouldBe Option("Decimal(76, 10)")
+    row.header.declaredTypeOf("v4") shouldBe Option("IPv4")
+    row.header.declaredTypeOf("v6") shouldBe Option("IPv6")
+  }
+
+  it should "read the decimals back through the existing BigDecimal decoder" in {
+    row.requiredByName[BigDecimal]("amount") shouldBe BigDecimal("1.25")
+    row.requiredByName[BigDecimal]("rate") shouldBe BigDecimal("2.5")
+    row.requiredByName[BigDecimal]("big") shouldBe BigDecimal("3.125")
+  }
+
+  it should "read the addresses back as their textual form" in {
+    row.requiredByName[String]("v4") shouldBe "10.0.0.1"
+    row.requiredByName[String]("v6") shouldBe "2001:db8::1"
+  }
+
+  it should "cast to a Decimal and to an IP" in {
+    r(toTypeName(cast(const(1), ColumnType.Decimal(10, 2)))) shouldBe "Decimal(10, 2)"
+    r(toTypeName(cast(const("10.0.0.1"), ColumnType.IPv4))) shouldBe "IPv4"
+  }
+}

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/Statement.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/Statement.scala
@@ -1,0 +1,79 @@
+package com.crobox.clickhouse.dsl
+
+/**
+ * A statement that changes data, as opposed to a query that reads it.
+ *
+ * Deliberately outside [[InternalQuery]], for the reason [[ExplainKind]] is: these wrap a whole statement rather than
+ * forming a clause inside one. As a field, `toRawSql` would render them inside a subquery's parentheses and a query
+ * merge would propagate them.
+ *
+ * The `WHERE` is an ordinary [[TableColumn]], so it is built with the same DSL as a `SELECT`'s and rendered by the same
+ * tokenizer -- which is the point: the alternative is composing the condition with the DSL and splicing the rendered
+ * string into hand-written SQL, where nothing checks the escaping.
+ *
+ * `ON CLUSTER` requires ZooKeeper (or Keeper) to be configured; without it the server answers NO_ELEMENTS_IN_CONFIG at
+ * execution time rather than at parse time.
+ */
+sealed trait Statement {
+  def table: Table
+  def onCluster: Option[String]
+}
+
+/**
+ * `DELETE FROM table WHERE condition` -- a lightweight delete, which marks rows deleted rather than rewriting the parts
+ * that hold them. [[AlterDelete]] is the mutation, and the two are not interchangeable operationally.
+ */
+case class DeleteFrom(
+    table: Table,
+    where: TableColumn[Boolean],
+    onCluster: Option[String] = None
+) extends Statement
+
+/**
+ * `ALTER TABLE table DELETE WHERE condition` -- a mutation, which rewrites every part the condition touches and runs
+ * asynchronously in the background. Progress shows up in `system.mutations`.
+ */
+case class AlterDelete(
+    table: Table,
+    where: TableColumn[Boolean],
+    onCluster: Option[String] = None
+) extends Statement
+
+/** One `column = expression` of an [[AlterUpdate]]. */
+case class Assignment(column: Column, value: Column)
+
+/**
+ * `ALTER TABLE table UPDATE assignments WHERE condition`, a mutation.
+ *
+ * The mutation spelling rather than the standalone `UPDATE table SET ...`: that one does not exist in 25.3, the oldest
+ * release this library supports, where it fails as a syntax error. This form works across the whole supported range.
+ *
+ * A column in the table's sorting key cannot be assigned to; the server answers CANNOT_UPDATE_COLUMN.
+ */
+case class AlterUpdate(
+    table: Table,
+    assignments: Seq[Assignment],
+    where: TableColumn[Boolean],
+    onCluster: Option[String] = None
+) extends Statement {
+  require(assignments.nonEmpty, "UPDATE needs at least one assignment")
+}
+
+/** Which partition [[DropPartition]] drops. */
+sealed trait PartitionRef
+
+object PartitionRef {
+
+  /** `PARTITION ID 'id'`, the literal part name as `system.parts` reports it. */
+  case class Id(id: String) extends PartitionRef
+
+  /** `PARTITION expr`, the partitioning expression's value -- what `PARTITION BY` computes. */
+  case class Expression(expr: Column) extends PartitionRef
+}
+
+/** `ALTER TABLE table DROP PARTITION ...`, which discards the parts wholesale rather than rewriting them. */
+case class DropPartition(
+    table: Table,
+    partition: PartitionRef,
+    onCluster: Option[String] = None
+) extends Statement

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/TypeCastFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/TypeCastFunctions.scala
@@ -156,6 +156,22 @@ trait TypeCastFunctions {
 
   implicit object DateTimeCastOutBind extends CastOutBind[ColumnType.DateTime.type, Int]
 
+  // Keyed on the class rather than on `<companion>.type`: `cast` infers T from the argument, and the argument's type
+  // for a parameterised column type is the class. (`Decimal(10, 2) : ColumnType.Decimal`, not `Decimal.type`.)
+  implicit object DecimalCastOutBind extends CastOutBind[ColumnType.Decimal, BigDecimal]
+
+  implicit object Decimal32CastOutBind extends CastOutBind[ColumnType.Decimal32, BigDecimal]
+
+  implicit object Decimal64CastOutBind extends CastOutBind[ColumnType.Decimal64, BigDecimal]
+
+  implicit object Decimal128CastOutBind extends CastOutBind[ColumnType.Decimal128, BigDecimal]
+
+  implicit object Decimal256CastOutBind extends CastOutBind[ColumnType.Decimal256, BigDecimal]
+
+  implicit object IPv4CastOutBind extends CastOutBind[ColumnType.IPv4.type, String]
+
+  implicit object IPv6CastOutBind extends CastOutBind[ColumnType.IPv6.type, String]
+
   def toUInt8(tableColumn: ConstOrColMagnet[_]): UInt8 = UInt8(tableColumn)
 
   def toUInt8OrDefault(tableColumn: ConstOrColMagnet[_], value: Byte): UInt8 =

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/execution/ClickhouseQueryExecutor.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/execution/ClickhouseQueryExecutor.scala
@@ -2,7 +2,7 @@ package com.crobox.clickhouse.dsl.execution
 
 import com.crobox.clickhouse.ClickhouseClient
 import com.crobox.clickhouse.dsl.language.{ClickhouseTokenizerModule, TokenizeContext, TokenizerModule}
-import com.crobox.clickhouse.dsl.{ExplainKind, Query, Table}
+import com.crobox.clickhouse.dsl.{ExplainKind, Query, Statement, Table}
 import com.crobox.clickhouse.internal.QuerySettings
 import spray.json.{JsonReader, _}
 
@@ -81,6 +81,12 @@ trait ClickhouseQueryExecutor extends QueryExecutor {
     val sql = toSql(query.internalQuery, formatting = Option(CompactRowParser.Format))(ctx = TokenizeContext())
     client.query(sql)(settings).map(CompactRowParser.parse)
   }
+
+  override def executeStatement(statement: Statement)(implicit
+      executionContext: ExecutionContext,
+      settings: QuerySettings = QuerySettings()
+  ): Future[String] =
+    client.execute(toStatementSql(statement)(ctx = TokenizeContext()))(settings)
 
   override def insert[V: JsonWriter](
       table: Table,

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/execution/QueryExecutor.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/execution/QueryExecutor.scala
@@ -1,7 +1,7 @@
 package com.crobox.clickhouse.dsl.execution
 
 import com.crobox.clickhouse.dsl.language.TokenizerModule
-import com.crobox.clickhouse.dsl.{ExplainKind, Query, Table}
+import com.crobox.clickhouse.dsl.{ExplainKind, Query, Statement, Table}
 import com.crobox.clickhouse.internal.QuerySettings
 import spray.json._
 
@@ -52,6 +52,19 @@ trait QueryExecutor { self: TokenizerModule =>
       query: Query,
       options: Seq[(String, String)] = Seq.empty
   )(implicit executionContext: ExecutionContext, settings: QuerySettings = QuerySettings()): Future[QueryResult[Row]]
+
+  /**
+   * Run a data-changing statement -- see [[com.crobox.clickhouse.dsl.Statement]] -- and return the server's response
+   * body, which is empty on success. Mirrors [[insert]] rather than the `execute`/`executeRows` pair: there are no rows
+   * to read back.
+   *
+   * A mutation (`ALTER TABLE ... DELETE`/`UPDATE`) returns as soon as it is queued, not when it has finished; pass
+   * `mutations_sync` through `settings` to wait, and watch `system.mutations` otherwise.
+   */
+  def executeStatement(statement: Statement)(implicit
+      executionContext: ExecutionContext,
+      settings: QuerySettings = QuerySettings()
+  ): Future[String]
 
   def insert[V: JsonWriter](table: Table, values: Seq[V])(implicit
       executionContext: ExecutionContext,

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -137,6 +137,33 @@ trait ClickhouseTokenizerModule
     sql
   }
 
+  override def toStatementSql(statement: Statement)(implicit ctx: TokenizeContext): String = {
+    // Between the table and the action for ALTER, but after the WHERE's table for DELETE FROM -- the two statements
+    // put the clause in different places.
+    def onCluster(name: Option[String]): String =
+      name.map(c => s" ON CLUSTER ${ClickhouseStatement.quoteIdentifier(c)}").getOrElse("")
+
+    val sql = statement match {
+      case DeleteFrom(table, where, cluster) =>
+        s"DELETE FROM ${table.quoted}${onCluster(cluster)} WHERE ${tokenizeColumn(where)}"
+      case AlterDelete(table, where, cluster) =>
+        s"ALTER TABLE ${table.quoted}${onCluster(cluster)} DELETE WHERE ${tokenizeColumn(where)}"
+      case AlterUpdate(table, assignments, where, cluster) =>
+        val sets = assignments
+          .map { case Assignment(column, value) => s"${aliasOrName(column)} = ${tokenizeColumn(value)}" }
+          .mkString(Tokens.Delimiter)
+        s"ALTER TABLE ${table.quoted}${onCluster(cluster)} UPDATE $sets WHERE ${tokenizeColumn(where)}"
+      case DropPartition(table, partition, cluster) =>
+        val target = partition match {
+          case PartitionRef.Id(id)           => s"ID ${"'" + ClickhouseStatement.escape(id) + "'"}"
+          case PartitionRef.Expression(expr) => tokenizeColumn(expr)
+        }
+        s"ALTER TABLE ${table.quoted}${onCluster(cluster)} DROP PARTITION $target"
+    }
+    logger.debug(s"Generated sql [$sql]")
+    sql
+  }
+
   private def removeSurroundingBrackets(value: String): String =
     if (value.startsWith("(") && value.endsWith(")") && value.count(_ == '(') == 1 && value.count(_ == ')') == 1) {
       value.substring(1, value.length - 1)

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/TokenizerModule.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/TokenizerModule.scala
@@ -1,6 +1,6 @@
 package com.crobox.clickhouse.dsl.language
 
-import com.crobox.clickhouse.dsl.{ExplainKind, InternalQuery}
+import com.crobox.clickhouse.dsl.{ExplainKind, InternalQuery, Statement}
 
 trait TokenizerModule {
 
@@ -22,4 +22,12 @@ trait TokenizerModule {
       query: InternalQuery,
       options: Seq[(String, String)] = Seq.empty
   )(implicit ctx: TokenizeContext): String
+
+  /**
+   * A data-changing statement -- see [[com.crobox.clickhouse.dsl.Statement]].
+   *
+   * One entry point for all of them rather than one each: unlike [[toExplainSql]], whose extra parameters earn it its
+   * own, they differ only in which case of the ADT they are.
+   */
+  def toStatementSql(statement: Statement)(implicit ctx: TokenizeContext): String
 }

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/schemabuilder/Column.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/schemabuilder/Column.scala
@@ -53,6 +53,54 @@ object ColumnType {
 
   case class FixedString(length: Int) extends SimpleColumnType(s"FixedString($length)")
 
+  /**
+   * `Decimal(P, S)`: `P` significant digits of which `S` are after the point.
+   *
+   * The read side already existed -- `BigDecimal` has a `QueryValue`, a `ColumnDecoder` and a full set of entries in
+   * the arithmetic widening table -- so only the declaration was missing. Values come back as JSON numbers at low
+   * precision and as strings at high; the decoder accepts either.
+   */
+  case class Decimal(precision: Int, scale: Int) extends SimpleColumnType(s"Decimal($precision, $scale)") {
+    require(
+      precision >= 1 && precision <= Decimal.MaxPrecision,
+      s"Decimal precision must be between 1 and ${Decimal.MaxPrecision}, got $precision"
+    )
+
+    // The server rejects a scale above the precision with "Negative scales and scales larger than precision are not
+    // supported"; equal is allowed, as in Decimal(76, 76).
+    require(scale >= 0 && scale <= precision, s"Decimal scale must be between 0 and the precision, got $scale")
+  }
+
+  object Decimal {
+    val MaxPrecision = 76
+  }
+
+  /**
+   * The fixed-width spellings, where the precision follows from the storage size rather than being given.
+   *
+   * `Decimal32(S)` is `Decimal(9, S)`, and likewise 18, 38 and 76 -- which is what `toTypeName` reports them as, so a
+   * column declared one way and read back reads as the other.
+   */
+  sealed abstract class SizedDecimal(name: String, val scale: Int, val precision: Int)
+      extends SimpleColumnType(s"$name($scale)") {
+    require(scale >= 0 && scale <= precision, s"$name scale must be between 0 and $precision, got $scale")
+  }
+
+  case class Decimal32(override val scale: Int)  extends SizedDecimal("Decimal32", scale, 9)
+  case class Decimal64(override val scale: Int)  extends SizedDecimal("Decimal64", scale, 18)
+  case class Decimal128(override val scale: Int) extends SizedDecimal("Decimal128", scale, 38)
+  case class Decimal256(override val scale: Int) extends SizedDecimal("Decimal256", scale, 76)
+
+  /**
+   * `IPv4` / `IPv6`.
+   *
+   * The functions already ship (see `IPFunctions`); only the declaration was missing. Both serialise as their textual
+   * form -- `"10.0.0.1"`, `"2001:db8::1"` -- so they are read as `String`.
+   */
+  case object IPv4 extends SimpleColumnType("IPv4")
+
+  case object IPv6 extends SimpleColumnType("IPv6")
+
   case object UUID extends SimpleColumnType("UUID")
 
   case object Date extends SimpleColumnType("Date")

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/StatementTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/StatementTest.scala
@@ -1,0 +1,74 @@
+package com.crobox.clickhouse.dsl
+
+import com.crobox.clickhouse.DslTestSpec
+
+/** Rendering of the data-changing statements. */
+class StatementTest extends DslTestSpec {
+
+  private def sql(statement: Statement): String = toStatementSql(statement)
+
+  private val condition = (col2 isEq 1) and (col3 isEq "x")
+
+  "DELETE FROM" should "render the lightweight delete" in {
+    sql(DeleteFrom(TwoTestTable, condition)) should matchSQL(
+      s"DELETE FROM ${TwoTestTable.quoted} WHERE column_2 = 1 AND column_3 = 'x'"
+    )
+  }
+
+  it should "take ON CLUSTER before the WHERE" in {
+    sql(DeleteFrom(TwoTestTable, condition, Option("my cluster"))) should matchSQL(
+      s"DELETE FROM ${TwoTestTable.quoted} ON CLUSTER `my cluster` WHERE column_2 = 1 AND column_3 = 'x'"
+    )
+  }
+
+  "ALTER TABLE ... DELETE" should "render the mutation form" in {
+    sql(AlterDelete(TwoTestTable, condition)) should matchSQL(
+      s"ALTER TABLE ${TwoTestTable.quoted} DELETE WHERE column_2 = 1 AND column_3 = 'x'"
+    )
+  }
+
+  "ALTER TABLE ... UPDATE" should "render one assignment" in {
+    sql(AlterUpdate(TwoTestTable, Seq(Assignment(col3, const("y"))), col2 isEq 1)) should matchSQL(
+      s"ALTER TABLE ${TwoTestTable.quoted} UPDATE column_3 = 'y' WHERE column_2 = 1"
+    )
+  }
+
+  it should "render several assignments, and an expression on the right" in {
+    val statement = AlterUpdate(
+      TwoTestTable,
+      Seq(Assignment(col3, const("y")), Assignment(col4, concat(col3, const("!")))),
+      col2 isEq 1,
+      Option("c")
+    )
+    sql(statement) should matchSQL(
+      s"ALTER TABLE ${TwoTestTable.quoted} ON CLUSTER c " +
+        s"UPDATE column_3 = 'y', column_4 = concat(column_3, '!') WHERE column_2 = 1"
+    )
+  }
+
+  it should "refuse an empty assignment list" in {
+    an[IllegalArgumentException] should be thrownBy AlterUpdate(TwoTestTable, Seq.empty, col2 isEq 1)
+  }
+
+  "DROP PARTITION" should "render a partition id as a quoted literal" in {
+    sql(DropPartition(TwoTestTable, PartitionRef.Id("202601"))) should matchSQL(
+      s"ALTER TABLE ${TwoTestTable.quoted} DROP PARTITION ID '202601'"
+    )
+  }
+
+  it should "escape a partition id rather than splice it" in {
+    sql(DropPartition(TwoTestTable, PartitionRef.Id("it's"))) should include("""ID 'it\'s'""")
+  }
+
+  it should "render a partitioning expression unquoted" in {
+    sql(DropPartition(TwoTestTable, PartitionRef.Expression(const(202601)))) should matchSQL(
+      s"ALTER TABLE ${TwoTestTable.quoted} DROP PARTITION 202601"
+    )
+  }
+
+  it should "take ON CLUSTER" in {
+    sql(DropPartition(TwoTestTable, PartitionRef.Id("202601"), Option("c"))) should matchSQL(
+      s"ALTER TABLE ${TwoTestTable.quoted} ON CLUSTER c DROP PARTITION ID '202601'"
+    )
+  }
+}

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/schemabuilder/DecimalAndIPColumnTypeTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/schemabuilder/DecimalAndIPColumnTypeTest.scala
@@ -1,0 +1,64 @@
+package com.crobox.clickhouse.dsl.schemabuilder
+
+import com.crobox.clickhouse.DslTestSpec
+import com.crobox.clickhouse.dsl._
+
+class DecimalAndIPColumnTypeTest extends DslTestSpec {
+
+  "Decimal" should "render its precision and scale" in {
+    ColumnType.Decimal(10, 2).toString shouldBe "Decimal(10, 2)"
+    ColumnType.Decimal(76, 76).toString shouldBe "Decimal(76, 76)"
+  }
+
+  it should "refuse a precision outside 1 to 76" in {
+    an[IllegalArgumentException] should be thrownBy ColumnType.Decimal(0, 0)
+    an[IllegalArgumentException] should be thrownBy ColumnType.Decimal(77, 2)
+  }
+
+  it should "refuse a scale above the precision, but allow one equal to it" in {
+    an[IllegalArgumentException] should be thrownBy ColumnType.Decimal(10, 11)
+    an[IllegalArgumentException] should be thrownBy ColumnType.Decimal(10, -1)
+    ColumnType.Decimal(10, 10).scale shouldBe 10
+  }
+
+  "The sized Decimals" should "render their scale and know their implied precision" in {
+    ColumnType.Decimal32(4).toString shouldBe "Decimal32(4)"
+    ColumnType.Decimal256(2).toString shouldBe "Decimal256(2)"
+    Seq(
+      ColumnType.Decimal32(0)  -> 9,
+      ColumnType.Decimal64(0)  -> 18,
+      ColumnType.Decimal128(0) -> 38,
+      ColumnType.Decimal256(0) -> 76
+    ).foreach { case (columnType, precision) => columnType.precision shouldBe precision }
+  }
+
+  it should "refuse a scale above the implied precision" in {
+    an[IllegalArgumentException] should be thrownBy ColumnType.Decimal32(10)
+    an[IllegalArgumentException] should be thrownBy ColumnType.Decimal64(19)
+    an[IllegalArgumentException] should be thrownBy ColumnType.Decimal128(39)
+    an[IllegalArgumentException] should be thrownBy ColumnType.Decimal256(77)
+  }
+
+  "IPv4 and IPv6" should "render their names" in {
+    ColumnType.IPv4.toString shouldBe "IPv4"
+    ColumnType.IPv6.toString shouldBe "IPv6"
+  }
+
+  "A column declaration" should "carry the new types" in {
+    NativeColumn[BigDecimal]("amount", ColumnType.Decimal(10, 2)).query shouldBe "amount Decimal(10, 2)"
+    NativeColumn[String]("addr", ColumnType.IPv4).query shouldBe "addr IPv4"
+    NativeColumn[BigDecimal]("rate", ColumnType.Nullable(ColumnType.Decimal64(4))).query shouldBe
+    "rate Nullable(Decimal64(4))"
+  }
+
+  "cast" should "type a Decimal target as BigDecimal and an IP target as String" in {
+    toSQL(select(cast(col2, ColumnType.Decimal(10, 2))), false) should matchSQL(
+      "SELECT cast(column_2 AS Decimal(10, 2))"
+    )
+    // Typing, not just rendering: these only compile if the CastOutBind resolves to the right output type.
+    val amount: TableColumn[BigDecimal] = cast(col2, ColumnType.Decimal(10, 2))
+    val scaled: TableColumn[BigDecimal] = cast(col2, ColumnType.Decimal64(4))
+    val address: TableColumn[String]    = cast(col3, ColumnType.IPv4)
+    Seq(amount, scaled, address) should have size 3
+  }
+}


### PR DESCRIPTION
> Stacked on #374. Review that one first; this diff is against it.

`DELETE`, `UPDATE` and `DROP PARTITION` had no representation. A caller wanting one composed the condition with the DSL, rendered it with `tokenizeColumn`, and spliced the string into hand-written SQL — which puts the escaping outside anything that checks it.

Taking the `WHERE` as an ordinary `TableColumn` is the point of the change: same DSL, same tokenizer, same escaping as a `SELECT`'s. There is a test that a value containing `' OR 1 = 1 --` is escaped rather than spliced.

## What this adds

`DeleteFrom`, `AlterDelete`, `AlterUpdate` and `DropPartition`, with a `TokenizerModule.toStatementSql` entry point and `QueryExecutor.executeStatement`.

Outside `InternalQuery`, for the reason `ExplainKind` is: these wrap a whole statement, so as a field they would render inside a subquery's parentheses and survive a query merge. One tokenizer entry point rather than four — `toExplainSql` earns its own only because its signature differs.

## Two spellings of DELETE, both here

They are not interchangeable operationally, so both are modelled. `DeleteFrom` is the lightweight delete, which marks rows deleted; `AlterDelete` is the mutation, which rewrites every part the condition touches and runs asynchronously.

## UPDATE is the ALTER TABLE spelling

Not the standalone `UPDATE t SET …`. That one does not parse at all in 25.3, the oldest release the CI matrix covers, where it fails as a syntax error. The mutation form works across the whole supported range.

## DROP PARTITION

Distinguishes the two ways to name a partition, because they render differently: an id is a quoted literal, a partitioning expression is not.

## Testing

`StatementIT` builds its own MergeTree table — the shared fixtures are `Engine.Memory`, which supports neither lightweight deletes nor mutations — and runs every statement with `mutations_sync`, since a mutation returns once queued rather than once applied.

Green on 2.13.18 and 3.3.8, and against a live 25.3 server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
