### PR TITLE
Test Magnet hashCode through a Set and a Map

### DIFF
--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/MagnetEqualityTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/MagnetEqualityTest.scala
@@ -94,4 +94,34 @@ class MagnetEqualityTest extends DslTestSpec {
     Seq[Column](expr).contains(expr) shouldBe true
     SelectQuery(Seq(expr)).addColumn(expr).columns should have size 1
   }
+
+  // hashCode self-recursed exactly as equals did, and moving the equality off Magnet fixed both at once. The tests
+  // above call hashCode, which proves it terminates, but they never check that equal nodes agree on it, and nothing
+  // put one of these columns in a Set or Map -- the path where a caller would have hit the overflow without ever
+  // comparing two columns itself.
+  it should "agree on hashCode for equal nodes" in {
+    intDiv(timestampColumn, 1000).hashCode shouldBe intDiv(timestampColumn, 1000).hashCode
+    abs(col2).hashCode shouldBe abs(col2).hashCode
+    (col2 + 1).hashCode shouldBe (col2 + 1).hashCode
+    cast(col2, ColumnType.UInt32).hashCode shouldBe cast(col2, ColumnType.UInt32).hashCode
+    toFixedString(col3, 2).hashCode shouldBe toFixedString(col3, 2).hashCode
+  }
+
+  it should "collapse in a Set" in {
+    Set[Column](intDiv(timestampColumn, 1000), intDiv(timestampColumn, 1000)) should have size 1
+    Set[Column](abs(col2), abs(col2)) should have size 1
+    Set[Column](cast(col2, ColumnType.UInt32), cast(col2, ColumnType.UInt32)) should have size 1
+    Set[Column](toFixedString(col3, 2), toFixedString(col3, 2)) should have size 1
+  }
+
+  it should "keep distinct nodes apart in a Set" in {
+    Set[Column](intDiv(timestampColumn, 1000), intDiv(timestampColumn, 500)) should have size 2
+    Set[Column](toFixedString(col3, 2), toFixedString(col3, 4)) should have size 2
+  }
+
+  it should "work as a Map key, looked up by an equal but distinct instance" in {
+    val key     = toDateTime(intDiv(toUInt64rNull(shieldId), 1000))
+    val rebuilt = toDateTime(intDiv(toUInt64rNull(shieldId), 1000))
+    Map[Column, String](key -> "bucket").get(rebuilt) shouldBe Some("bucket")
+  }
 }


### PR DESCRIPTION
Follow-up to the review point on #371: `hashCode` self-recursed exactly as `equals` did, and moving the equality off `Magnet` fixed both in one move — but the tests only covered one side of it.

They called `hashCode` (which proves it terminates) and asserted equality separately. **Neither checked that equal nodes agree on `hashCode`**, and nothing put one of these columns in a `Set` or `Map` — the path where a caller hits the overflow without ever comparing two columns itself. The one existing `Set` test used a `LogicalFunction`, which was never affected.

## Added

| | |
|---|---|
| hashCode contract | equal nodes agree, for all five previously-overflowing classes |
| `Set` collapse | two equal nodes → size 1 |
| `Set` separation | `intDiv(ts, 1000)` vs `intDiv(ts, 500)` → size 2 |
| `Map` key | lookup by an equal-but-distinct instance returns the value |

## These actually catch it

With the pre-fix `equals`/`hashCode` restored on `Magnet`:

```
[info]   java.lang.StackOverflowError:
[error] Uncaught exception when running MagnetEqualityTest: java.lang.StackOverflowError
[info] Tests: succeeded 11, failed 0
```

The suite dies rather than failing an assertion — 11 of 19 tests run. Restored, all 19 pass.

Test-only change. 477 dsl unit tests on 2.13.18 and 3.3.8.