### PR TITLE
Declare Decimal and IPv4/IPv6 column types

### DIFF
--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/schemabuilder/DecimalAndIPColumnTypeIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/schemabuilder/DecimalAndIPColumnTypeIT.scala
@@ -1,0 +1,65 @@
+package com.crobox.clickhouse.dsl.schemabuilder
+
+import com.crobox.clickhouse.DslITSpec
+import com.crobox.clickhouse.dsl._
+import spray.json.DefaultJsonProtocol._
+import spray.json.RootJsonFormat
+
+/**
+ * The declarations round-tripped through a real table: that the server accepts them, reports them back as expected, and
+ * that the existing decoders read the values without any new marshalling.
+ */
+class DecimalAndIPColumnTypeIT extends DslITSpec {
+
+  private object TypedTable extends Table {
+    override val database                = DecimalAndIPColumnTypeIT.this.database
+    override val name                    = "decimalAndIpTable"
+    val amount: NativeColumn[BigDecimal] = NativeColumn("amount", ColumnType.Decimal(10, 2))
+    val rate: NativeColumn[BigDecimal]   = NativeColumn("rate", ColumnType.Decimal32(4))
+    val big: NativeColumn[BigDecimal]    = NativeColumn("big", ColumnType.Decimal256(10))
+    val v4: NativeColumn[String]         = NativeColumn("v4", ColumnType.IPv4)
+    val v6: NativeColumn[String]         = NativeColumn("v6", ColumnType.IPv6)
+    override val columns                 = List(amount, rate, big, v4, v6)
+  }
+
+  private case class Entry(amount: BigDecimal, rate: BigDecimal, big: BigDecimal, v4: String, v6: String)
+  private implicit val entryFormat: RootJsonFormat[Entry] = jsonFormat5(Entry.apply)
+
+  private lazy val row = {
+    clickClient.execute(CreateTable(TypedTable, Engine.Memory, ifNotExists = true).query).futureValue
+    clickClient.execute(s"TRUNCATE TABLE ${TypedTable.quoted}").futureValue
+    queryExecutor
+      .insert(
+        TypedTable,
+        Seq(Entry(BigDecimal("1.25"), BigDecimal("2.5"), BigDecimal("3.125"), "10.0.0.1", "2001:db8::1"))
+      )
+      .futureValue
+    queryExecutor.executeRows(select(com.crobox.clickhouse.dsl.all) from TypedTable).futureValue.rows.head
+  }
+
+  it should "accept every declaration and report the type back" in {
+    // Decimal32(4) is Decimal(9, 4) and Decimal256(10) is Decimal(76, 10): the sized spelling is an alias, so the
+    // server reports the canonical form rather than the one that was declared.
+    row.header.declaredTypeOf("amount") shouldBe Option("Decimal(10, 2)")
+    row.header.declaredTypeOf("rate") shouldBe Option("Decimal(9, 4)")
+    row.header.declaredTypeOf("big") shouldBe Option("Decimal(76, 10)")
+    row.header.declaredTypeOf("v4") shouldBe Option("IPv4")
+    row.header.declaredTypeOf("v6") shouldBe Option("IPv6")
+  }
+
+  it should "read the decimals back through the existing BigDecimal decoder" in {
+    row.requiredByName[BigDecimal]("amount") shouldBe BigDecimal("1.25")
+    row.requiredByName[BigDecimal]("rate") shouldBe BigDecimal("2.5")
+    row.requiredByName[BigDecimal]("big") shouldBe BigDecimal("3.125")
+  }
+
+  it should "read the addresses back as their textual form" in {
+    row.requiredByName[String]("v4") shouldBe "10.0.0.1"
+    row.requiredByName[String]("v6") shouldBe "2001:db8::1"
+  }
+
+  it should "cast to a Decimal and to an IP" in {
+    r(toTypeName(cast(const(1), ColumnType.Decimal(10, 2)))) shouldBe "Decimal(10, 2)"
+    r(toTypeName(cast(const("10.0.0.1"), ColumnType.IPv4))) shouldBe "IPv4"
+  }
+}

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/TypeCastFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/TypeCastFunctions.scala
@@ -156,6 +156,22 @@ trait TypeCastFunctions {
 
   implicit object DateTimeCastOutBind extends CastOutBind[ColumnType.DateTime.type, Int]
 
+  // Keyed on the class rather than on `<companion>.type`: `cast` infers T from the argument, and the argument's type
+  // for a parameterised column type is the class. (`Decimal(10, 2) : ColumnType.Decimal`, not `Decimal.type`.)
+  implicit object DecimalCastOutBind extends CastOutBind[ColumnType.Decimal, BigDecimal]
+
+  implicit object Decimal32CastOutBind extends CastOutBind[ColumnType.Decimal32, BigDecimal]
+
+  implicit object Decimal64CastOutBind extends CastOutBind[ColumnType.Decimal64, BigDecimal]
+
+  implicit object Decimal128CastOutBind extends CastOutBind[ColumnType.Decimal128, BigDecimal]
+
+  implicit object Decimal256CastOutBind extends CastOutBind[ColumnType.Decimal256, BigDecimal]
+
+  implicit object IPv4CastOutBind extends CastOutBind[ColumnType.IPv4.type, String]
+
+  implicit object IPv6CastOutBind extends CastOutBind[ColumnType.IPv6.type, String]
+
   def toUInt8(tableColumn: ConstOrColMagnet[_]): UInt8 = UInt8(tableColumn)
 
   def toUInt8OrDefault(tableColumn: ConstOrColMagnet[_], value: Byte): UInt8 =

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/schemabuilder/Column.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/schemabuilder/Column.scala
@@ -53,6 +53,54 @@ object ColumnType {
 
   case class FixedString(length: Int) extends SimpleColumnType(s"FixedString($length)")
 
+  /**
+   * `Decimal(P, S)`: `P` significant digits of which `S` are after the point.
+   *
+   * The read side already existed -- `BigDecimal` has a `QueryValue`, a `ColumnDecoder` and a full set of entries in
+   * the arithmetic widening table -- so only the declaration was missing. Values come back as JSON numbers at low
+   * precision and as strings at high; the decoder accepts either.
+   */
+  case class Decimal(precision: Int, scale: Int) extends SimpleColumnType(s"Decimal($precision, $scale)") {
+    require(
+      precision >= 1 && precision <= Decimal.MaxPrecision,
+      s"Decimal precision must be between 1 and ${Decimal.MaxPrecision}, got $precision"
+    )
+
+    // The server rejects a scale above the precision with "Negative scales and scales larger than precision are not
+    // supported"; equal is allowed, as in Decimal(76, 76).
+    require(scale >= 0 && scale <= precision, s"Decimal scale must be between 0 and the precision, got $scale")
+  }
+
+  object Decimal {
+    val MaxPrecision = 76
+  }
+
+  /**
+   * The fixed-width spellings, where the precision follows from the storage size rather than being given.
+   *
+   * `Decimal32(S)` is `Decimal(9, S)`, and likewise 18, 38 and 76 -- which is what `toTypeName` reports them as, so a
+   * column declared one way and read back reads as the other.
+   */
+  sealed abstract class SizedDecimal(name: String, val scale: Int, val precision: Int)
+      extends SimpleColumnType(s"$name($scale)") {
+    require(scale >= 0 && scale <= precision, s"$name scale must be between 0 and $precision, got $scale")
+  }
+
+  case class Decimal32(override val scale: Int)  extends SizedDecimal("Decimal32", scale, 9)
+  case class Decimal64(override val scale: Int)  extends SizedDecimal("Decimal64", scale, 18)
+  case class Decimal128(override val scale: Int) extends SizedDecimal("Decimal128", scale, 38)
+  case class Decimal256(override val scale: Int) extends SizedDecimal("Decimal256", scale, 76)
+
+  /**
+   * `IPv4` / `IPv6`.
+   *
+   * The functions already ship (see `IPFunctions`); only the declaration was missing. Both serialise as their textual
+   * form -- `"10.0.0.1"`, `"2001:db8::1"` -- so they are read as `String`.
+   */
+  case object IPv4 extends SimpleColumnType("IPv4")
+
+  case object IPv6 extends SimpleColumnType("IPv6")
+
   case object UUID extends SimpleColumnType("UUID")
 
   case object Date extends SimpleColumnType("Date")

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/schemabuilder/DecimalAndIPColumnTypeTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/schemabuilder/DecimalAndIPColumnTypeTest.scala
@@ -1,0 +1,64 @@
+package com.crobox.clickhouse.dsl.schemabuilder
+
+import com.crobox.clickhouse.DslTestSpec
+import com.crobox.clickhouse.dsl._
+
+class DecimalAndIPColumnTypeTest extends DslTestSpec {
+
+  "Decimal" should "render its precision and scale" in {
+    ColumnType.Decimal(10, 2).toString shouldBe "Decimal(10, 2)"
+    ColumnType.Decimal(76, 76).toString shouldBe "Decimal(76, 76)"
+  }
+
+  it should "refuse a precision outside 1 to 76" in {
+    an[IllegalArgumentException] should be thrownBy ColumnType.Decimal(0, 0)
+    an[IllegalArgumentException] should be thrownBy ColumnType.Decimal(77, 2)
+  }
+
+  it should "refuse a scale above the precision, but allow one equal to it" in {
+    an[IllegalArgumentException] should be thrownBy ColumnType.Decimal(10, 11)
+    an[IllegalArgumentException] should be thrownBy ColumnType.Decimal(10, -1)
+    ColumnType.Decimal(10, 10).scale shouldBe 10
+  }
+
+  "The sized Decimals" should "render their scale and know their implied precision" in {
+    ColumnType.Decimal32(4).toString shouldBe "Decimal32(4)"
+    ColumnType.Decimal256(2).toString shouldBe "Decimal256(2)"
+    Seq(
+      ColumnType.Decimal32(0)  -> 9,
+      ColumnType.Decimal64(0)  -> 18,
+      ColumnType.Decimal128(0) -> 38,
+      ColumnType.Decimal256(0) -> 76
+    ).foreach { case (columnType, precision) => columnType.precision shouldBe precision }
+  }
+
+  it should "refuse a scale above the implied precision" in {
+    an[IllegalArgumentException] should be thrownBy ColumnType.Decimal32(10)
+    an[IllegalArgumentException] should be thrownBy ColumnType.Decimal64(19)
+    an[IllegalArgumentException] should be thrownBy ColumnType.Decimal128(39)
+    an[IllegalArgumentException] should be thrownBy ColumnType.Decimal256(77)
+  }
+
+  "IPv4 and IPv6" should "render their names" in {
+    ColumnType.IPv4.toString shouldBe "IPv4"
+    ColumnType.IPv6.toString shouldBe "IPv6"
+  }
+
+  "A column declaration" should "carry the new types" in {
+    NativeColumn[BigDecimal]("amount", ColumnType.Decimal(10, 2)).query shouldBe "amount Decimal(10, 2)"
+    NativeColumn[String]("addr", ColumnType.IPv4).query shouldBe "addr IPv4"
+    NativeColumn[BigDecimal]("rate", ColumnType.Nullable(ColumnType.Decimal64(4))).query shouldBe
+    "rate Nullable(Decimal64(4))"
+  }
+
+  "cast" should "type a Decimal target as BigDecimal and an IP target as String" in {
+    toSQL(select(cast(col2, ColumnType.Decimal(10, 2))), false) should matchSQL(
+      "SELECT cast(column_2 AS Decimal(10, 2))"
+    )
+    // Typing, not just rendering: these only compile if the CastOutBind resolves to the right output type.
+    val amount: TableColumn[BigDecimal] = cast(col2, ColumnType.Decimal(10, 2))
+    val scaled: TableColumn[BigDecimal] = cast(col2, ColumnType.Decimal64(4))
+    val address: TableColumn[String]    = cast(col3, ColumnType.IPv4)
+    Seq(amount, scaled, address) should have size 3
+  }
+}


### PR DESCRIPTION
> Stacked on #375. Review that one first; this diff is against it.

Both halves of these already shipped except the declaration. `BigDecimal` has a `QueryValue`, a `ColumnDecoder` and a full set of entries in the arithmetic widening table; the IP functions ship with careful `FixedString(16)` typing (`#364`). Only `ColumnType` could not name the types, so a table holding either had to be created outside the schema builder.

## What this adds

`Decimal(P, S)` with the server's own bounds — precision 1 to 76, scale 0 to the precision, equal allowed as in `Decimal(76, 76)` — plus the sized spellings `Decimal32/64/128/256(S)`, which carry the precision that follows from their storage size so the scale can be checked against it. And `IPv4` / `IPv6`.

No marshalling follows: decimals come back as JSON numbers at low precision and as strings at high, and the decoder already accepts either; the addresses come back in textual form and read as `String`.

## Cast bindings

The `CastOutBind` instances are keyed on the **class** rather than on `<companion>.type`, because `cast` infers its type parameter from the argument and a parameterised column type's argument has the class as its type.

Worth noting separately, not changed here: the existing `StringCastOutBind` and `FixedStringCastOutBind` (`TypeCastFunctions.scala:151-153`) are keyed on `<companion>.type`, so they can never resolve for a parameterised type — and both are declared as producing `Int`. Both look like latent bugs, but they are pre-existing and outside this change.

## Testing

The IT round-trips a real table and pins the *reported* types rather than the declared ones, since the sized spellings are aliases — `Decimal32(4)` is reported as `Decimal(9, 4)`.

Green on 2.13.18 and 3.3.8, and against a live 25.3 server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
