### PR TITLE
Keep the column's type through the nullable builders, and clear the build warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,8 @@ lazy val root = (project in file("."))
             uri("https://crobox.com")
           )
         ),
+        // sbt-ci-release publishes with no version scheme otherwise, and warns on every task that reads it.
+        versionScheme      := Some("early-semver"),
         scalaVersion       := "2.13.18",
         crossScalaVersions := List("2.13.18", "3.3.8"),
         javacOptions ++= Seq("-g", "-Xlint:unchecked", "-Xlint:deprecation", "-source", "11", "-target", "11"),

--- a/client/src/main/scala/com/crobox/clickhouse/ClickhouseClient.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/ClickhouseClient.scala
@@ -71,8 +71,9 @@ class ClickhouseClient(
    * Progress events and the result, streamed together.
    *
    * Unlike [[queryWithProgress]], which hands back the body as a materialised `Future[String]` and so holds the whole
-   * result in memory, this emits it as [[QueryProgress.QueryResultPart]] events as it arrives. Not retried, since a
-   * retry would re-run the query after the consumer had already seen part of a result.
+   * result in memory, this emits it as [[com.crobox.clickhouse.internal.progress.QueryProgress.QueryResultPart]] events
+   * as it arrives. Not retried, since a retry would re-run the query after the consumer had already seen part of a
+   * result.
    */
   def queryWithProgressStreaming(sql: String)(implicit
       settings: QuerySettings = QuerySettings(ReadQueries)

--- a/client/src/main/scala/com/crobox/clickhouse/balancing/discovery/ConnectionManagerActor.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/balancing/discovery/ConnectionManagerActor.scala
@@ -33,8 +33,10 @@ class ConnectionManagerActor(
   private var currentConfiguredHosts: Set[Uri]                    = Set.empty
   private var initialized: Boolean                                = false
 
+  // Both implicits spelled out: leaving `sender` to its default argument is a warning under Scala 3.
   context.system.scheduler.scheduleWithFixedDelay(30.seconds, 30.seconds, self, LogDeadConnections)(
-    context.system.dispatcher
+    context.system.dispatcher,
+    Actor.noSender
   )
 
   override def receive: Receive = {

--- a/client/src/main/scala/com/crobox/clickhouse/internal/ClickHouseExecutor.scala
+++ b/client/src/main/scala/com/crobox/clickhouse/internal/ClickHouseExecutor.scala
@@ -131,7 +131,7 @@ private[clickhouse] trait ClickHouseExecutor extends LazyLogging {
    *
    * `executeRequestWithProgress` returns the body as its materialised value, which means draining the entity into a
    * single String -- a million-row result is one 7MB allocation. Here the body is framed and emitted as
-   * [[QueryProgress.QueryResultPart]] events instead.
+   * [[com.crobox.clickhouse.internal.progress.QueryProgress.QueryResultPart]] events instead.
    *
    * No retries: a retry would re-run the request after the consumer had already seen part of a result.
    */

--- a/dsl/src/it/scala/com/crobox/clickhouse/dsl/ExplainIT.scala
+++ b/dsl/src/it/scala/com/crobox/clickhouse/dsl/ExplainIT.scala
@@ -60,7 +60,7 @@ class ExplainIT extends DslITSpec {
   it should "explain a query carrying the clauses added for #328" in {
     val clauses = select(shieldId)
       .from(OneTestTable)
-      .withArrayJoin(numbers as "n")
+      .withArrayJoin(this.numbers as "n")
       .where(shieldId isEq "a")
       .limit(Option(Limit(5)))
       .settings("max_threads" -> "1")

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/OperationalQuery.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/OperationalQuery.scala
@@ -89,7 +89,7 @@ trait OperationalQuery extends Query {
    * `SAMPLE rate [OFFSET offset]`, where `rate` is a fraction in (0, 1] or a row count above 1.
    *
    * Only valid on a table whose engine declares a `SAMPLE BY` expression; the server rejects it otherwise. Rejected
-   * here on a subquery for the same reason [[asFinal]] is -- there is no sampling key to read.
+   * here on a subquery for the same reason `asFinal` is -- there is no sampling key to read.
    */
   def sample(rate: Double, offset: Option[Double] = None): OperationalQuery =
     OperationalQuery(

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/OrderingColumn.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/OrderingColumn.scala
@@ -1,5 +1,7 @@
 package com.crobox.clickhouse.dsl
 
+import scala.language.implicitConversions
+
 /**
  * `WITH FILL` on one `ORDER BY` column: rows for the gaps in an otherwise sparse ordering.
  *

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/TableFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/TableFunctions.scala
@@ -24,7 +24,7 @@ trait TableFunctions {
   def numbers(start: Long, count: Long): TableFunctionFromQuery =
     tableFunction("numbers", const(start), const(count))
 
-  /** `zeros(count)`, which is [[numbers]] without the counter -- cheaper when only the row count matters. */
+  /** `zeros(count)`, which is `numbers` without the counter -- cheaper when only the row count matters. */
   def zeros(count: Long): TableFunctionFromQuery = tableFunction("zeros", const(count))
 
   /** `values(rows)`, an inline table. Build each row with `tuple(...)`; a single-column table can take bare values. */

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/AggregationFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/AggregationFunctions.scala
@@ -72,7 +72,7 @@ trait AggregationFunctions {
 
   /**
    * `count(DISTINCT column)`. ClickHouse rewrites this to `uniqExact` by default -- see the
-   * `count_distinct_implementation` setting -- so [[UniqFunctions.uniqExact]] says the same thing more directly.
+   * `count_distinct_implementation` setting -- so `uniqExact` says the same thing more directly.
    */
   def countDistinct(column: TableColumn[_]): Count = Count(Option(column), distinct = true)
 
@@ -224,7 +224,7 @@ trait UniqFunctions { self: Magnets with AggregationFunctions =>
   }
 
   /**
-   * `uniqCombined64`, which uses a 64-bit hash for every type where [[uniqCombined]] uses one only for String.
+   * `uniqCombined64`, which uses a 64-bit hash for every type where `uniqCombined` uses one only for String.
    *
    * Prefer it above roughly `UINT_MAX` distinct values: the 32-bit hash collides badly at that scale, and the error
    * rate rises with it.

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/DistanceFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/DistanceFunctions.scala
@@ -5,7 +5,7 @@ import com.crobox.clickhouse.dsl.{EmptyColumn, ExpressionColumn}
 trait DistanceFunctions { self: Magnets =>
 
   sealed trait DistanceFunction
-  abstract class DistanceFunctionOp[V] extends ExpressionColumn[V](EmptyColumn) with DistanceFunction
+  sealed abstract class DistanceFunctionOp[V] extends ExpressionColumn[V](EmptyColumn) with DistanceFunction
 
   // The *Normalize functions are not shaped like the rest of the family: the server gives them one argument, not
   // two, and it must be a Tuple rather than an Array -- an Array is rejected with ILLEGAL_TYPE_OF_ARGUMENT. They

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/Magnets.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/Magnets.scala
@@ -51,11 +51,14 @@ trait Magnets {
    * compiler synthesises for a case class, so every case class extending a magnet -- `IntDiv`, `Cast`, `FixedString`
    * and the rest, whose `column` is `this` -- inherited `column == that.column` and recursed until the stack ran out.
    * Off `Magnet`, those get their own field-wise equality back.
+   *
+   * `Magnet` is a trait inside a trait, so it carries no outer pointer and the type test cannot confirm the other value
+   * came from this DSL instance. There is only ever the one, `object dsl`.
    */
   trait MagnetEquality { self: Magnet[_] =>
     override def equals(other: Any): Boolean = other match {
-      case that: Magnet[_] => column == that.column
-      case _               => false
+      case that: (Magnet[_] @unchecked) => column == that.column
+      case _                            => false
     }
 
     override def hashCode(): Int = column.hashCode()

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/Magnets.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/Magnets.scala
@@ -94,7 +94,7 @@ trait Magnets {
   /**
    * Any constant or column. Sidenote: The current implementation doesn't represent collections.
    */
-  trait ConstOrColMagnet[+C] extends Magnet[C] with ScalaBooleanFunctionOps with InOps with NullableOps
+  trait ConstOrColMagnet[+C] extends Magnet[C] with ScalaBooleanFunctionOps with InOps with NullableOps[C]
 
   implicit def constOrColMagnetFromCol[C](s: TableColumn[C]): ConstOrColMagnet[C] =
     new ConstOrColMagnet[C] with MagnetEquality {

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/NullableFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/NullableFunctions.scala
@@ -10,35 +10,47 @@ trait NullableFunctions { self: Magnets =>
       extends ExpressionColumn[V](innerCol)
       with NullableFunction
 
-  case class IsNull(col: ConstOrColMagnet[_])                           extends AbsNullableFunction[Boolean](col.column)
-  case class IsNullable(col: ConstOrColMagnet[_])                       extends AbsNullableFunction[Boolean](col.column)
-  case class IsNotNull(col: ConstOrColMagnet[_])                        extends AbsNullableFunction[Boolean](col.column)
-  case class IsZeroOrNull(col: ConstOrColMagnet[_])                     extends AbsNullableFunction[Boolean](col.column)
-  case class AssumeNotNull(col: ConstOrColMagnet[_])                    extends AbsNullableFunction(col.column)
-  case class ToNullable(col: ConstOrColMagnet[_])                       extends AbsNullableFunction(col.column)
-  case class IfNull(col: ConstOrColMagnet[_], alt: ConstOrColMagnet[_]) extends AbsNullableFunction(col.column)
-  case class NullIf(col: ConstOrColMagnet[_], other: ConstOrColMagnet[_]) extends AbsNullableFunction(col.column)
+  case class IsNull(col: ConstOrColMagnet[_])       extends AbsNullableFunction[Boolean](col.column)
+  case class IsNullable(col: ConstOrColMagnet[_])   extends AbsNullableFunction[Boolean](col.column)
+  case class IsNotNull(col: ConstOrColMagnet[_])    extends AbsNullableFunction[Boolean](col.column)
+  case class IsZeroOrNull(col: ConstOrColMagnet[_]) extends AbsNullableFunction[Boolean](col.column)
 
-  trait NullableOps {
-    self: ConstOrColMagnet[_] =>
+  /**
+   * The four that hand their column back keep its type, so the result can still be fed to a function that asks for one.
+   * Without it they were `AbsNullableFunction[Nothing]`, and `divide(x, nullIf(y, 0.0))` had no numeric conversion to
+   * pick -- every one of them applies to `Nothing`.
+   *
+   * The result follows the *first* argument. `nullIf` is that in ClickHouse too; `ifNull` is really the supertype of
+   * both, but inferring one would type `ifNull(price, 0)` as `AnyVal` and put the caller right back where they started.
+   * So the alternative stays untyped and unchecked against the column.
+   */
+  case class AssumeNotNull[+V](col: ConstOrColMagnet[V]) extends AbsNullableFunction[V](col.column)
+  case class ToNullable[+V](col: ConstOrColMagnet[V])    extends AbsNullableFunction[V](col.column)
 
-    def isNull(): IsNull                                 = IsNull(self)
-    def isNullable(): IsNullable                         = IsNullable(self)
-    def isNotNull(): IsNotNull                           = IsNotNull(self)
-    def isZeroOrNull(): IsZeroOrNull                     = IsZeroOrNull(self)
-    def ifNull(alternative: ConstOrColMagnet[_]): IfNull = IfNull(self, alternative)
-    def nullIf(other: ConstOrColMagnet[_]): NullIf       = NullIf(self, other)
-    def assumeNotNull(): AssumeNotNull                   = AssumeNotNull(self)
-    def toNullable(): ToNullable                         = ToNullable(self)
+  case class IfNull[+V](col: ConstOrColMagnet[V], alt: ConstOrColMagnet[_])   extends AbsNullableFunction[V](col.column)
+  case class NullIf[+V](col: ConstOrColMagnet[V], other: ConstOrColMagnet[_]) extends AbsNullableFunction[V](col.column)
+
+  trait NullableOps[+C] {
+    self: ConstOrColMagnet[C] =>
+
+    def isNull(): IsNull                                    = IsNull(self)
+    def isNullable(): IsNullable                            = IsNullable(self)
+    def isNotNull(): IsNotNull                              = IsNotNull(self)
+    def isZeroOrNull(): IsZeroOrNull                        = IsZeroOrNull(self)
+    def ifNull(alternative: ConstOrColMagnet[_]): IfNull[C] = IfNull(self, alternative)
+    def nullIf(other: ConstOrColMagnet[_]): NullIf[C]       = NullIf(self, other)
+    def assumeNotNull(): AssumeNotNull[C]                   = AssumeNotNull(self)
+    def toNullable(): ToNullable[C]                         = ToNullable(self)
 
   }
 
-  def isNull(col: ConstOrColMagnet[_]): IsNull                                   = IsNull(col)
-  def isNullable(col: ConstOrColMagnet[_]): IsNullable                           = IsNullable(col)
-  def isNotNull(col: ConstOrColMagnet[_]): IsNotNull                             = IsNotNull(col)
-  def isZeroOrNull(col: ConstOrColMagnet[_]): IsZeroOrNull                       = IsZeroOrNull(col)
-  def ifNull(col: ConstOrColMagnet[_], alternative: ConstOrColMagnet[_]): IfNull = IfNull(col, alternative)
-  def nullIf(col: ConstOrColMagnet[_], other: ConstOrColMagnet[_]): NullIf       = NullIf(col, other)
-  def assumeNotNull(col: ConstOrColMagnet[_]): AssumeNotNull                     = AssumeNotNull(col)
-  def toNullable(col: ConstOrColMagnet[_]): ToNullable                           = ToNullable(col)
+  def isNull(col: ConstOrColMagnet[_]): IsNull             = IsNull(col)
+  def isNullable(col: ConstOrColMagnet[_]): IsNullable     = IsNullable(col)
+  def isNotNull(col: ConstOrColMagnet[_]): IsNotNull       = IsNotNull(col)
+  def isZeroOrNull(col: ConstOrColMagnet[_]): IsZeroOrNull = IsZeroOrNull(col)
+
+  def ifNull[V](col: ConstOrColMagnet[V], alternative: ConstOrColMagnet[_]): IfNull[V] = IfNull(col, alternative)
+  def nullIf[V](col: ConstOrColMagnet[V], other: ConstOrColMagnet[_]): NullIf[V]       = NullIf(col, other)
+  def assumeNotNull[V](col: ConstOrColMagnet[V]): AssumeNotNull[V]                     = AssumeNotNull(col)
+  def toNullable[V](col: ConstOrColMagnet[V]): ToNullable[V]                           = ToNullable(col)
 }

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/URLFunctions.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/column/URLFunctions.scala
@@ -4,8 +4,8 @@ import com.crobox.clickhouse.dsl.ExpressionColumn
 
 trait URLFunctions { self: Magnets =>
   sealed abstract class URLFunction[V](val urlColumn: StringColMagnet[_]) extends ExpressionColumn[V](urlColumn.column)
-  abstract class URLStrFunction(col: StringColMagnet[_])                  extends URLFunction[String](col)
-  abstract class URLArrFunction(col: StringColMagnet[_])                  extends URLFunction[Seq[String]](col)
+  sealed abstract class URLStrFunction(col: StringColMagnet[_])           extends URLFunction[String](col)
+  sealed abstract class URLArrFunction(col: StringColMagnet[_])           extends URLFunction[Seq[String]](col)
 
   case class Protocol(col: StringColMagnet[_])                                       extends URLStrFunction(col)
   case class Domain(col: StringColMagnet[_])                                         extends URLStrFunction(col)

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ArrayFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ArrayFunctionTokenizer.scala
@@ -10,71 +10,71 @@ trait ArrayFunctionTokenizer { this: ClickhouseTokenizerModule =>
   }
 
   protected def tokenizeArrayFunctionOp(col: ArrayFunctionOp[_])(implicit ctx: TokenizeContext): String = col match {
-    case EmptyArrayToSingle(col: ArrayColMagnet[_]) =>
+    case EmptyArrayToSingle(col) =>
       s"emptyArrayToSingle(${tokenizeColumn(col.column)})"
     case Array(columns @ _*) =>
       s"[${tokenizeSeqCol(columns.map(_.column): _*)}]" // Array Creation Operator
-    case ArrayConcat(col1: ArrayColMagnet[_], columns @ _*) =>
+    case ArrayConcat(col1, columns @ _*) =>
       s"arrayConcat(${tokenizeSeqCol(col1.column, columns.map(_.column): _*)})"
-    case ArrayElement(col: ArrayColMagnet[_], n: NumericCol[_]) =>
+    case ArrayElement(col, n) =>
       s"${tokenizeColumn(col.column)}[${tokenizeColumn(n.column)}]"
-    case Has(col: ArrayColMagnet[_], elm: ConstOrColMagnet[_]) =>
+    case Has(col, elm) =>
       s"has(${tokenizeColumn(col.column)}, ${tokenizeColumn(elm.column)})"
-    case HasAll(col: ArrayColMagnet[_], elm: ArrayColMagnet[_]) =>
+    case HasAll(col, elm) =>
       s"hasAll(${tokenizeColumn(col.column)}, ${tokenizeColumn(elm.column)})"
-    case HasAny(col: ArrayColMagnet[_], elm: ArrayColMagnet[_]) =>
+    case HasAny(col, elm) =>
       s"hasAny(${tokenizeColumn(col.column)}, ${tokenizeColumn(elm.column)})"
-    case IndexOf(col: ArrayColMagnet[_], elm: ConstOrColMagnet[_]) =>
+    case IndexOf(col, elm) =>
       s"indexOf(${tokenizeColumn(col.column)}, ${tokenizeColumn(elm.column)})"
-    case CountEqual(col: ArrayColMagnet[_], elm: ConstOrColMagnet[_]) =>
+    case CountEqual(col, elm) =>
       s"countEqual(${tokenizeColumn(col.column)}, ${tokenizeColumn(elm.column)})"
-    case ArrayEnumerate(col: ArrayColMagnet[_]) =>
+    case ArrayEnumerate(col) =>
       s"arrayEnumerate(${tokenizeColumn(col.column)})"
-    case ArrayEnumerateUniq(col1: ArrayColMagnet[_], columns @ _*) =>
+    case ArrayEnumerateUniq(col1, columns @ _*) =>
       s"arrayEnumerateUniq(${tokenizeSeqCol(col1.column, columns.map(_.column): _*)})"
-    case ArrayPopBack(col: ArrayColMagnet[_]) =>
+    case ArrayPopBack(col) =>
       s"arrayPopBack(${tokenizeColumn(col.column)})"
-    case ArrayPopFront(col: ArrayColMagnet[_]) =>
+    case ArrayPopFront(col) =>
       s"arrayPopFront(${tokenizeColumn(col.column)})"
-    case ArrayPushBack(col: ArrayColMagnet[_], elm: ConstOrColMagnet[_]) =>
+    case ArrayPushBack(col, elm) =>
       s"arrayPushBack(${tokenizeColumn(col.column)}, ${tokenizeColumn(elm.column)})"
-    case ArrayPushFront(col: ArrayColMagnet[_], elm: ConstOrColMagnet[_]) =>
+    case ArrayPushFront(col, elm) =>
       s"arrayPushFront(${tokenizeColumn(col.column)}, ${tokenizeColumn(elm.column)})"
-    case ArrayResize(col: ArrayColMagnet[_], size: NumericCol[_], extender: ConstOrColMagnet[_]) =>
+    case ArrayResize(col, size, extender) =>
       s"arrayResize(${tokenizeColumn(col.column)},${tokenizeColumn(size.column)},${tokenizeColumn(extender.column)})"
-    case ArraySlice(col: ArrayColMagnet[_], offset: NumericCol[_], length: NumericCol[_]) =>
+    case ArraySlice(col, offset, length) =>
       s"arraySlice(${tokenizeColumn(col.column)},${tokenizeColumn(offset.column)},${tokenizeColumn(length.column)})"
-    case ArrayUniq(col1: ArrayColMagnet[_], columns @ _*) =>
+    case ArrayUniq(col1, columns @ _*) =>
       s"arrayUniq(${tokenizeSeqCol(col1.column, columns.map(_.column): _*)})"
-    case ArrayJoin(col: ArrayColMagnet[_])                     => s"arrayJoin(${tokenizeColumn(col.column)})"
-    case ArrayDifference(col: ArrayColMagnet[_])               => s"arrayDifference(${tokenizeColumn(col.column)})"
-    case ArrayDistinct(col: ArrayColMagnet[_])                 => s"arrayDistinct(${tokenizeColumn(col.column)})"
-    case ArrayIntersect(col1: ArrayColMagnet[_], columns @ _*) =>
+    case ArrayJoin(col)                     => s"arrayJoin(${tokenizeColumn(col.column)})"
+    case ArrayDifference(col)               => s"arrayDifference(${tokenizeColumn(col.column)})"
+    case ArrayDistinct(col)                 => s"arrayDistinct(${tokenizeColumn(col.column)})"
+    case ArrayIntersect(col1, columns @ _*) =>
       s"arrayIntersect(${tokenizeSeqCol(col1.column, columns.map(_.column): _*)})"
-    case ArrayReduce(function: String, col1: ArrayColMagnet[_], columns @ _*) =>
+    case ArrayReduce(function, col1, columns @ _*) =>
       s"arrayReduce('$function', ${tokenizeSeqCol(col1.column, columns.map(_.column): _*)})"
-    case ArrayReverse(col: ArrayColMagnet[_])  => s"arrayReverse(${tokenizeColumn(col.column)})"
-    case ArrayEmpty(col: ArrayColMagnet[_])    => s"empty(${tokenizeColumn(col.column)})"
-    case ArrayNotEmpty(col: ArrayColMagnet[_]) => s"notEmpty(${tokenizeColumn(col.column)})"
-    case ArrayLength(col: ArrayColMagnet[_])   => s"length(${tokenizeColumn(col.column)})"
-    case ArrayFlatten(col: ArrayColMagnet[_])  => s"arrayFlatten(${tokenizeColumn(col.column)})"
+    case ArrayReverse(col)  => s"arrayReverse(${tokenizeColumn(col.column)})"
+    case ArrayEmpty(col)    => s"empty(${tokenizeColumn(col.column)})"
+    case ArrayNotEmpty(col) => s"notEmpty(${tokenizeColumn(col.column)})"
+    case ArrayLength(col)   => s"length(${tokenizeColumn(col.column)})"
+    case ArrayFlatten(col)  => s"arrayFlatten(${tokenizeColumn(col.column)})"
   }
 
   protected def tokenizeArrayFunctionConst(col: ArrayFunctionConst[_])(implicit ctx: TokenizeContext): String =
     col match {
-      case _: EmptyArrayUInt8      => "emptyArrayUInt8()"
-      case _: EmptyArrayUInt16     => "emptyArrayUInt16()"
-      case _: EmptyArrayUInt32     => "emptyArrayUInt32()"
-      case _: EmptyArrayUInt64     => "emptyArrayUInt64()"
-      case _: EmptyArrayInt8       => "emptyArrayInt8()"
-      case _: EmptyArrayInt16      => "emptyArrayInt16()"
-      case _: EmptyArrayInt32      => "emptyArrayInt32()"
-      case _: EmptyArrayInt64      => "emptyArrayInt64()"
-      case _: EmptyArrayFloat32    => "emptyArrayFloat32()"
-      case _: EmptyArrayFloat64    => "emptyArrayFloat64()"
-      case _: EmptyArrayDate       => "emptyArrayDate()"
-      case _: EmptyArrayDateTime   => "emptyArrayDateTime()"
-      case _: EmptyArrayString     => "emptyArrayString()"
-      case Range(n: NumericCol[_]) => s"range(${tokenizeColumn(n.column)})"
+      case _: EmptyArrayUInt8    => "emptyArrayUInt8()"
+      case _: EmptyArrayUInt16   => "emptyArrayUInt16()"
+      case _: EmptyArrayUInt32   => "emptyArrayUInt32()"
+      case _: EmptyArrayUInt64   => "emptyArrayUInt64()"
+      case _: EmptyArrayInt8     => "emptyArrayInt8()"
+      case _: EmptyArrayInt16    => "emptyArrayInt16()"
+      case _: EmptyArrayInt32    => "emptyArrayInt32()"
+      case _: EmptyArrayInt64    => "emptyArrayInt64()"
+      case _: EmptyArrayFloat32  => "emptyArrayFloat32()"
+      case _: EmptyArrayFloat64  => "emptyArrayFloat64()"
+      case _: EmptyArrayDate     => "emptyArrayDate()"
+      case _: EmptyArrayDateTime => "emptyArrayDateTime()"
+      case _: EmptyArrayString   => "emptyArrayString()"
+      case Range(n)              => s"range(${tokenizeColumn(n.column)})"
     }
 }

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -357,41 +357,43 @@ trait ClickhouseTokenizerModule
     }
   }
 
+  // The `@unchecked`s are on the markers that are `sealed trait`s inside a trait: a trait carries no outer pointer,
+  // so the type test cannot confirm the value came from this DSL instance. There is only ever the one, `object dsl`.
   private def tokenizeExpressionColumn(inCol: ExpressionColumn[_])(implicit ctx: TokenizeContext): String =
     inCol match {
-      case agg: AggregateFunction[_]            => tokenizeAggregateFunction(agg)
-      case col: ArithmeticFunctionCol[_]        => tokenizeArithmeticFunctionColumn(col)
-      case col: ArithmeticFunctionOp[_]         => tokenizeArithmeticFunctionOperator(col)
-      case col: ArrayFunction                   => tokenizeArrayFunction(col)
-      case col: BitFunction                     => tokenizeBitFunction(col)
-      case col: ComparisonColumn                => tokenizeComparisonColumn(col)
-      case col: DateTimeFunctionCol[_]          => tokenizeDateTimeColumn(col)
-      case col: DateTimeConst[_]                => tokenizeDateTimeConst(col)
-      case col: DictionaryFuncColumn[_]         => tokenizeDictionaryFunction(col)
-      case col: DistanceFunction                => tokenizeDistanceFunction(col)
-      case col: EmptyFunction[_]                => tokenizeEmptyCol(col)
-      case col: EncodingFunction[_]             => tokenizeEncodingFunction(col)
-      case col: HashFunction                    => tokenizeHashFunction(col)
-      case col: HigherOrderFunction[_, _]       => tokenizeHigherOrderFunction(col)
-      case col: IPFunction[_]                   => tokenizeIPFunction(col)
-      case col: InFunction                      => tokenizeInFunction(col)
-      case col: JsonFunction[_]                 => tokenizeJsonFunction(col)
-      case col: LogicalFunction                 => tokenizeLogicalFunction(col)
-      case col: MathFuncColumn                  => tokenizeMathematicalFunction(col)
-      case col: MiscellaneousFunction           => tokenizeMiscellaneousFunction(col)
-      case col: NullableFunction                => tokenizeNullableFunction(col)
-      case col: RandomFunction                  => tokenizeRandomFunction(col)
-      case col: RoundingFunction                => tokenizeRoundingFunction(col)
-      case col: SplitMergeFunction[_]           => tokenizeSplitMergeFunction(col)
-      case col: StringFunctionCol[_]            => tokenizeStringCol(col)
-      case col: StringSearchFunc[_]             => tokenizeStringSearchFunction(col)
-      case col: TypeCastColumn[_]               => tokenizeTypeCastColumn(col)
-      case col: URLFunction[_]                  => tokenizeURLFunction(col)
-      case col: WindowOnlyFunctionCol[_]        => tokenizeWindowOnlyFunction(col)
-      case All()                                => "*"
-      case RawColumn(rawSql)                    => rawSql
-      case Conditional(Nil, default, _)         => tokenizeColumn(default)
-      case Conditional(cases, default, multiIf) =>
+      case agg: AggregateFunction[_]               => tokenizeAggregateFunction(agg)
+      case col: ArithmeticFunctionCol[_]           => tokenizeArithmeticFunctionColumn(col)
+      case col: ArithmeticFunctionOp[_]            => tokenizeArithmeticFunctionOperator(col)
+      case col: (ArrayFunction @unchecked)         => tokenizeArrayFunction(col)
+      case col: BitFunction                        => tokenizeBitFunction(col)
+      case col: ComparisonColumn                   => tokenizeComparisonColumn(col)
+      case col: DateTimeFunctionCol[_]             => tokenizeDateTimeColumn(col)
+      case col: DateTimeConst[_]                   => tokenizeDateTimeConst(col)
+      case col: DictionaryFuncColumn[_]            => tokenizeDictionaryFunction(col)
+      case col: (DistanceFunction @unchecked)      => tokenizeDistanceFunction(col)
+      case col: EmptyFunction[_]                   => tokenizeEmptyCol(col)
+      case col: EncodingFunction[_]                => tokenizeEncodingFunction(col)
+      case col: HashFunction                       => tokenizeHashFunction(col)
+      case col: HigherOrderFunction[_, _]          => tokenizeHigherOrderFunction(col)
+      case col: IPFunction[_]                      => tokenizeIPFunction(col)
+      case col: (InFunction @unchecked)            => tokenizeInFunction(col)
+      case col: JsonFunction[_]                    => tokenizeJsonFunction(col)
+      case col: LogicalFunction                    => tokenizeLogicalFunction(col)
+      case col: MathFuncColumn                     => tokenizeMathematicalFunction(col)
+      case col: (MiscellaneousFunction @unchecked) => tokenizeMiscellaneousFunction(col)
+      case col: (NullableFunction @unchecked)      => tokenizeNullableFunction(col)
+      case col: RandomFunction                     => tokenizeRandomFunction(col)
+      case col: RoundingFunction                   => tokenizeRoundingFunction(col)
+      case col: SplitMergeFunction[_]              => tokenizeSplitMergeFunction(col)
+      case col: StringFunctionCol[_]               => tokenizeStringCol(col)
+      case col: StringSearchFunc[_]                => tokenizeStringSearchFunction(col)
+      case col: TypeCastColumn[_]                  => tokenizeTypeCastColumn(col)
+      case col: URLFunction[_]                     => tokenizeURLFunction(col)
+      case col: WindowOnlyFunctionCol[_]           => tokenizeWindowOnlyFunction(col)
+      case All()                                   => "*"
+      case RawColumn(rawSql)                       => rawSql
+      case Conditional(Nil, default, _)            => tokenizeColumn(default)
+      case Conditional(cases, default, multiIf)    =>
         if (multiIf) {
           s"${if (cases.size > 1) "multiIf" else "if"}(${cases
               .map(`case` => s"${tokenizeColumn(`case`.condition)}, ${tokenizeColumn(`case`.result)}")

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/ClickhouseTokenizerModule.scala
@@ -390,6 +390,7 @@ trait ClickhouseTokenizerModule
       case col: WindowOnlyFunctionCol[_]        => tokenizeWindowOnlyFunction(col)
       case All()                                => "*"
       case RawColumn(rawSql)                    => rawSql
+      case Conditional(Nil, default, _)         => tokenizeColumn(default)
       case Conditional(cases, default, multiIf) =>
         if (multiIf) {
           s"${if (cases.size > 1) "multiIf" else "if"}(${cases

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/DateTimeFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/DateTimeFunctionTokenizer.scala
@@ -7,52 +7,52 @@ trait DateTimeFunctionTokenizer {
 
   protected def tokenizeDateTimeColumn(col: DateTimeFunctionCol[_])(implicit ctx: TokenizeContext): String =
     col match {
-      case Year(d: DateOrDateTime[_])                               => s"toYear(${tokenizeColumn(d.column)})"
-      case YYYYMM(d: DateOrDateTime[_])                             => s"toYYYYMM(${tokenizeColumn(d.column)})"
-      case Month(d: DateOrDateTime[_])                              => s"toMonth(${tokenizeColumn(d.column)})"
-      case DayOfMonth(d: DateOrDateTime[_])                         => s"toDayOfMonth(${tokenizeColumn(d.column)})"
-      case DayOfWeek(d: DateOrDateTime[_])                          => s"toDayOfWeek(${tokenizeColumn(d.column)})"
-      case Hour(d: DateOrDateTime[_])                               => s"toHour(${tokenizeColumn(d.column)})"
-      case Minute(d: DateOrDateTime[_])                             => s"toMinute(${tokenizeColumn(d.column)})"
-      case Second(d: DateOrDateTime[_])                             => s"toSecond(${tokenizeColumn(d.column)})"
-      case Monday(d: DateOrDateTime[_])                             => s"toMonday(${tokenizeColumn(d.column)})"
-      case AddSeconds(d: DateOrDateTime[_], seconds: NumericCol[_]) =>
+      case Year(d)                => s"toYear(${tokenizeColumn(d.column)})"
+      case YYYYMM(d)              => s"toYYYYMM(${tokenizeColumn(d.column)})"
+      case Month(d)               => s"toMonth(${tokenizeColumn(d.column)})"
+      case DayOfMonth(d)          => s"toDayOfMonth(${tokenizeColumn(d.column)})"
+      case DayOfWeek(d)           => s"toDayOfWeek(${tokenizeColumn(d.column)})"
+      case Hour(d)                => s"toHour(${tokenizeColumn(d.column)})"
+      case Minute(d)              => s"toMinute(${tokenizeColumn(d.column)})"
+      case Second(d)              => s"toSecond(${tokenizeColumn(d.column)})"
+      case Monday(d)              => s"toMonday(${tokenizeColumn(d.column)})"
+      case AddSeconds(d, seconds) =>
         s"addSeconds(${tokenizeColumn(d.column)},${tokenizeColumn(seconds.column)})"
-      case AddMinutes(d: DateOrDateTime[_], minutes: NumericCol[_]) =>
+      case AddMinutes(d, minutes) =>
         s"addMinutes(${tokenizeColumn(d.column)},${tokenizeColumn(minutes.column)})"
-      case AddHours(d: DateOrDateTime[_], hours: NumericCol[_]) =>
+      case AddHours(d, hours) =>
         s"addHours(${tokenizeColumn(d.column)},${tokenizeColumn(hours.column)})"
-      case AddDays(d: DateOrDateTime[_], days: NumericCol[_]) =>
+      case AddDays(d, days) =>
         s"addDays(${tokenizeColumn(d.column)},${tokenizeColumn(days.column)})"
-      case AddWeeks(d: DateOrDateTime[_], weeks: NumericCol[_]) =>
+      case AddWeeks(d, weeks) =>
         s"addWeeks(${tokenizeColumn(d.column)},${tokenizeColumn(weeks.column)})"
-      case AddMonths(d: DateOrDateTime[_], months: NumericCol[_]) =>
+      case AddMonths(d, months) =>
         s"addMonths(${tokenizeColumn(d.column)},${tokenizeColumn(months.column)})"
-      case AddYears(d: DateOrDateTime[_], years: NumericCol[_]) =>
+      case AddYears(d, years) =>
         s"addYears(${tokenizeColumn(d.column)},${tokenizeColumn(years.column)})"
-      case StartOfMonth(d: DateOrDateTime[_])          => s"toStartOfMonth(${tokenizeColumn(d.column)})"
-      case StartOfQuarter(d: DateOrDateTime[_])        => s"toStartOfQuarter(${tokenizeColumn(d.column)})"
-      case StartOfYear(d: DateOrDateTime[_])           => s"toStartOfYear(${tokenizeColumn(d.column)})"
-      case StartOfMinute(d: DateOrDateTime[_])         => s"toStartOfMinute(${tokenizeColumn(d.column)})"
-      case StartOfFiveMinute(d: DateOrDateTime[_])     => s"toStartOfFiveMinute(${tokenizeColumn(d.column)})"
-      case StartOfFifteenMinutes(d: DateOrDateTime[_]) => s"toStartOfFifteenMinutes(${tokenizeColumn(d.column)})"
-      case StartOfHour(d: DateOrDateTime[_])           => s"toStartOfHour(${tokenizeColumn(d.column)})"
-      case StartOfDay(d: DateOrDateTime[_])            => s"toStartOfDay(${tokenizeColumn(d.column)})"
-      case Time(d: DateOrDateTime[_])                  => s"toTime(${tokenizeColumn(d.column)})"
-      case RelativeYearNum(d: DateOrDateTime[_])       => s"toRelativeYearNum(${tokenizeColumn(d.column)})"
-      case RelativeQuarterNum(d: DateOrDateTime[_])    => s"toRelativeQuarterNum(${tokenizeColumn(d.column)})"
-      case RelativeMonthNum(d: DateOrDateTime[_])      => s"toRelativeMonthNum(${tokenizeColumn(d.column)})"
-      case RelativeWeekNum(d: DateOrDateTime[_])       => s"toRelativeWeekNum(${tokenizeColumn(d.column)})"
-      case RelativeDayNum(d: DateOrDateTime[_])        => s"toRelativeDayNum(${tokenizeColumn(d.column)})"
-      case RelativeHourNum(d: DateOrDateTime[_])       => s"toRelativeHourNum(${tokenizeColumn(d.column)})"
-      case RelativeMinuteNum(d: DateOrDateTime[_])     => s"toRelativeMinuteNum(${tokenizeColumn(d.column)})"
-      case RelativeSecondNum(d: DateOrDateTime[_])     => s"toRelativeSecondNum(${tokenizeColumn(d.column)})"
-      case TimeSlot(d: DateOrDateTime[_])              => s"timeSlot(${tokenizeColumn(d.column)})"
-      case TimeSlots(d: DateOrDateTime[_], duration: NumericCol[_]) =>
+      case StartOfMonth(d)          => s"toStartOfMonth(${tokenizeColumn(d.column)})"
+      case StartOfQuarter(d)        => s"toStartOfQuarter(${tokenizeColumn(d.column)})"
+      case StartOfYear(d)           => s"toStartOfYear(${tokenizeColumn(d.column)})"
+      case StartOfMinute(d)         => s"toStartOfMinute(${tokenizeColumn(d.column)})"
+      case StartOfFiveMinute(d)     => s"toStartOfFiveMinute(${tokenizeColumn(d.column)})"
+      case StartOfFifteenMinutes(d) => s"toStartOfFifteenMinutes(${tokenizeColumn(d.column)})"
+      case StartOfHour(d)           => s"toStartOfHour(${tokenizeColumn(d.column)})"
+      case StartOfDay(d)            => s"toStartOfDay(${tokenizeColumn(d.column)})"
+      case Time(d)                  => s"toTime(${tokenizeColumn(d.column)})"
+      case RelativeYearNum(d)       => s"toRelativeYearNum(${tokenizeColumn(d.column)})"
+      case RelativeQuarterNum(d)    => s"toRelativeQuarterNum(${tokenizeColumn(d.column)})"
+      case RelativeMonthNum(d)      => s"toRelativeMonthNum(${tokenizeColumn(d.column)})"
+      case RelativeWeekNum(d)       => s"toRelativeWeekNum(${tokenizeColumn(d.column)})"
+      case RelativeDayNum(d)        => s"toRelativeDayNum(${tokenizeColumn(d.column)})"
+      case RelativeHourNum(d)       => s"toRelativeHourNum(${tokenizeColumn(d.column)})"
+      case RelativeMinuteNum(d)     => s"toRelativeMinuteNum(${tokenizeColumn(d.column)})"
+      case RelativeSecondNum(d)     => s"toRelativeSecondNum(${tokenizeColumn(d.column)})"
+      case TimeSlot(d)              => s"timeSlot(${tokenizeColumn(d.column)})"
+      case TimeSlots(d, duration)   =>
         s"timeSlots(${tokenizeColumn(d.column)},${tokenizeColumn(duration.column)})"
-      case ISOWeek(d: DateOrDateTime[_])         => s"toISOWeek(${tokenizeColumn(d.column)})"
-      case ISOYear(d: DateOrDateTime[_])         => s"toISOYear(${tokenizeColumn(d.column)})"
-      case Week(d: DateOrDateTime[_], mode: Int) => s"toWeek(${tokenizeColumn(d.column)},$mode)"
+      case ISOWeek(d)    => s"toISOWeek(${tokenizeColumn(d.column)})"
+      case ISOYear(d)    => s"toISOYear(${tokenizeColumn(d.column)})"
+      case Week(d, mode) => s"toWeek(${tokenizeColumn(d.column)},$mode)"
     }
 
   protected def tokenizeDateTimeConst(col: DateTimeConst[_]): String =

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/DictionaryFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/DictionaryFunctionTokenizer.scala
@@ -18,26 +18,25 @@ trait DictionaryFunctionTokenizer {
   }
 
   def tokenizeDictionaryFunction(col: DictionaryFuncColumn[_])(implicit ctx: TokenizeContext): String = col match {
-    case col: DictGetUInt8    => tokenizeDictionaryGet(col, "UInt8")
-    case col: DictGetUInt16   => tokenizeDictionaryGet(col, "UInt16")
-    case col: DictGetUInt32   => tokenizeDictionaryGet(col, "UInt32")
-    case col: DictGetUInt64   => tokenizeDictionaryGet(col, "UInt64")
-    case col: DictGetInt8     => tokenizeDictionaryGet(col, "Int8")
-    case col: DictGetInt16    => tokenizeDictionaryGet(col, "Int16")
-    case col: DictGetInt32    => tokenizeDictionaryGet(col, "Int32")
-    case col: DictGetInt64    => tokenizeDictionaryGet(col, "Int64")
-    case col: DictGetFloat32  => tokenizeDictionaryGet(col, "Float32")
-    case col: DictGetFloat64  => tokenizeDictionaryGet(col, "Float64")
-    case col: DictGetDate     => tokenizeDictionaryGet(col, "Date")
-    case col: DictGetDateTime => tokenizeDictionaryGet(col, "DateTime")
-    case col: DictGetUUID     => tokenizeDictionaryGet(col, "UUID")
-    case col: DictGetString   => tokenizeDictionaryGet(col, "String")
-    case DictIsIn(dictName: StringColMagnet[_], childId: ConstOrColMagnet[_], ancestorId: ConstOrColMagnet[_]) =>
+    case col: DictGetUInt8                       => tokenizeDictionaryGet(col, "UInt8")
+    case col: DictGetUInt16                      => tokenizeDictionaryGet(col, "UInt16")
+    case col: DictGetUInt32                      => tokenizeDictionaryGet(col, "UInt32")
+    case col: DictGetUInt64                      => tokenizeDictionaryGet(col, "UInt64")
+    case col: DictGetInt8                        => tokenizeDictionaryGet(col, "Int8")
+    case col: DictGetInt16                       => tokenizeDictionaryGet(col, "Int16")
+    case col: DictGetInt32                       => tokenizeDictionaryGet(col, "Int32")
+    case col: DictGetInt64                       => tokenizeDictionaryGet(col, "Int64")
+    case col: DictGetFloat32                     => tokenizeDictionaryGet(col, "Float32")
+    case col: DictGetFloat64                     => tokenizeDictionaryGet(col, "Float64")
+    case col: DictGetDate                        => tokenizeDictionaryGet(col, "Date")
+    case col: DictGetDateTime                    => tokenizeDictionaryGet(col, "DateTime")
+    case col: DictGetUUID                        => tokenizeDictionaryGet(col, "UUID")
+    case col: DictGetString                      => tokenizeDictionaryGet(col, "String")
+    case DictIsIn(dictName, childId, ancestorId) =>
       s"dictIsIn(${tokenizeColumn(dictName.column)},${tokenizeColumn(childId.column)},${tokenizeColumn(ancestorId.column)})"
-    case DictGetHierarchy(dictName: StringColMagnet[_], id: ConstOrColMagnet[_]) =>
+    case DictGetHierarchy(dictName, id) =>
       s"dictGetHierarchy(${tokenizeColumn(dictName.column)},${tokenizeColumn(id.column)})"
-    case DictHas(dictName: StringColMagnet[_], id: ConstOrColMagnet[_]) =>
+    case DictHas(dictName, id) =>
       s"dictHas(${tokenizeColumn(dictName.column)},${tokenizeColumn(id.column)})"
-    case _ => throw new IllegalArgumentException(s"Unsupported dictionary")
   }
 }

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/DistanceFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/DistanceFunctionTokenizer.scala
@@ -35,9 +35,9 @@ trait DistanceFunctionTokenizer {
       s"LinfDistance(${tokenizeColumn(vector1.column)}, ${tokenizeColumn(vector2.column)})"
 
     // LP
-    case LPNorm(vector, p)                      => s"LpNorm(${tokenizeColumn(vector.column)}, $p)"
-    case LPNormalize(vector, p: Float)          => s"LpNormalize(${tokenizeColumn(vector.column)}, $p)"
-    case LPDistance(vector1, vector2, p: Float) =>
+    case LPNorm(vector, p)               => s"LpNorm(${tokenizeColumn(vector.column)}, $p)"
+    case LPNormalize(vector, p)          => s"LpNormalize(${tokenizeColumn(vector.column)}, $p)"
+    case LPDistance(vector1, vector2, p) =>
       s"LpDistance(${tokenizeColumn(vector1.column)}, ${tokenizeColumn(vector2.column)}, $p)"
   }
 }

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/InFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/InFunctionTokenizer.scala
@@ -15,13 +15,13 @@ trait InFunctionTokenizer {
   }
 
   private def tokenizeInFunctionCol(col: InFunctionCol[_])(implicit ctx: TokenizeContext): String = col match {
-    case In(l: ConstOrColMagnet[_], r: InFuncRHMagnet) =>
+    case In(l, r) =>
       s"${tokenizeColumn(l.column)} IN ${tokenizeInFunRHCol(r, aliasTables(r))}"
-    case NotIn(l: ConstOrColMagnet[_], r: InFuncRHMagnet) =>
+    case NotIn(l, r) =>
       s"${tokenizeColumn(l.column)} NOT IN ${tokenizeInFunRHCol(r, aliasTables(r))}"
-    case GlobalIn(l: ConstOrColMagnet[_], r: InFuncRHMagnet) =>
+    case GlobalIn(l, r) =>
       s"${tokenizeColumn(l.column)} GLOBAL IN ${tokenizeInFunRHCol(r, aliasTables = false)}"
-    case GlobalNotIn(l: ConstOrColMagnet[_], r: InFuncRHMagnet) =>
+    case GlobalNotIn(l, r) =>
       s"${tokenizeColumn(l.column)} GLOBAL NOT IN ${tokenizeInFunRHCol(r, aliasTables = false)}"
   }
 
@@ -31,11 +31,8 @@ trait InFunctionTokenizer {
   private def tokenizeInFunRHCol(value: InFuncRHMagnet, aliasTables: Boolean)(implicit
       ctx: TokenizeContext
   ): String =
-    value match {
-      case col: InFuncRHMagnet if col.query.isDefined =>
-        s"(${ctx.withTableAlias(aliasTables)(toRawSql(col.query.get.internalQuery))})"
-      case col: InFuncRHMagnet if col.tableRef.isDefined =>
-        col.tableRef.map(table => table.quoted + ctx.withTableAlias(aliasTables)(ctx.tableAlias(table))).get
-      case col: InFuncRHMagnet => tokenizeColumn(col.column)
-    }
+    value.query
+      .map(query => s"(${ctx.withTableAlias(aliasTables)(toRawSql(query.internalQuery))})")
+      .orElse(value.tableRef.map(table => table.quoted + ctx.withTableAlias(aliasTables)(ctx.tableAlias(table))))
+      .getOrElse(tokenizeColumn(value.column))
 }

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/MiscellaneousFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/MiscellaneousFunctionTokenizer.scala
@@ -21,12 +21,7 @@ trait MiscellaneousFunctionTokenizer {
     case Bar(col: NumericCol[_], from: NumericCol[_], to: NumericCol[_], default: Option[NumericCol[_]]) =>
       val defaultPart = default.map(col => Tokens.Delimiter + tokenizeColumn(col.column)).getOrElse("")
       s"bar(${tokenizeColumn(col.column)},${tokenizeColumn(from.column)},${tokenizeColumn(to.column)}${defaultPart})"
-    case Transform(
-          col: ConstOrColMagnet[_],
-          arrayFrom: ArrayColMagnet[_],
-          arrayTo: ArrayColMagnet[_],
-          default: ConstOrColMagnet[_]
-        ) =>
+    case Transform(col, arrayFrom, arrayTo, default) =>
       s"transform(${tokenizeColumn(col.column)},${tokenizeColumn(arrayFrom.column)},${tokenizeColumn(arrayTo.column)},${tokenizeColumn(default.column)})"
     case FormatReadableSize(col: NumericCol[_])                => s"formatReadableSize(${tokenizeColumn(col.column)})"
     case Least(a: ConstOrColMagnet[_], b: ConstOrColMagnet[_]) =>

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/SplitMergeFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/SplitMergeFunctionTokenizer.scala
@@ -37,7 +37,7 @@ trait SplitMergeFunctionTokenizer {
       }
     case SplitByString(sep: StringColMagnet[_], col: StringColMagnet[_]) =>
       s"splitByString(${tokenizeColumn(sep.column)}, ${tokenizeColumn(col.column)})"
-    case ArrayStringConcat(col: ArrayColMagnet[_], sep: StringColMagnet[_]) =>
+    case ArrayStringConcat(col, sep) =>
       s"arrayStringConcat(${tokenizeColumn(col.column)}, ${tokenizeColumn(sep.column)})"
     case AlphaTokens(col: StringColMagnet[_]) => s"alphaTokens(${tokenizeColumn(col.column)})"
   }

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/URLFunctionTokenizer.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/language/URLFunctionTokenizer.scala
@@ -29,7 +29,6 @@ trait URLFunctionTokenizer {
       case CutFragment(_)                    => "cutFragment"
       case CutQueryStringAndFragment(_)      => "cutQueryStringAndFragment"
       case CutURLParameter(_, _)             => "cutURLParameter"
-      case unsupported                       => throw new IllegalArgumentException(s"Unsupported command: $unsupported")
     }
     val tail = col match {
       case ExtractURLParameter(_, c2) => Tokens.Delimiter + tokenizeColumn(c2.column)

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/misc/DSLImprovements.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/misc/DSLImprovements.scala
@@ -117,23 +117,14 @@ object DSLImprovements {
     def insertConstraint(condition: Option[ExpressionColumn[Boolean]]): OperationalQuery =
       condition.map(insertConstraint).getOrElse(query)
 
-    def insertConstraint(condition: ExpressionColumn[Boolean]): OperationalQuery = {
-      query.internalQuery.from.foreach {
-        case l1: InnerFromQuery =>
-          return query.from(l1.innerQuery.andConstraint(condition))
-
-        // this might be even another level 'deep'
-        // See FilterQueryTransformerFourTableTest#
-        //          l1.internalQuery.from.foreach {
-        //            case l2: InnerFromQuery   => return query.from(l1.innerQuery.from(l2.innerQuery.andConstraint(condition)))
-        //            case _: TableFromQuery[_] => return query.from(l1.innerQuery.andConstraint(condition))
-        //            case _                    =>
-        //          }
-        case _: TableFromQuery[_] => return query.andConstraint(condition)
-        case _                    =>
+    // Only the one level: a constraint on a query selecting from a subquery that itself selects from a subquery lands
+    // on the outer of the two. See FilterQueryTransformerFourTableTest.
+    def insertConstraint(condition: ExpressionColumn[Boolean]): OperationalQuery =
+      query.internalQuery.from match {
+        case Some(l1: InnerFromQuery)   => query.from(l1.innerQuery.andConstraint(condition))
+        case Some(_: TableFromQuery[_]) => query.andConstraint(condition)
+        case _                          => query
       }
-      query
-    }
   }
 
   implicit class OrderingColumnsImprovements(values: Seq[OrderingColumn]) {

--- a/dsl/src/main/scala/com/crobox/clickhouse/dsl/package.scala
+++ b/dsl/src/main/scala/com/crobox/clickhouse/dsl/package.scala
@@ -68,13 +68,20 @@ package object dsl extends ClickhouseColumnFunctions with QueryFactory with Quer
 
   def columnCase[V](condition: TableColumn[Boolean], result: TableColumn[V]): Case[V] = Case[V](condition, result)
 
-  def switch[V](defaultValue: TableColumn[V], cases: Case[V]*): TableColumn[V] = cases match {
-    case Nil => defaultValue
-    case _   => Conditional(cases, defaultValue, multiIf = false)
-  }
+  /**
+   * Both build the node even with no cases, where they once handed the default straight back. That short-circuit is
+   * what forced the return type up to `TableColumn`, and a lambda -- `arrayMap`'s and every other higher-order one --
+   * asks for an `ExpressionColumn`, so every conditional inside one needed a cast the compiler could not check.
+   *
+   * The degenerate case is not lost, only moved: the tokenizer renders a caseless conditional as the bare default, so
+   * `multiIf(x)` is still `x`.
+   *
+   * `Conditional` rather than `ExpressionColumn` because a caller building one up -- adding a case to a conditional it
+   * already has -- needs the node, and every other builder here hands its own node back too.
+   */
+  def switch[V](defaultValue: TableColumn[V], cases: Case[V]*): Conditional[V] =
+    Conditional(cases, defaultValue, multiIf = false)
 
-  def multiIf[V](defaultValue: TableColumn[V], cases: Case[V]*): TableColumn[V] = cases match {
-    case Nil => defaultValue
-    case _   => Conditional(cases, defaultValue, multiIf = true)
-  }
+  def multiIf[V](defaultValue: TableColumn[V], cases: Case[V]*): Conditional[V] =
+    Conditional(cases, defaultValue, multiIf = true)
 }

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/InternalQueryFieldsTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/InternalQueryFieldsTest.scala
@@ -36,7 +36,7 @@ class InternalQueryFieldsTest extends DslTestSpec {
     groupBy = Option(GroupByQuery(usingColumns = Seq(itemId))),
     having = Option(condition),
     joins = Seq(JoinQuery(JoinQuery.InnerJoin, TableFromQuery(ThreeTestTable), `using` = Seq(itemId))),
-    arrayJoin = Option(ArrayJoinQuery(Seq(numbers))),
+    arrayJoin = Option(ArrayJoinQuery(Seq(this.numbers))),
     orderBy = Seq(OrderingColumn(itemId, DESC, nulls = Option(NullsOrder.NullsLast))),
     limit = Option(Limit(Option(10), 5, withTies = true)),
     limitBy = Option(LimitBy(1, 0, Seq(itemId))),

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/JoinQueryTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/JoinQueryTest.scala
@@ -231,7 +231,7 @@ class JoinQueryTest extends DslTestSpec with TableDrivenPropertyChecks {
   it should "keep ARRAY JOIN between the left alias and the first JOIN of a chain" in {
     val query = select(itemId)
       .from(TwoTestTable)
-      .withArrayJoin(numbers)
+      .withArrayJoin(this.numbers)
       .join(InnerJoin, ThreeTestTable)
       .on(itemId)
       .join(InnerJoin, TwoTestTable)

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/QueryClausesTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/QueryClausesTest.scala
@@ -14,30 +14,31 @@ class QueryClausesTest extends DslTestSpec {
   private def sql(query: OperationalQuery): String = toSql(query.internalQuery, None)
 
   "ARRAY JOIN" should "unfold a single column" in {
-    sql(select(shieldId).from(OneTestTable).withArrayJoin(numbers)) should matchSQL(
+    sql(select(shieldId).from(OneTestTable).withArrayJoin(this.numbers)) should matchSQL(
       s"SELECT shield_id FROM ${OneTestTable.quoted} ARRAY JOIN numbers"
     )
   }
 
   it should "render LEFT ARRAY JOIN" in {
-    sql(select(shieldId).from(OneTestTable).withLeftArrayJoin(numbers)) should matchSQL(
+    sql(select(shieldId).from(OneTestTable).withLeftArrayJoin(this.numbers)) should matchSQL(
       s"SELECT shield_id FROM ${OneTestTable.quoted} LEFT ARRAY JOIN numbers"
     )
   }
 
   it should "carry an alias, which is how the unfolded column gets named" in {
-    sql(select(shieldId).from(OneTestTable).withArrayJoin(numbers as "n")) should matchSQL(
+    sql(select(shieldId).from(OneTestTable).withArrayJoin(this.numbers as "n")) should matchSQL(
       s"SELECT shield_id FROM ${OneTestTable.quoted} ARRAY JOIN numbers AS n"
     )
   }
 
   it should "accumulate columns across calls rather than replacing them" in {
-    val query = select(shieldId).from(OneTestTable).withArrayJoin(numbers as "n").withArrayJoin(numbers as "m")
+    val query =
+      select(shieldId).from(OneTestTable).withArrayJoin(this.numbers as "n").withArrayJoin(this.numbers as "m")
     sql(query) should matchSQL(s"SELECT shield_id FROM ${OneTestTable.quoted} ARRAY JOIN numbers AS n, numbers AS m")
   }
 
   it should "sit between FROM and WHERE" in {
-    val query = select(shieldId).from(OneTestTable).withArrayJoin(numbers).where(shieldId isEq "a")
+    val query = select(shieldId).from(OneTestTable).withArrayJoin(this.numbers).where(shieldId isEq "a")
     sql(query) should matchSQL(
       s"SELECT shield_id FROM ${OneTestTable.quoted} ARRAY JOIN numbers WHERE shield_id = 'a'"
     )
@@ -48,7 +49,7 @@ class QueryClausesTest extends DslTestSpec {
   it should "sit after the left table's alias and before JOIN" in {
     val query = select(shieldId as itemId)
       .from(OneTestTable)
-      .withArrayJoin(numbers as "n")
+      .withArrayJoin(this.numbers as "n")
       .join(JoinQuery.InnerJoin, TwoTestTable) using itemId
     sql(query) should matchSQL(
       s"SELECT shield_id AS item_id FROM ${OneTestTable.quoted} AS L1 ARRAY JOIN numbers AS n " +

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/column/HeterogeneousHigherOrderTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/column/HeterogeneousHigherOrderTest.scala
@@ -116,4 +116,17 @@ class HeterogeneousHigherOrderTest extends DslTestSpec {
     toSQL(select(arrayReverseSplit[Int](x => x > const(1), quantities)), false) should
     matchSQL("SELECT arrayReverseSplit(x -> x > 1, quantities)")
   }
+
+  // A conditional is an ExpressionColumn whether or not it has cases, so it can be a lambda body directly. It used to
+  // be typed TableColumn, which no higher-order function accepts, and callers reached for a cast.
+  it should "take a conditional as a lambda body" in {
+    val expr = arrayMap[Double, Int, Double](
+      (price, qty) => multiIf(const(0.0), columnCase(qty > const(0), price * qty)),
+      prices,
+      quantities
+    )
+    toSQL(select(expr), false) should matchSQL(
+      "SELECT arrayMap((x,y) -> if(y > 0, x * y, 0.0), prices, quantities)"
+    )
+  }
 }

--- a/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/NullableFunctionTokenizerTest.scala
+++ b/dsl/src/test/scala/com/crobox/clickhouse/dsl/language/NullableFunctionTokenizerTest.scala
@@ -97,4 +97,18 @@ class NullableFunctionTokenizerTest extends DslTestSpec {
     shouldMatch(query2, expected)
   }
 
+  // The four that hand their column back keep its type: without it every one of these needed an asInstanceOf at the
+  // call site, because a NumericCol conversion cannot be picked for Nothing.
+  it should "keep the column's type, so the result feeds a function that asks for one" in {
+    val expected = s"SELECT column_2 / nullIf(column_2, 0) FROM $database.twoTestTable"
+
+    shouldMatch(select(divide(col2, nullIf(col2, const(0)))).from(TwoTestTable), expected)
+    shouldMatch(select(divide(col2, col2.nullIf(const(0)))).from(TwoTestTable), expected)
+
+    val typed: TableColumn[Int] = assumeNotNull(col2)
+    shouldMatch(
+      select(divide(col2, typed)).from(TwoTestTable),
+      s"SELECT column_2 / assumeNotNull(column_2) FROM $database.twoTestTable"
+    )
+  }
 }


### PR DESCRIPTION
Two separate concerns, one commit each.

## Keep the column's type through the nullable and conditional builders

`assumeNotNull`, `toNullable`, `ifNull` and `nullIf` hand their column back, but were typed `AbsNullableFunction[Nothing]`. A result could not be fed to a function that asks for a type — `divide(x, nullIf(y, 0.0))` had no numeric conversion to pick, because every one of them applies to `Nothing`, so call sites reached for an `asInstanceOf`. They now carry the column's type, threaded through from `ConstOrColMagnet[+C]` via `NullableOps[+C]`.

The result follows the **first** argument. That is what `nullIf` does in ClickHouse too. `ifNull` is really the supertype of both, but inferring one would type `ifNull(price, 0)` as `AnyVal` and put the caller back where they started, so the alternative stays untyped and unchecked against the column.

`switch` and `multiIf` now always build the node instead of handing the default straight back when there are no cases. That short-circuit is what forced their return type up to `TableColumn`, and a lambda body — `arrayMap`'s and every other higher-order one — has to be an `ExpressionColumn`, so every conditional inside one needed a cast the compiler could not check. The degenerate case is not lost, only moved: the tokenizer renders a caseless conditional as the bare default, so `multiIf(x)` is still `x`.

## Clear the build warnings on both 2.13 and Scala 3

The [v2.0.0-RC4 release build](https://github.com/crobox/clickhouse-scala-client/actions/runs/33104006497/job/98628891510) emitted around thirty warnings from five distinct causes.

| Cause | Fix |
| --- | --- |
| `versionScheme setting is empty` (8×) | set to `early-semver` in `build.sbt` |
| `unreachable code` (6×, 2.13) | dropped redundant type ascriptions from the tokenizer patterns |
| `outer reference in this type test cannot be checked` (6×, 2.13) | `@unchecked` on the markers that are `sealed trait`s inside a trait |
| `match may not be exhaustive` (both) | sealed `DistanceFunctionOp` |
| Scala 3 only | `implicitConversions` import, no more non-local returns, explicit `Actor.noSender` |
| Scaladoc links (5×) | fully qualified one, backticked three ambiguous ones |

The `unreachable code` warnings traced to ascriptions like `case Year(d: DateOrDateTime[_])` on `case class Year(d: DateOrDateTime[_])`. Those restate the field's own type and become type tests the matcher cannot discharge — the magnets are traits inside a trait, so there is no outer pointer — and it then blames an arbitrary arm as unreachable. Fixing one arm only moved the warning to the next, so they went from the whole match. `tokenizeInFunRHCol` type-tested its own scrutinee's type on every arm, which read as the second arm being unreachable; chaining the two Options says the same thing and drops a `.get`.

The same ascriptions were why 2.13 could not prove the dictionary match exhaustive. With `-Ypatmat-exhaust-depth off` it reports the arms as failing on `DictIsIn(x forSome x not in StringColMagnet[?], …)`; without them it proves exhaustiveness unaided. So the `case _ => throw` that Scala 3 called unreachable is gone, and **both compilers now enforce the sealed hierarchy** — a missing arm is a compile error rather than a runtime throw. `URLFunctionTokenizer` had the same kind of fall-through: `URLFunction` was sealed but `URLStrFunction` and `URLArrFunction` were not, so nothing was ever checked. Sealing both — all 22 subclasses live in that file — retires the throw there too.

Also fixed nine `reference to numbers is ambiguous` warnings in the dsl tests, qualified as `this.numbers` per the compiler's own quickfix. These are a Scala 3 hazard the release job never surfaces, because it builds main only.

### Not included, worth a decision

`StringSearchFunc` and `StringSearchReplaceFunc` are not sealed, and `tokenizeStringSearchFunction`'s `command` match has no fall-through at all — a new subclass is a silent runtime `MatchError` with no compile-time warning. All its subclasses are in one file, so `sealed` on both would buy the same check the other two now have. Left out because it restricts subclassing of a published type.

## Breaking changes, for the hand-written 2.0.0 notes

All of this lands on the unreleased 2.0.0 line, but per `RELEASE.md` the generated notes are just PR titles, so these need writing up by hand:

**Binary-breaking, source-compatible for ordinary callers.** `IfNull`, `NullIf`, `AssumeNotNull` and `ToNullable` gained a type parameter, and `switch`/`multiIf` narrowed their return type from `TableColumn[V]` to `Conditional[V]`. Descriptors change either way, so a consumer has to recompile.

**Source-breaking for an external subclass.** `DistanceFunctionOp`, `URLStrFunction` and `URLArrFunction` are now `sealed`. That is the same tradeoff I declined to make for `StringSearchFunc` below, and the reasoning cuts the other way here: sealing those three is what lets the compiler check the matches that previously fell through to a runtime throw, whereas sealing `StringSearchFunc` only adds a check to a match that already looks total. All of them are internal AST nodes rather than things a consumer would plausibly extend, but the restriction is real.

## Verification

- `+clean; +compile; +Test/compile; +doc` clean on 2.13.18 and 3.3.8. The only warnings left are five scaladoc links into **scalatest and pekko** sources, which nothing in this repo can fix.
- `dsl/testFull` 494 pass on both versions; `testkit/testFull` passes.
- `scalafmtCheckAll` and `scalafmtSbtCheck` pass.
- `client/testFull` has its two usual environmental failures (needs ClickHouse on `localhost:8123` and `../.docker/certs/keystore.jks`), unchanged from before this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

