### PR TITLE
Render GROUP BY keys as expressions rather than naming them

### DIFF
--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/language/SqlValidationITSpec.scala
@@ -681,6 +681,20 @@ class SqlValidationITSpec extends DslITSpec {
       "group by a column an aggregate already covers, which is now projected",
       select(sum(col2)).from(TwoTestTable).groupBy(col2)
     ),
+    // GROUP BY named its keys rather than rendering them, so an expression key became its argument's name -- or NULL
+    // for an arithmetic one, which the server rejects outright.
+    Construct(
+      "group by a function expression",
+      select(count()).from(OneTestTable).groupBy(toStartOfDay(toDateTime(timestampColumn)))
+    ),
+    Construct(
+      "group by an arithmetic expression",
+      select(count()).from(OneTestTable).groupBy(intDiv(timestampColumn, 1000))
+    ),
+    Construct(
+      "group by a nested expression",
+      select(count()).from(OneTestTable).groupBy(toDateTime(intDiv(toUInt64rNull(shieldId), 1000)))
+    ),
     Construct(
       "order by an expression differing from the projection",
       select(sum(col2)).from(TwoTestTable).orderBy(uniq(col2))

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -657,10 +657,8 @@ trait ClickhouseTokenizerModule
   private def tokenizeGroupByKeys(columns: Seq[Column])(implicit ctx: TokenizeContext): String =
     columns
       .map {
-        case EmptyColumn             => ""
+        // The alias alone. tokenizeColumn would render `<expression> AS d`, which is a projection, not a key.
         case alias: AliasedColumn[_] => alias.quoted
-        case col: NativeColumn[_]    => col.quoted
-        case col: RefColumn[_]       => col.quoted
         case col                     => tokenizeColumn(col)
       }
       .filter(_.nonEmpty)

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -577,10 +577,10 @@ trait ClickhouseTokenizerModule
         s"$keyword ${removeSurroundingBrackets(tokenizeColumn(condition).trim)}"
     }
 
-  private def tokenizeGroupBy(groupBy: Option[GroupByQuery]): String = {
+  private def tokenizeGroupBy(groupBy: Option[GroupByQuery])(implicit ctx: TokenizeContext): String = {
     val groupByColumns = groupBy match {
       case Some(GroupByQuery(usingColumns, _, _)) if usingColumns.nonEmpty =>
-        Some(s"GROUP BY ${tokenizeColumnsAliased(usingColumns)}")
+        Option(tokenizeGroupByKeys(usingColumns)).filter(_.nonEmpty).map(keys => s"GROUP BY $keys")
       case _ =>
         None
     }
@@ -646,8 +646,25 @@ trait ClickhouseTokenizerModule
         }
     }
 
-  private def tokenizeColumnsAliased(columns: Seq[Column]): String =
-    columns.map(aliasOrName).mkString(", ")
+  /**
+   * `GROUP BY` keys.
+   *
+   * An alias is referred to by name, since the projection already defines it, but anything else has to render as
+   * itself. `Column.name` for an expression is its *argument's* name, so naming the key here grouped `toStartOfDay(ts)`
+   * by the raw `ts` -- a query that succeeds and aggregates over the wrong buckets -- and rendered an arithmetic
+   * expression as `NULL`, which the server rejects outright.
+   */
+  private def tokenizeGroupByKeys(columns: Seq[Column])(implicit ctx: TokenizeContext): String =
+    columns
+      .map {
+        case EmptyColumn             => ""
+        case alias: AliasedColumn[_] => alias.quoted
+        case col: NativeColumn[_]    => col.quoted
+        case col: RefColumn[_]       => col.quoted
+        case col                     => tokenizeColumn(col)
+      }
+      .filter(_.nonEmpty)
+      .mkString(Tokens.Delimiter)
 
   private def tokenizeTuplesAliased(columns: Seq[OrderingColumn])(implicit ctx: TokenizeContext): String =
     columns

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/GroupByKeysTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/GroupByKeysTest.scala
@@ -1,0 +1,79 @@
+package com.crobox.clickhouse.dsl
+
+import com.crobox.clickhouse.DslTestSpec
+import com.crobox.clickhouse.dsl.schemabuilder.ColumnType
+
+import java.time.ZonedDateTime
+
+/**
+ * `GROUP BY` used to name its keys rather than render them. `Column.name` for an expression is its argument's name, so
+ * `toStartOfDay(ts)` grouped by the raw `ts` -- succeeding, over the wrong buckets -- and an arithmetic expression,
+ * built on `EmptyColumn`, became the literal `NULL`.
+ */
+class GroupByKeysTest extends DslTestSpec {
+
+  private val stamp = NativeColumn[ZonedDateTime]("ts_dt", ColumnType.DateTime)
+
+  private def sql(query: OperationalQuery): String = toSql(query.internalQuery, None)
+
+  it should "render a function expression as itself" in {
+    sql(select(count()).from(OneTestTable).groupBy(toStartOfDay(stamp))) should matchSQL(
+      s"SELECT count(), toStartOfDay(ts_dt) FROM ${OneTestTable.quoted} GROUP BY toStartOfDay(ts_dt)"
+    )
+  }
+
+  it should "render an arithmetic expression as itself" in {
+    sql(select(count()).from(OneTestTable).groupBy(intDiv(timestampColumn, 1000))) should matchSQL(
+      s"SELECT count(), intDiv(ts, 1000) FROM ${OneTestTable.quoted} GROUP BY intDiv(ts, 1000)"
+    )
+  }
+
+  it should "render a nested expression as itself" in {
+    // shieldId, not the timestamp: toUInt64OrNull rejects numeric input, and an expectation the server would reject
+    // is the kind this harness exists to avoid.
+    sql(select(count()).from(OneTestTable).groupBy(toDateTime(intDiv(toUInt64rNull(shieldId), 1000)))) should
+    matchSQL(
+      s"SELECT count(), toDateTime(intDiv(toUInt64OrNull(shield_id), 1000)) FROM ${OneTestTable.quoted} " +
+        "GROUP BY toDateTime(intDiv(toUInt64OrNull(shield_id), 1000))"
+    )
+  }
+
+  it should "still refer to an alias by name" in {
+    sql(
+      select(toStartOfDay(stamp) as "d", count()).from(OneTestTable).groupBy(ref[ZonedDateTime]("d"))
+    ) should matchSQL(
+      s"SELECT toStartOfDay(ts_dt) AS d, count() FROM ${OneTestTable.quoted} GROUP BY d"
+    )
+  }
+
+  it should "still refer to an aliased column by its alias" in {
+    val day = toStartOfDay(stamp) as "d"
+    sql(select(day, count()).from(OneTestTable).groupBy(day)) should matchSQL(
+      s"SELECT toStartOfDay(ts_dt) AS d, count() FROM ${OneTestTable.quoted} GROUP BY d"
+    )
+  }
+
+  it should "still name a stored column" in {
+    sql(select(col2, count()).from(TwoTestTable).groupBy(col2)) should matchSQL(
+      s"SELECT column_2, count() FROM ${TwoTestTable.quoted} GROUP BY column_2"
+    )
+  }
+
+  it should "render a constant rather than NULL" in {
+    sql(select(count()).from(OneTestTable).groupBy(const(1))) should matchSQL(
+      s"SELECT count(), 1 FROM ${OneTestTable.quoted} GROUP BY 1"
+    )
+  }
+
+  it should "keep WITH ROLLUP, WITH CUBE and WITH TOTALS attached" in {
+    sql(select(count()).from(OneTestTable).groupBy(toStartOfDay(stamp)).withRollup) should include(
+      "GROUP BY toStartOfDay(ts_dt) WITH ROLLUP"
+    )
+    sql(select(count()).from(OneTestTable).groupBy(toStartOfDay(stamp)).withCube) should include(
+      "GROUP BY toStartOfDay(ts_dt) WITH CUBE"
+    )
+    sql(select(count()).from(OneTestTable).groupBy(toStartOfDay(stamp)).withTotals) should include(
+      "GROUP BY toStartOfDay(ts_dt) WITH TOTALS"
+    )
+  }
+}

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/GroupByKeysTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/GroupByKeysTest.scala
@@ -65,6 +65,14 @@ class GroupByKeysTest extends DslTestSpec {
     )
   }
 
+  // Raised in review on #378: with no key left to render, is the trailing modifier valid on its own? It is --
+  // `SELECT count() FROM numbers(3) WITH ROLLUP` and the same with WITH TOTALS both answer 3 on 25.3, whereas the
+  // `GROUP BY  WITH ROLLUP` this used to emit is a syntax error.
+  it should "drop an empty GROUP BY rather than emit a bare one" in {
+    val query = select(count()).from(OneTestTable).groupBy(EmptyColumn).withRollup
+    sql(query) should matchSQL(s"SELECT count() FROM ${OneTestTable.quoted} WITH ROLLUP")
+  }
+
   it should "keep WITH ROLLUP, WITH CUBE and WITH TOTALS attached" in {
     sql(select(count()).from(OneTestTable).groupBy(toStartOfDay(stamp)).withRollup) should include(
       "GROUP BY toStartOfDay(ts_dt) WITH ROLLUP"


### PR DESCRIPTION
Found while investigating #370. **Pre-existing** — v1.3.0 has byte-identical `aliasOrName` and `ArithmeticFunctionOp`, so grouping by an expression has never worked.

`tokenizeGroupBy` passed its keys through `aliasOrName`, which renders an `AliasedColumn`'s alias and everything else's `name`. Right for a stored column; wrong for an expression, whose `name` is its **argument's** name:

```scala
abstract class ExpressionColumn[+V](targetColumn: Column) extends TableColumn[V](targetColumn.name)
```

## The dangerous case: succeeds, wrong results

```sql
SELECT count(), toStartOfDay(ts_dt) FROM t GROUP BY ts_dt
--                                                  ^^^^^ the raw timestamp
```

Over 48 hourly rows spanning 3 days:

| grouping | result |
|---|---|
| `GROUP BY ts_dt` | 48 groups |
| `GROUP BY toStartOfDay(ts_dt)` | 3 groups |

No error — just wrong aggregation.

## The loud case

`ArithmeticFunctionOp` is built on `EmptyColumn`, whose name is the string `"NULL"`:

```
groupBy(intDiv(ts, 1000))  ->  GROUP BY NULL
Code: 215. Column ts is not under aggregate function and not in GROUP BY keys
```

## After

| key | emitted |
|---|---|
| `col2` | `GROUP BY column_2` (unchanged) |
| `ref[T]("d")` | `GROUP BY d` (unchanged) |
| `expr as "d"` | `GROUP BY d` (unchanged) |
| `toStartOfDay(stamp)` | `GROUP BY toStartOfDay(ts_dt)` |
| `intDiv(ts, 1000)` | `GROUP BY intDiv(ts, 1000)` |
| `const(1)` | `GROUP BY 1` |

`aliasOrName` is untouched and still used for `INTERPOLATE`, its only other caller, where naming a projected column is what the clause wants.

## Tests

`GroupByKeysTest` covers all six shapes above plus `WITH ROLLUP` / `WITH CUBE` / `WITH TOTALS` staying attached. The three expression shapes are registered in `SqlValidationITSpec` (now 394 constructs), so what GROUP BY emits is checked against a real server from now on — this whole family was unregistered, which is how it survived to 2.0.

- 399 dsl unit tests on 2.13.18 and 3.3.8
- 146 dsl integration tests against 25.3

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)